### PR TITLE
Don't handle empty input in DomainInput

### DIFF
--- a/src/components/list/DomainInput.js
+++ b/src/components/list/DomainInput.js
@@ -25,6 +25,12 @@ class DomainInput extends Component {
     e.preventDefault();
 
     const domain = this.state.domain;
+
+    // Don't do anything for empty inputs
+    if(domain.length === 0) {
+      return;
+    }
+
     const isValid = this.props.isValid(domain);
     this.setState({ isValid });
     if (isValid) {

--- a/src/components/list/DomainInput.js
+++ b/src/components/list/DomainInput.js
@@ -27,7 +27,7 @@ class DomainInput extends Component {
     const domain = this.state.domain;
 
     // Don't do anything for empty inputs
-    if(domain.length === 0) {
+    if (domain.length === 0) {
       return;
     }
 

--- a/src/components/list/DomainInput.test.js
+++ b/src/components/list/DomainInput.test.js
@@ -128,15 +128,15 @@ it("does not call onEnter when input is empty", () => {
     <DomainInput
       onEnter={onEnter}
       onRefresh={jest.fn()}
-      isValid={isValidDomain}
+      isValid={() => true}
       onValidationError={jest.fn()}
     />
   );
 
   wrapper
-    .find("button")
+    .find("form")
     .first()
-    .simulate("click");
+    .simulate("submit", { preventDefault: jest.fn() });
 
   expect(onEnter).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
The test was broken when the component changed to use a form, because simply clicking the button didn't activate the handler.