### PR TITLE
Allow fake settings data to be deployed

### DIFF
--- a/public/fakeAPI/.gitignore
+++ b/public/fakeAPI/.gitignore
@@ -1,5 +1,6 @@
 *
 !.gitignore
-!dns
-!stats
-!stats/overTime
+!dns/
+!stats/
+!settings/
+!stats/overTime/


### PR DESCRIPTION
If it is ignored, then the deploy commit would not include the data.

Also made it explicit that the folders are not ignored, not a file with
the same name as the folder.