### PR TITLE
Use the correct env variable when checking if this is a tag build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ version: 2
       BRANCH=$([ -z "$CIRCLE_TAG" ] && echo "$CIRCLE_BRANCH" || echo "master")
       echo "$CIRCLE_TAG $BRANCH ${CIRCLE_SHA1::7}" > build/VERSION
       cat build/VERSION
-      echo "export BRANCH=$BRANCH" >> $BASH_ENV
 
 jobs:
   build:
@@ -41,10 +40,11 @@ jobs:
         name: "Upload"
         command: |
           [ -z "$FTL_SECRET" ] && exit 0
+          FOLDER=$([ -z "$CIRCLE_TAG" ] && echo "$CIRCLE_BRANCH" || echo "$CIRCLE_TAG")
           tar -czvf pihole-web.tar.gz -C build .
           wget https://ftl.pi-hole.net:8080/FTL-client
           chmod +x ./FTL-client
-          ./FTL-client "$BRANCH" pihole-web.tar.gz "$FTL_SECRET"
+          ./FTL-client "$FOLDER" pihole-web.tar.gz "$FTL_SECRET"
           rm ./FTL-client
     - save_cache:
         key: v1-build-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ version: 2
   run:
     name: "Store Version"
     command: |
-      BRANCH=$([ -z "$CI_COMMIT_TAG" ] && echo "$CIRCLE_BRANCH" || echo "master")
+      BRANCH=$([ -z "$CIRCLE_TAG" ] && echo "$CIRCLE_BRANCH" || echo "master")
       echo "$CIRCLE_TAG $BRANCH ${CIRCLE_SHA1::7}" > build/VERSION
       cat build/VERSION
       echo "export BRANCH=$BRANCH" >> $BASH_ENV


### PR DESCRIPTION
It used to use a GitLab env variable, but we are using CircleCI.

Also, tag builds will be put in a folder named after the tag instead of master.