### PR TITLE
Upload Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ script:
   - npm run gulp sass
   - rm public/fakeAPI/.gitignore # Make sure that the fakeAPI data is deployed
   - 'if [ "$TRAVIS_BRANCH" = "master" ]; then
-      npm run build-fake
+      npm run build-fake;
       echo "web.pi-hole.io" > build/CNAME;
     else
-      npm run build
+      npm run build;
     fi'
   - tar -czvf pihole-web.tar.gz build
   - wget https://ftl.pi-hole.net:8080/FTL-client

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
     else
       npm run build;
     fi'
-  - tar -czvf pihole-web.tar.gz build
+  - tar -czvf pihole-web.tar.gz -C build .
   - wget https://ftl.pi-hole.net:8080/FTL-client
   - chmod +x ./FTL-client
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./FTL-client "${TRAVIS_BRANCH}" pihole-web.tar.gz "${TRAVIS_SECRET}"; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,17 @@ env:
 script:
   - npm run gulp sass
   - rm public/fakeAPI/.gitignore # Make sure that the fakeAPI data is deployed
-  - npm run build-fake
-  - echo "web.pi-hole.io" > build/CNAME
+  - 'if [ "$TRAVIS_BRANCH" = "master" ]; then
+      npm run build-fake
+      echo "web.pi-hole.io" > build/CNAME;
+    else
+      npm run build
+    fi'
+  - tar -czvf pihole-web.tar.gz build
+  - wget https://ftl.pi-hole.net:8080/FTL-client
+  - chmod +x ./FTL-client
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./FTL-client "${TRAVIS_BRANCH}" pihole-web.tar.gz "${TRAVIS_SECRET}"; fi'
+  - rm ./FTL-client
 
 deploy:
   provider: pages


### PR DESCRIPTION
Upload builds to ftl.pi-hole.net

This PR relies on #19 because the API branch uses the new API format already.

On `master`, it will be built with fake data and the CNAME set to `web.pi-hole.io` as it previously did, but when not on `master` it will do a normal build without fake data.