### PR TITLE
Be able to exclude certain domains / clients

### DIFF
--- a/data.php
+++ b/data.php
@@ -126,6 +126,13 @@
                 $sources[$ip] = 1;
             }
         }
+
+        global $setupVars;
+        if(isset($setupVars["WEBUI_EXCLUDE_CLIENTS"]))
+        {
+            $sources = excludeFromList($sources, "WEBUI_EXCLUDE_CLIENTS");
+        }
+
         arsort($sources);
         $sources = array_slice($sources, 0, 10);
         return Array(

--- a/data.php
+++ b/data.php
@@ -259,16 +259,17 @@
         global $setupVars;
         if(isset($setupVars["WEBUI_EXCLUDE_DOMAINS"]))
         {
-            $splitQueries = excludeDomainsfromList($splitQueries);
+            $splitQueries = excludeFromList($splitQueries, "WEBUI_EXCLUDE_DOMAINS");
         }
+
         arsort($splitQueries);
         return array_slice($splitQueries, 0, $qty);
     }
 
-    function excludeDomainsfromList($array)
+    function excludeFromList($array,$key)
     {
         global $setupVars;
-        $domains = explode(",",$setupVars["WEBUI_EXCLUDE_DOMAINS"]);
+        $domains = explode(",",$setupVars[$key]);
         foreach ($domains as $domain) {
             if(isset($array[$domain]))
             {

--- a/data.php
+++ b/data.php
@@ -1,6 +1,7 @@
 <?php
     $log = array();
-    $divide =  parse_ini_file("/etc/pihole/setupVars.conf")['IPV6_ADDRESS'] != "" && parse_ini_file("/etc/pihole/setupVars.conf")['IPV4_ADDRESS'] != "";
+    $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
+    $divide =  $setupVars['IPV6_ADDRESS'] != "" && $setupVars['IPV4_ADDRESS'] != "";
     $hosts = file_exists("/etc/hosts") ? file("/etc/hosts") : array();
     $log = new \SplFileObject('/var/log/pihole.log');
 
@@ -254,8 +255,27 @@
                 }
             }
         }
+
+        global $setupVars;
+        if(isset($setupVars["WEBUI_EXCLUDE_DOMAINS"]))
+        {
+            $splitQueries = excludeDomainsfromList($splitQueries);
+        }
         arsort($splitQueries);
         return array_slice($splitQueries, 0, $qty);
+    }
+
+    function excludeDomainsfromList($array)
+    {
+        global $setupVars;
+        $domains = explode(",",$setupVars["WEBUI_EXCLUDE_DOMAINS"]);
+        foreach ($domains as $domain) {
+            if(isset($array[$domain]))
+            {
+                unset($array[$domain]);
+            }
+        }
+        return $array;
     }
 
     function overTime($entries) {

--- a/data.php
+++ b/data.php
@@ -128,9 +128,9 @@
         }
 
         global $setupVars;
-        if(isset($setupVars["WEBUI_EXCLUDE_CLIENTS"]))
+        if(isset($setupVars["API_EXCLUDE_CLIENTS"]))
         {
-            $sources = excludeFromList($sources, "WEBUI_EXCLUDE_CLIENTS");
+            $sources = excludeFromList($sources, "API_EXCLUDE_CLIENTS");
         }
 
         arsort($sources);
@@ -264,9 +264,9 @@
         }
 
         global $setupVars;
-        if(isset($setupVars["WEBUI_EXCLUDE_DOMAINS"]))
+        if(isset($setupVars["API_EXCLUDE_DOMAINS"]))
         {
-            $splitQueries = excludeFromList($splitQueries, "WEBUI_EXCLUDE_DOMAINS");
+            $splitQueries = excludeFromList($splitQueries, "API_EXCLUDE_DOMAINS");
         }
 
         arsort($splitQueries);


### PR DESCRIPTION
Changes proposed in this pull request:

- Be able to exclude certain domains / clients from showing up on the main page (as well as the API result)

Add the following to your `/etc/pihole/setupVars.conf`:
```
API_EXCLUDE_DOMAINS=domain.com,anotherdomain.com
```
will prevent the two domains `domain.com`, and `anotherdomain.com` from showing up in the Top Lists (both Top Domains and Top Advertisers).

Furthermore,
```
API_EXCLUDE_CLIENTS=10.100.0.1
```
will prevent the client with IP `10.100.0.1` to show up in the Top Clients results.

You can add as many domains/IPs as you like, separate them with `,`.

Note that the "Frequency" display stays unchanged, since we still relate to the total amount of queries.

@pi-hole/dashboard
