### PR TITLE
Update i18n strings and allow dialects

### DIFF
--- a/public/i18n/de/common.json
+++ b/public/i18n/de/common.json
@@ -9,5 +9,7 @@
     "Add": "Hinzufügen",
     "Time": "Zeit",
     "Type": "Art",
-    "Action": "Aktion"
+    "Action": "Aktion",
+    "Enabled": "Aktiviert",
+    "Disabled": "Deaktiviert"
 }

--- a/public/i18n/de/lists.json
+++ b/public/i18n/de/lists.json
@@ -7,5 +7,6 @@
     "Add a domain (example.com or sub.example.com)": "Füge eine Domain hinzu (beispiel.de oder sub.beispiel.de)",
     "{{domain}} is already added": "{{domain}} wurde bereits hinzugefügt",
     "Failed to remove {{domain}}": "Fehler beim entfernen von {{domain}}",
-    "There are no domains in this list": "Es sind keine Domains auf dieser Liste vorhanden"
+    "There are no domains in this list": "Es sind keine Domains auf dieser Liste vorhanden",
+    "Input a regular expression": "Eingabe eines reguläres Ausdrucks\n"
 }

--- a/public/i18n/de/location.json
+++ b/public/i18n/de/location.json
@@ -6,5 +6,6 @@
     "Exact": "exakt",
     "Wildcard": "Wildcard",
     "Login": "Anmelden",
-    "Logout": "Abmelden"
+    "Logout": "Abmelden",
+    "Regex": "Regulärer Ausdruck"
 }

--- a/public/i18n/en/dashboard.json
+++ b/public/i18n/en/dashboard.json
@@ -16,5 +16,7 @@
     "Total Queries": "Total Queries",
     "Blocked Queries": "Blocked Queries",
     "Client activity from {{from}} to {{to}}": "Client activity from {{from}} to {{to}}",
-    "{{percent}}% of {{total}}": "{{percent}}% of {{total}}"
+    "{{percent}}% of {{total}}": "{{percent}}% of {{total}}",
+    "No Clients Found": "No Clients Found",
+    "No Domains Found": "No Domains Found"
 }

--- a/public/i18n/es/common.json
+++ b/public/i18n/es/common.json
@@ -9,5 +9,7 @@
     "Add": "Añadir",
     "Time": "Fecha/hora",
     "Type": "Tipo",
-    "Action": "Acción"
+    "Action": "Acción",
+    "Enabled": "Habilitado",
+    "Disabled": "Deshabilitado"
 }

--- a/public/i18n/es/lists.json
+++ b/public/i18n/es/lists.json
@@ -7,5 +7,6 @@
     "Add a domain (example.com or sub.example.com)": "Añadir un dominio: (example.com o sub.example.com)",
     "{{domain}} is already added": "Ya existe el dominio {{domain}}",
     "Failed to remove {{domain}}": "Error al borrar el dominio {{domain}}",
-    "There are no domains in this list": "No hay dominios en la lista"
+    "There are no domains in this list": "No hay dominios en la lista",
+    "Input a regular expression": "Introduzca una expresión tipo"
 }

--- a/public/i18n/es/location.json
+++ b/public/i18n/es/location.json
@@ -6,5 +6,6 @@
     "Exact": "Exacto",
     "Wildcard": "Wildcard",
     "Login": "Login",
-    "Logout": "Logout"
+    "Logout": "Logout",
+    "Regex": "Regex"
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -11,8 +11,6 @@ export function setupI18n() {
     .use(reactI18nextModule)
     .init({
       fallbackLng: "en",
-      // Only attempt to load the base language, for example only attempt en and not en-US
-      load: "languageOnly",
       ns: ['common'],
       defaultNS: "common",
       fallbackNS: ['dashboard', 'footer', 'lists', 'location', 'login', 'query-log'],


### PR DESCRIPTION
This update brings support for `zh-CN` but not `zh`. Previously the web interface could not use the former and would only look for the latter.