### PR TITLE
Change whitelist icon

### DIFF
--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -29,7 +29,7 @@ const nav = {
     {
       name: 'Whitelist',
       url: '/whitelist',
-      icon: 'fa fa-check-square-o'
+      icon: 'fa fa-check-circle-o'
     },
     {
       name: 'Blacklist',


### PR DESCRIPTION
As mentioned in my [PR for the current UI](https://github.com/pi-hole/AdminLTE/pull/695#event-1501857725), `fa-check-circle-o` looks nicer next to the ban icon since it's also circular.

Signed-off-by: Thomas Robinson <tom@dnomaid.co.uk>