### PR TITLE
Remove the default whitelisted domains note

### DIFF
--- a/src/views/Whitelist.js
+++ b/src/views/Whitelist.js
@@ -15,17 +15,7 @@ import { api } from "../utils";
 export default props => (
   <ListPage
     title="Whitelist"
-    note={
-      <div>
-        <p>Note: Whitelisting a subdomain of a wildcard blocked domain is not possible.</p>
-        <p>
-          Some of the domains shown below are the ad list domains, which are automatically added in order to prevent
-          ad lists being able to blacklist each other.
-          See <a href="https://github.com/pi-hole/pi-hole/blob/master/adlists.default" target="_blank" rel="noopener noreferrer">here</a> for
-          the default set of ad lists.
-        </p>
-      </div>
-    }
+    note={<p>Note: Whitelisting a subdomain of a wildcard blocked domain is not possible.</p>}
     add={api.addWhitelist}
     remove={api.removeWhitelist}
     refresh={api.getWhitelist}


### PR DESCRIPTION
As of this Core PR (pi-hole/pi-hole#1973), adlist domains are no longer whitelisted by default.