### PR TITLE
Updated URL and fixed the text styling of GitHub

### DIFF
--- a/header.php
+++ b/header.php
@@ -83,7 +83,7 @@
                             <!-- Menu Body -->
                             <li class="user-body">
                                 <div class="col-xs-4 text-center">
-                                    <a href="https://github.com/jacobsalmela/pi-hole">Github</a>
+                                    <a href="https://github.com/pi-hole/pi-hole">GitHub</a>
                                 </div>
                                 <div class="col-xs-4 text-center">
                                     <a href="http://jacobsalmela.com/block-millions-ads-network-wide-with-a-raspberry-pi-hole-2-0/">Details</a>


### PR DESCRIPTION
Very minor (if not pedantic) change:
- URL now points to the pi-hole org name
- fixed the styling of GitHub (not "Github").
