### PR TITLE
Generate route data from the existing navigation data

### DIFF
--- a/public/i18n/bg/login.json
+++ b/public/i18n/bg/login.json
@@ -5,6 +5,6 @@
     "Forgot Password": "Забравена парола",
     "forgot_password_description": "забравена парола описание",
     "Wrong Password!": "Грешна парола!",
-    "You will be transferred to the {{page}}": "Ще бъдете прехвърлени на {{страницата}}",
+    "You will be transferred to the \"{{page}}\" page": "Ще бъдете прехвърлени на {{страницата}}",
     "Verify that cookies are allowed for {{host}}": "Уверете се, че бисквитките са разрешени за {{хост}}"
 }

--- a/public/i18n/ca/login.json
+++ b/public/i18n/ca/login.json
@@ -5,6 +5,6 @@
     "Forgot Password": "He oblidat la clau",
     "forgot_password_description": "Després de Instal·lar Pi-hole per primer cop, es genera una clau i es mostra al usuari.\nLa clau no pot eser recuperada mes tard, però es pot canviar (o esborrar-la explícitament establint una clau buida) utilitzant la comanda:",
     "Wrong Password!": "Clau incorrecta",
-    "You will be transferred to the {{page}}": "Serás redirigit a {{page}}",
+    "You will be transferred to the \"{{page}}\" page": "Serás redirigit a {{page}}",
     "Verify that cookies are allowed for {{host}}": "Verifica que s'han permés les cookies per {{host}}"
 }

--- a/public/i18n/en/login.json
+++ b/public/i18n/en/login.json
@@ -5,6 +5,6 @@
     "Forgot Password": "Forgot Password",
     "forgot_password_description": "After installing Pi-hole for the first time, a password is generated and displayed to the user. The password cannot be retrieved later on, but it is possible to set a new password (or explicitly disable the password by setting an empty password) using the command:",
     "Wrong Password!": "Wrong Password!",
-    "You will be transferred to the {{page}}": "You will be transferred to the {{page}}",
+    "You will be transferred to the \"{{page}}\" page": "You will be transferred to the \"{{page}}\" page",
     "Verify that cookies are allowed for {{host}}": "Verify that cookies are allowed for {{host}}"
 }

--- a/public/i18n/es/login.json
+++ b/public/i18n/es/login.json
@@ -5,6 +5,6 @@
     "Forgot Password": "Olvidé la contraseña",
     "forgot_password_description": "Frase para recordar la contraseña",
     "Wrong Password!": "Contraseña incorrecta",
-    "You will be transferred to the {{page}}": "Será trasferido a la página: {{page}}",
+    "You will be transferred to the \"{{page}}\" page": "Será trasferido a la página: {{page}}",
     "Verify that cookies are allowed for {{host}}": "Verifique que {{host}} admite cookies."
 }

--- a/public/i18n/pt/login.json
+++ b/public/i18n/pt/login.json
@@ -5,6 +5,6 @@
     "Forgot Password": "Esqueceu a palavra passe",
     "forgot_password_description": "Esqueceu a palavra passe descrição",
     "Wrong Password!": "Palavra passe incorreta!",
-    "You will be transferred to the {{page}}": "Você será transferido para a {{página}}",
+    "You will be transferred to the \"{{page}}\" page": "Você será transferido para a {{página}}",
     "Verify that cookies are allowed for {{host}}": "Verifique se os cookies são permitidos para {{host}}"
 }

--- a/src/containers/Full.js
+++ b/src/containers/Full.js
@@ -13,15 +13,6 @@ import { Switch, Route, Redirect } from 'react-router-dom'
 import Header, { mobileSidebarHide } from '../components/common/Header';
 import Sidebar from '../components/common/Sidebar';
 import Footer from '../components/common/Footer';
-import Dashboard from '../views/Dashboard';
-import QueryLog from '../components/log/QueryLog';
-import Whitelist from "../views/Whitelist";
-import Blacklist from "../views/Blacklist";
-import Regexlist from "../views/Regexlist";
-import Versions from "../views/Versions";
-import Networking from "../views/Networking";
-import Login from "../views/Login";
-import Logout from "../views/Logout";
 import { api } from "../utils";
 import { nav } from "../routes";
 
@@ -33,16 +24,8 @@ export default props => (
       <main className="main" onClick={mobileSidebarHide}>
         <div className="container-fluid" style={{"marginTop": "1.5rem"}}>
           <Switch>
-            <Route path="/dashboard" name="Dashboard" component={Dashboard}/>
             <Redirect exact from="/" to="/dashboard"/>
-            <AuthRoute path="/query-log" name="Query Log" component={QueryLog}/>
-            <Route path="/whitelist" name="Whitelist" component={Whitelist}/>
-            <Route path="/blacklist/exact" name="Blacklist" component={Blacklist}/>
-            <Route path="/blacklist/regex" name="Regexlist" component={Regexlist}/>
-            <Route path="/settings/versions" name="Versions" component={Versions}/>
-            <Route path="/settings/networking" name="Networking" component={Networking}/>
-            <Route path="/login" name="Login" component={Login}/>
-            <AuthRoute path="/logout" name="Logout" component={Logout}/>
+            {nav.map(createRoute)}
           </Switch>
         </div>
       </main>
@@ -50,6 +33,22 @@ export default props => (
     <Footer/>
   </div>
 );
+
+/**
+ * Create a route from the route data.
+ * If the route has children, an array of routes will be returned.
+ *
+ * @param routeData the route data (see routes.js)
+ */
+const createRoute = routeData => {
+  if(routeData.children) {
+    return routeData.children.map(createRoute);
+  }
+
+  return routeData.auth
+    ? <AuthRoute key={routeData.url} path={routeData.url} component={routeData.component}/>
+    : <Route key={routeData.url} path={routeData.url} component={routeData.component}/>;
+};
 
 /**
  * Create a route which requires authentication.

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,6 +8,16 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
+import Dashboard from "./views/Dashboard";
+import QueryLog from "./components/log/QueryLog";
+import Whitelist from "./views/Whitelist";
+import Blacklist from "./views/Blacklist";
+import Regexlist from "./views/Regexlist";
+import Versions from "./views/Versions";
+import Networking from "./views/Networking";
+import Login from "./views/Login";
+import Logout from "./views/Logout";
+
 export const routes = t => ({
   '/dashboard': t('Dashboard'),
   '/query-log': t('Query Log'),
@@ -24,18 +34,21 @@ export const nav = [
   {
     name: 'Dashboard',
     url: '/dashboard',
+    component: Dashboard,
     icon: 'fa fa-dashboard',
     auth: false
   },
   {
     name: 'Query Log',
     url: '/query-log',
+    component: QueryLog,
     icon: 'fa fa-database',
     auth: true
   },
   {
     name: 'Whitelist',
     url: '/whitelist',
+    component: Whitelist,
     icon: 'fa fa-check-circle-o',
     auth: false
   },
@@ -48,12 +61,14 @@ export const nav = [
       {
         name: 'Exact',
         url: '/blacklist/exact',
+        component: Blacklist,
         icon: 'fa fa-ban',
         auth: false
       },
       {
         name: 'Regex',
         url: '/blacklist/regex',
+        component: Regexlist,
         icon: 'fa fa-ban',
         auth: false
       }
@@ -68,12 +83,14 @@ export const nav = [
       { 
         name: 'Versions',
         url: '/settings/versions',
+        component: Versions,
         icon: 'fa fa-download',
         auth: true
       },
       {
         name: 'Networking',
         url: '/settings/networking',
+        component: Networking,
         icon: 'fa fa-sitemap',
         auth: true,
       }
@@ -82,6 +99,7 @@ export const nav = [
   {
     name: 'Login',
     url: '/login',
+    component: Login,
     icon: 'fa fa-user',
     auth: false,
     authStrict: true
@@ -89,6 +107,7 @@ export const nav = [
   {
     name: 'Logout',
     url: '/logout',
+    component: Logout,
     icon: 'fa fa-user-times',
     auth: true,
     authStrict: true

--- a/src/views/Login.js
+++ b/src/views/Login.js
@@ -106,7 +106,7 @@ class Login extends Component {
                     <Fragment>
                       <br/>
                       {t(
-                        "You will be transferred to the {{page}}",
+                        "You will be transferred to the \"{{page}}\" page",
                         { page: routes(t)[this.props.location.state.from.pathname] }
                       )}
                     </Fragment>


### PR DESCRIPTION
This fixes a bug where the settings endpoints were able to be accessed without authentication (the API still requires auth, so no data would have been shown).

A slight change was made to the wording of the login page redirect.