### PR TITLE
Move outer layout from components to their usage (Dashboard)

### DIFF
--- a/src/components/ClientsGraph.js
+++ b/src/components/ClientsGraph.js
@@ -134,27 +134,23 @@ class ClientsGraph extends Component {
     };
 
     return (
-      <div className="row">
-        <div className="col-md-12">
-          <div className="card">
-            <div className="card-header">
-              {t("Clients Over Last 24 Hours")}
-            </div>
-            <div className="card-block">
-              <Line width={970} height={170} data={this.state.data} options={options} ref={this.graphRef}/>
-            </div>
-            {
-              this.state.loading
-                ?
-                <div className="card-img-overlay" style={{ background: "rgba(255,255,255,0.7)" }}>
-                  <i className="fa fa-refresh fa-spin"
-                     style={{ position: "absolute", top: "50%", left: "50%", fontSize: "30px" }}/>
-                </div>
-                :
-                null
-            }
-          </div>
+      <div className="card">
+        <div className="card-header">
+          {t("Clients Over Last 24 Hours")}
         </div>
+        <div className="card-block">
+          <Line width={970} height={170} data={this.state.data} options={options} ref={this.graphRef}/>
+        </div>
+        {
+          this.state.loading
+            ?
+            <div className="card-img-overlay" style={{ background: "rgba(255,255,255,0.7)" }}>
+              <i className="fa fa-refresh fa-spin"
+                 style={{ position: "absolute", top: "50%", left: "50%", fontSize: "30px" }}/>
+            </div>
+            :
+            null
+        }
         {
           // Now you're thinking with portals!
           ReactDOM.createPortal(

--- a/src/components/QueriesGraph.js
+++ b/src/components/QueriesGraph.js
@@ -136,27 +136,23 @@ class QueriesGraph extends Component {
     };
 
     return (
-      <div className="row">
-        <div className="col-md-12">
-          <div className="card">
-            <div className="card-header">
-              {t("Queries Over Last 24 Hours")}
-            </div>
-            <div className="card-block">
-              <Line width={970} height={170} data={data} options={options}/>
-            </div>
-            {
-              this.state.loading
-                ?
-                <div className="card-img-overlay" style={{ background: "rgba(255,255,255,0.7)" }}>
-                  <i className="fa fa-refresh fa-spin"
-                     style={{ position: "absolute", top: "50%", left: "50%", fontSize: "30px" }}/>
-                </div>
-                :
-                null
-            }
-          </div>
+      <div className="card">
+        <div className="card-header">
+          {t("Queries Over Last 24 Hours")}
         </div>
+        <div className="card-block">
+          <Line width={970} height={170} data={data} options={options}/>
+        </div>
+        {
+          this.state.loading
+            ?
+            <div className="card-img-overlay" style={{ background: "rgba(255,255,255,0.7)" }}>
+              <i className="fa fa-refresh fa-spin"
+                 style={{ position: "absolute", top: "50%", left: "50%", fontSize: "30px" }}/>
+            </div>
+            :
+            null
+        }
       </div>
     );
   }

--- a/src/components/SummaryStats.js
+++ b/src/components/SummaryStats.js
@@ -8,7 +8,7 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { translate } from 'react-i18next';
 import { api, makeCancelable } from '../utils';
 
@@ -61,7 +61,7 @@ class SummaryStats extends Component {
     const { t } = this.props;
 
     return (
-      <div className="row">
+      <Fragment>
         <div className="col-lg-3 col-xs-12">
           <div className="card card-inverse card-success stat-height-lock">
             <div className="card-block">
@@ -102,7 +102,7 @@ class SummaryStats extends Component {
             </div>
           </div>
         </div>
-      </div>
+      </Fragment>
     );
   }
 }

--- a/src/components/TopBlocked.js
+++ b/src/components/TopBlocked.js
@@ -93,26 +93,24 @@ class TopBlocked extends Component {
     const { t } = this.props;
 
     return (
-      <div className="col-md-6 col-xl-4">
-        <div className="card">
-          <div className="card-header">
-            {t("Top Blocked Domains")}
-          </div>
-          <div className="card-block">
-            <div style={{overflowX: "auto"}}>
-              {this.generateTable(t)}
-            </div>
-          </div>
-          {
-            this.state.loading
-              ?
-              <div className="card-img-overlay" style={{background: "rgba(255,255,255,0.7)"}}>
-                <i className="fa fa-refresh fa-spin" style={{position: "absolute", top: "50%", left: "50%", fontSize: "30px"}}/>
-              </div>
-              :
-              null
-          }
+      <div className="card">
+        <div className="card-header">
+          {t("Top Blocked Domains")}
         </div>
+        <div className="card-block">
+          <div style={{overflowX: "auto"}}>
+            {this.generateTable(t)}
+          </div>
+        </div>
+        {
+          this.state.loading
+            ?
+            <div className="card-img-overlay" style={{background: "rgba(255,255,255,0.7)"}}>
+              <i className="fa fa-refresh fa-spin" style={{position: "absolute", top: "50%", left: "50%", fontSize: "30px"}}/>
+            </div>
+            :
+            null
+        }
       </div>
     );
   }

--- a/src/components/TopClients.js
+++ b/src/components/TopClients.js
@@ -94,26 +94,24 @@ class TopClients extends Component {
     const { t } = this.props;
 
     return (
-      <div className="col-md-6 col-xl-4">
-        <div className="card">
-          <div className="card-header">
-            {t("Top Clients")}
-          </div>
-          <div className="card-block">
-            <div style={{overflowX: "auto"}}>
-              {this.generateTable(t)}
-            </div>
-          </div>
-          {
-            this.state.loading
-              ?
-              <div className="card-img-overlay" style={{background: "rgba(255,255,255,0.7)"}}>
-                <i className="fa fa-refresh fa-spin" style={{position: "absolute", top: "50%", left: "50%", fontSize: "30px"}}/>
-              </div>
-              :
-              null
-          }
+      <div className="card">
+        <div className="card-header">
+          {t("Top Clients")}
         </div>
+        <div className="card-block">
+          <div style={{overflowX: "auto"}}>
+            {this.generateTable(t)}
+          </div>
+        </div>
+        {
+          this.state.loading
+            ?
+            <div className="card-img-overlay" style={{background: "rgba(255,255,255,0.7)"}}>
+              <i className="fa fa-refresh fa-spin" style={{position: "absolute", top: "50%", left: "50%", fontSize: "30px"}}/>
+            </div>
+            :
+            null
+        }
       </div>
     );
   }

--- a/src/components/TopDomains.js
+++ b/src/components/TopDomains.js
@@ -95,26 +95,24 @@ class TopDomains extends Component {
     const { t } = this.props;
 
     return (
-      <div className="col-md-6 col-xl-4">
-        <div className="card">
-          <div className="card-header">
-            {t("Top Permitted Domains")}
-          </div>
-          <div className="card-block">
-            <div style={{overflowX: "auto"}}>
-              {this.generateTable(t)}
-            </div>
-          </div>
-          {
-            this.state.loading
-              ?
-              <div className="card-img-overlay" style={{background: "rgba(255,255,255,0.7)"}}>
-                <i className="fa fa-refresh fa-spin" style={{position: "absolute", top: "50%", left: "50%", fontSize: "30px"}}/>
-              </div>
-              :
-              null
-          }
+      <div className="card">
+        <div className="card-header">
+          {t("Top Permitted Domains")}
         </div>
+        <div className="card-block">
+          <div style={{overflowX: "auto"}}>
+            {this.generateTable(t)}
+          </div>
+        </div>
+        {
+          this.state.loading
+            ?
+            <div className="card-img-overlay" style={{background: "rgba(255,255,255,0.7)"}}>
+              <i className="fa fa-refresh fa-spin" style={{position: "absolute", top: "50%", left: "50%", fontSize: "30px"}}/>
+            </div>
+            :
+            null
+        }
       </div>
     );
   }

--- a/src/views/Dashboard.js
+++ b/src/views/Dashboard.js
@@ -19,16 +19,32 @@ import { api } from "../utils";
 
 export default () => (
   <div className="animated fadeIn">
-    <SummaryStats/>
-    <QueriesGraph/>
+    <div className="row">
+      <SummaryStats/>
+    </div>
+    <div className="row">
+      <div className="col-md-12">
+        <QueriesGraph/>
+      </div>
+    </div>
     {
       api.loggedIn ?
         <Fragment>
-          <ClientsGraph/>
           <div className="row">
-            <TopDomains/>
-            <TopBlocked/>
-            <TopClients/>
+            <div className="col-md-12">
+              <ClientsGraph/>
+            </div>
+          </div>
+          <div className="row">
+            <div className="col-md-6 col-xl-4">
+              <TopDomains/>
+            </div>
+            <div className="col-md-6 col-xl-4">
+              <TopBlocked/>
+            </div>
+            <div className="col-md-6 col-xl-4">
+              <TopClients/>
+            </div>
           </div>
         </Fragment>
         : null


### PR DESCRIPTION
Instead of placing page-level layouts in the components, put them around the usage of the component so the component can easily be used elsewhere.