### PR TITLE
Query Log: Remember last selected "Show X entries"

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -282,7 +282,7 @@ $(document).ready(function() {
             // Receive previous state from client's local storage area
             var data = localStorage.getItem("query_log_table");
             // Return if not available
-            if(data === null) return null;
+            if(data === null){ return null; }
             // Ensure that we always start on the first page (most recent query)
             data = JSON.parse(data);
             data["start"] = 0;

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -273,6 +273,22 @@ $(document).ready(function() {
             { "width" : "10%", "orderData": 4 }
         ],
         "lengthMenu": [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]],
+        "stateSave": true,
+        stateSaveCallback: function(settings, data) {
+            // Store current state in client's local storage area
+            localStorage.setItem("query_log_table", JSON.stringify(data));
+        },
+        stateLoadCallback: function(settings) {
+            // Receive previous state from client's local storage area
+            var data = localStorage.getItem("query_log_table");
+            // Return if not available
+            if(data === null) return null;
+            // Ensure that we always start on the first page (most recent query)
+            data = JSON.parse(data);
+            data["start"] = 0;
+            // Apply loaded state to table
+            return data;
+        },
         "columnDefs": [ {
             "targets": -1,
             "data": null,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

See title and animation:

![ezgif-5-22bd6de52f](https://user-images.githubusercontent.com/16748619/40885524-14a37932-6728-11e8-837c-b9d5a2750b7a.gif)

**How does this PR accomplish the above?:**

We use the [`localStorage`](https://www.w3schools.com/Html/html5_webstorage.asp) API of HTML5 to store the last configuration (number of entries to be shown, etc.) in the local storage of the client's browser. The `localStorage` object stores the data with no expiration date. The data will not be deleted when the browser is closed, and will be available the next day, week, or year

Different users can use the same Pi-hole with different preferred settings as their settings are stored by the user's browser locally. This information is never transferred to the server (unlike, e.g., cookie).

**What documentation changes (if any) are needed to support this PR?:**

None