### PR TITLE
DHCP Settings

### DIFF
--- a/src/components/settings/DHCPInfo.js
+++ b/src/components/settings/DHCPInfo.js
@@ -11,6 +11,7 @@
 import React, { Component } from "react";
 import { translate } from "react-i18next";
 import { api, ignoreCancel, makeCancelable } from "../../utils";
+import { Col, Form, FormGroup, Input, InputGroup, InputGroupAddon, Label } from "reactstrap";
 
 class DHCPInfo extends Component {
   state = {
@@ -67,25 +68,56 @@ class DHCPInfo extends Component {
     this.updateHandler.cancel();
   }
 
+  onChange = (key, attr) => {
+    return e => this.setState({
+      [key]: e.target[attr]
+    });
+  };
+
   render() {
     const { t } = this.props;
 
     return (
-      <pre>
-        {t("DHCP Active")}: {this.state.active.toString()}
-        <br />
-        {t("Start IP")}: {this.state.ip_start}
-        <br />
-        {t("End IP")}: {this.state.ip_end}
-        <br />
-        {t("Router IP")}: {this.state.router_ip}
-        <br />
-        {t("Lease Time")}: {this.state.lease_time} h<br />
-        {t("Domain")}: {this.state.domain}
-        <br />
-        {t("IPv6 Support")}: {this.state.ipv6_support.toString()}
-        <br />
-      </pre>
+      <Form>
+        <FormGroup check style={{ paddingBottom: "10px" }}>
+          <Label check>
+            <Input type="checkbox" checked={this.state.active} onChange={this.onChange("active", "checked")}/>
+            Enabled
+          </Label>
+        </FormGroup>
+        <FormGroup>
+          <Label for="startIP">{t("Start IP")}</Label>
+          <Input id="startIP" value={this.state.ip_start} onChange={this.onChange("ip_start", "value")}/>
+        </FormGroup>
+        <FormGroup>
+          <Label for="endIP">{t("End IP")}</Label>
+          <Input id="endIP" value={this.state.ip_end} onChange={this.onChange("ip_end", "value")}/>
+        </FormGroup>
+        <FormGroup>
+          <Label for="routerIP">{t("Router IP")}</Label>
+          <Input id="routerIP" value={this.state.router_ip} onChange={this.onChange("router_ip", "value")}/>
+        </FormGroup>
+        <FormGroup>
+          <Label for="leaseTime">{t("Lease Time")}</Label>
+          <InputGroup>
+            <Input id="leaseTime" value={this.state.lease_time} onChange={this.onChange("lease_time", "value")}/>
+            <InputGroupAddon addonType={"append"}>
+              Hours
+            </InputGroupAddon>
+          </InputGroup>
+        </FormGroup>
+        <FormGroup>
+          <Label for="domain">{t("Domain")}</Label>
+          <Input id="domain" value={this.state.domain} onChange={this.onChange("domain", "value")}/>
+        </FormGroup>
+        <FormGroup check>
+          <Label check>
+            <Input type="checkbox" checked={this.state.ipv6_support}
+                   onChange={this.onChange("ipv6_support", "checked")}/>
+            {t("IPv6 Support")}
+          </Label>
+        </FormGroup>
+      </Form>
     );
   }
 }

--- a/src/components/settings/DHCPInfo.js
+++ b/src/components/settings/DHCPInfo.js
@@ -21,11 +21,7 @@ import {
   InputGroupAddon,
   Label
 } from "reactstrap";
-import {
-  isStrictPositiveNumber,
-  isValidHostname,
-  isValidIpv4
-} from "../../validate";
+import { isPositiveNumber, isValidHostname, isValidIpv4 } from "../../validate";
 
 class DHCPInfo extends Component {
   state = {
@@ -103,7 +99,7 @@ class DHCPInfo extends Component {
     const isIpStartValid = isValidIpv4(this.state.ip_start);
     const isIpEndValid = isValidIpv4(this.state.ip_end);
     const isRouterIpValid = isValidIpv4(this.state.router_ip);
-    const isLeaseTimeValid = isStrictPositiveNumber(this.state.lease_time);
+    const isLeaseTimeValid = isPositiveNumber(this.state.lease_time);
     const isDomainValid = isValidHostname(this.state.domain);
 
     return (

--- a/src/components/settings/DHCPInfo.js
+++ b/src/components/settings/DHCPInfo.js
@@ -23,13 +23,13 @@ import {
 
 class DHCPInfo extends Component {
   state = {
-    active: "---",
-    ip_start: "---",
-    ip_end: "---",
-    router_ip: "---",
-    lease_time: "---",
-    domain: "---",
-    ipv6_support: "---"
+    active: false,
+    ip_start: "",
+    ip_end: "",
+    router_ip: "",
+    lease_time: 24,
+    domain: "",
+    ipv6_support: false
   };
 
   constructor(props) {
@@ -54,18 +54,7 @@ class DHCPInfo extends Component {
           ipv6_support: res.ipv6_support
         });
       })
-      .catch(ignoreCancel)
-      .catch(() => {
-        this.setState({
-          active: "-!-",
-          ip_start: "-!-",
-          ip_end: "-!-",
-          router_ip: "-!-",
-          lease_time: "-!-",
-          domain: "-!-",
-          ipv6_support: "-!-"
-        });
-      });
+      .catch(ignoreCancel);
   }
 
   componentDidMount() {

--- a/src/components/settings/DHCPInfo.js
+++ b/src/components/settings/DHCPInfo.js
@@ -12,6 +12,7 @@ import React, { Component } from "react";
 import { translate } from "react-i18next";
 import { api, ignoreCancel, makeCancelable } from "../../utils";
 import {
+  Button,
   Col,
   Form,
   FormGroup,
@@ -20,6 +21,11 @@ import {
   InputGroupAddon,
   Label
 } from "reactstrap";
+import {
+  isStrictPositiveNumber,
+  isValidHostname,
+  isValidIpv4
+} from "../../validate";
 
 class DHCPInfo extends Component {
   state = {
@@ -65,6 +71,14 @@ class DHCPInfo extends Component {
     this.updateHandler.cancel();
   }
 
+  /**
+   * Create a function which will update the key in the state with the value
+   * of the event attribute.
+   *
+   * @param key {string} the state to update
+   * @param attr {string} the event target attribute to use
+   * @returns {function(Event)}
+   */
   onChange = (key, attr) => {
     return e =>
       this.setState({
@@ -72,19 +86,36 @@ class DHCPInfo extends Component {
       });
   };
 
+  /**
+   * Save changes to DHCP settings
+   *
+   * @param e the submit event
+   */
+  saveSettings = e => {
+    e.preventDefault();
+
+    // TODO: send settings to API
+  };
+
   render() {
     const { t } = this.props;
 
+    const isIpStartValid = isValidIpv4(this.state.ip_start);
+    const isIpEndValid = isValidIpv4(this.state.ip_end);
+    const isRouterIpValid = isValidIpv4(this.state.router_ip);
+    const isLeaseTimeValid = isStrictPositiveNumber(this.state.lease_time);
+    const isDomainValid = isValidHostname(this.state.domain);
+
     return (
-      <Form>
-        <FormGroup check style={{ paddingBottom: "10px" }}>
+      <Form onSubmit={this.saveSettings}>
+        <FormGroup check>
           <Label check>
             <Input
               type="checkbox"
               checked={this.state.active}
               onChange={this.onChange("active", "checked")}
             />
-            Enabled
+            {t("Enabled")}
           </Label>
         </FormGroup>
         <FormGroup row>
@@ -97,6 +128,7 @@ class DHCPInfo extends Component {
               disabled={!this.state.active}
               value={this.state.ip_start}
               onChange={this.onChange("ip_start", "value")}
+              invalid={this.state.active && !isIpStartValid}
             />
           </Col>
         </FormGroup>
@@ -110,6 +142,7 @@ class DHCPInfo extends Component {
               disabled={!this.state.active}
               value={this.state.ip_end}
               onChange={this.onChange("ip_end", "value")}
+              invalid={this.state.active && !isIpEndValid}
             />
           </Col>
         </FormGroup>
@@ -123,6 +156,7 @@ class DHCPInfo extends Component {
               disabled={!this.state.active}
               value={this.state.router_ip}
               onChange={this.onChange("router_ip", "value")}
+              invalid={this.state.active && !isRouterIpValid}
             />
           </Col>
         </FormGroup>
@@ -137,6 +171,7 @@ class DHCPInfo extends Component {
                 disabled={!this.state.active}
                 value={this.state.lease_time}
                 onChange={this.onChange("lease_time", "value")}
+                invalid={this.state.active && !isLeaseTimeValid}
               />
               <InputGroupAddon addonType={"append"}>Hours</InputGroupAddon>
             </InputGroup>
@@ -152,6 +187,7 @@ class DHCPInfo extends Component {
               disabled={!this.state.active}
               value={this.state.domain}
               onChange={this.onChange("domain", "value")}
+              invalid={this.state.active && !isDomainValid}
             />
           </Col>
         </FormGroup>
@@ -166,6 +202,19 @@ class DHCPInfo extends Component {
             {t("IPv6 Support")}
           </Label>
         </FormGroup>
+        <Button
+          type="submit"
+          disabled={
+            this.state.active &&
+            (!isIpStartValid ||
+              !isIpEndValid ||
+              !isRouterIpValid ||
+              !isLeaseTimeValid ||
+              !isDomainValid)
+          }
+        >
+          {t("Apply")}
+        </Button>
       </Form>
     );
   }

--- a/src/components/settings/DHCPInfo.js
+++ b/src/components/settings/DHCPInfo.js
@@ -11,7 +11,7 @@
 import React, { Component } from "react";
 import { translate } from "react-i18next";
 import { api, ignoreCancel, makeCancelable } from "../../utils";
-import { Col, Form, FormGroup, Input, InputGroup, InputGroupAddon, Label } from "reactstrap";
+import { Form, FormGroup, Input, InputGroup, InputGroupAddon, Label } from "reactstrap";
 
 class DHCPInfo extends Component {
   state = {
@@ -87,20 +87,20 @@ class DHCPInfo extends Component {
         </FormGroup>
         <FormGroup>
           <Label for="startIP">{t("Start IP")}</Label>
-          <Input id="startIP" value={this.state.ip_start} onChange={this.onChange("ip_start", "value")}/>
+          <Input id="startIP" disabled={!this.state.active} value={this.state.ip_start} onChange={this.onChange("ip_start", "value")}/>
         </FormGroup>
         <FormGroup>
           <Label for="endIP">{t("End IP")}</Label>
-          <Input id="endIP" value={this.state.ip_end} onChange={this.onChange("ip_end", "value")}/>
+          <Input id="endIP" disabled={!this.state.active} value={this.state.ip_end} onChange={this.onChange("ip_end", "value")}/>
         </FormGroup>
         <FormGroup>
           <Label for="routerIP">{t("Router IP")}</Label>
-          <Input id="routerIP" value={this.state.router_ip} onChange={this.onChange("router_ip", "value")}/>
+          <Input id="routerIP" disabled={!this.state.active} value={this.state.router_ip} onChange={this.onChange("router_ip", "value")}/>
         </FormGroup>
         <FormGroup>
           <Label for="leaseTime">{t("Lease Time")}</Label>
           <InputGroup>
-            <Input id="leaseTime" value={this.state.lease_time} onChange={this.onChange("lease_time", "value")}/>
+            <Input id="leaseTime" disabled={!this.state.active} value={this.state.lease_time} onChange={this.onChange("lease_time", "value")}/>
             <InputGroupAddon addonType={"append"}>
               Hours
             </InputGroupAddon>
@@ -108,11 +108,11 @@ class DHCPInfo extends Component {
         </FormGroup>
         <FormGroup>
           <Label for="domain">{t("Domain")}</Label>
-          <Input id="domain" value={this.state.domain} onChange={this.onChange("domain", "value")}/>
+          <Input id="domain" disabled={!this.state.active} value={this.state.domain} onChange={this.onChange("domain", "value")}/>
         </FormGroup>
         <FormGroup check>
           <Label check>
-            <Input type="checkbox" checked={this.state.ipv6_support}
+            <Input type="checkbox" disabled={!this.state.active} checked={this.state.ipv6_support}
                    onChange={this.onChange("ipv6_support", "checked")}/>
             {t("IPv6 Support")}
           </Label>

--- a/src/components/settings/DHCPInfo.js
+++ b/src/components/settings/DHCPInfo.js
@@ -11,7 +11,7 @@
 import React, { Component } from "react";
 import { translate } from "react-i18next";
 import { api, ignoreCancel, makeCancelable } from "../../utils";
-import { Form, FormGroup, Input, InputGroup, InputGroupAddon, Label } from "reactstrap";
+import { Col, Form, FormGroup, Input, InputGroup, InputGroupAddon, Label } from "reactstrap";
 
 class DHCPInfo extends Component {
   state = {
@@ -85,30 +85,45 @@ class DHCPInfo extends Component {
             Enabled
           </Label>
         </FormGroup>
-        <FormGroup>
-          <Label for="startIP">{t("Start IP")}</Label>
-          <Input id="startIP" disabled={!this.state.active} value={this.state.ip_start} onChange={this.onChange("ip_start", "value")}/>
+        <FormGroup row>
+          <Label for="startIP" sm={2}>{t("Start IP")}</Label>
+          <Col sm={10}>
+            <Input id="startIP" disabled={!this.state.active} value={this.state.ip_start}
+                   onChange={this.onChange("ip_start", "value")}/>
+          </Col>
         </FormGroup>
-        <FormGroup>
-          <Label for="endIP">{t("End IP")}</Label>
-          <Input id="endIP" disabled={!this.state.active} value={this.state.ip_end} onChange={this.onChange("ip_end", "value")}/>
+        <FormGroup row>
+          <Label for="endIP" sm={2}>{t("End IP")}</Label>
+          <Col sm={10}>
+            <Input id="endIP" disabled={!this.state.active} value={this.state.ip_end}
+                   onChange={this.onChange("ip_end", "value")}/>
+          </Col>
         </FormGroup>
-        <FormGroup>
-          <Label for="routerIP">{t("Router IP")}</Label>
-          <Input id="routerIP" disabled={!this.state.active} value={this.state.router_ip} onChange={this.onChange("router_ip", "value")}/>
+        <FormGroup row>
+          <Label for="routerIP" sm={2}>{t("Router IP")}</Label>
+          <Col sm={10}>
+            <Input id="routerIP" disabled={!this.state.active} value={this.state.router_ip}
+                   onChange={this.onChange("router_ip", "value")}/>
+          </Col>
         </FormGroup>
-        <FormGroup>
-          <Label for="leaseTime">{t("Lease Time")}</Label>
-          <InputGroup>
-            <Input id="leaseTime" disabled={!this.state.active} value={this.state.lease_time} onChange={this.onChange("lease_time", "value")}/>
-            <InputGroupAddon addonType={"append"}>
-              Hours
-            </InputGroupAddon>
-          </InputGroup>
+        <FormGroup row>
+          <Label for="leaseTime" sm={2}>{t("Lease Time")}</Label>
+          <Col sm={10}>
+            <InputGroup>
+              <Input id="leaseTime" disabled={!this.state.active} value={this.state.lease_time}
+                     onChange={this.onChange("lease_time", "value")}/>
+              <InputGroupAddon addonType={"append"}>
+                Hours
+              </InputGroupAddon>
+            </InputGroup>
+          </Col>
         </FormGroup>
-        <FormGroup>
-          <Label for="domain">{t("Domain")}</Label>
-          <Input id="domain" disabled={!this.state.active} value={this.state.domain} onChange={this.onChange("domain", "value")}/>
+        <FormGroup row>
+          <Label for="domain" sm={2}>{t("Domain")}</Label>
+          <Col sm={10}>
+            <Input id="domain" disabled={!this.state.active} value={this.state.domain}
+                   onChange={this.onChange("domain", "value")}/>
+          </Col>
         </FormGroup>
         <FormGroup check>
           <Label check>

--- a/src/components/settings/DHCPInfo.js
+++ b/src/components/settings/DHCPInfo.js
@@ -11,7 +11,15 @@
 import React, { Component } from "react";
 import { translate } from "react-i18next";
 import { api, ignoreCancel, makeCancelable } from "../../utils";
-import { Col, Form, FormGroup, Input, InputGroup, InputGroupAddon, Label } from "reactstrap";
+import {
+  Col,
+  Form,
+  FormGroup,
+  Input,
+  InputGroup,
+  InputGroupAddon,
+  Label
+} from "reactstrap";
 
 class DHCPInfo extends Component {
   state = {
@@ -69,9 +77,10 @@ class DHCPInfo extends Component {
   }
 
   onChange = (key, attr) => {
-    return e => this.setState({
-      [key]: e.target[attr]
-    });
+    return e =>
+      this.setState({
+        [key]: e.target[attr]
+      });
   };
 
   render() {
@@ -81,54 +90,90 @@ class DHCPInfo extends Component {
       <Form>
         <FormGroup check style={{ paddingBottom: "10px" }}>
           <Label check>
-            <Input type="checkbox" checked={this.state.active} onChange={this.onChange("active", "checked")}/>
+            <Input
+              type="checkbox"
+              checked={this.state.active}
+              onChange={this.onChange("active", "checked")}
+            />
             Enabled
           </Label>
         </FormGroup>
         <FormGroup row>
-          <Label for="startIP" sm={2}>{t("Start IP")}</Label>
+          <Label for="startIP" sm={2}>
+            {t("Start IP")}
+          </Label>
           <Col sm={10}>
-            <Input id="startIP" disabled={!this.state.active} value={this.state.ip_start}
-                   onChange={this.onChange("ip_start", "value")}/>
+            <Input
+              id="startIP"
+              disabled={!this.state.active}
+              value={this.state.ip_start}
+              onChange={this.onChange("ip_start", "value")}
+            />
           </Col>
         </FormGroup>
         <FormGroup row>
-          <Label for="endIP" sm={2}>{t("End IP")}</Label>
+          <Label for="endIP" sm={2}>
+            {t("End IP")}
+          </Label>
           <Col sm={10}>
-            <Input id="endIP" disabled={!this.state.active} value={this.state.ip_end}
-                   onChange={this.onChange("ip_end", "value")}/>
+            <Input
+              id="endIP"
+              disabled={!this.state.active}
+              value={this.state.ip_end}
+              onChange={this.onChange("ip_end", "value")}
+            />
           </Col>
         </FormGroup>
         <FormGroup row>
-          <Label for="routerIP" sm={2}>{t("Router IP")}</Label>
+          <Label for="routerIP" sm={2}>
+            {t("Router IP")}
+          </Label>
           <Col sm={10}>
-            <Input id="routerIP" disabled={!this.state.active} value={this.state.router_ip}
-                   onChange={this.onChange("router_ip", "value")}/>
+            <Input
+              id="routerIP"
+              disabled={!this.state.active}
+              value={this.state.router_ip}
+              onChange={this.onChange("router_ip", "value")}
+            />
           </Col>
         </FormGroup>
         <FormGroup row>
-          <Label for="leaseTime" sm={2}>{t("Lease Time")}</Label>
+          <Label for="leaseTime" sm={2}>
+            {t("Lease Time")}
+          </Label>
           <Col sm={10}>
             <InputGroup>
-              <Input id="leaseTime" disabled={!this.state.active} value={this.state.lease_time}
-                     onChange={this.onChange("lease_time", "value")}/>
-              <InputGroupAddon addonType={"append"}>
-                Hours
-              </InputGroupAddon>
+              <Input
+                id="leaseTime"
+                disabled={!this.state.active}
+                value={this.state.lease_time}
+                onChange={this.onChange("lease_time", "value")}
+              />
+              <InputGroupAddon addonType={"append"}>Hours</InputGroupAddon>
             </InputGroup>
           </Col>
         </FormGroup>
         <FormGroup row>
-          <Label for="domain" sm={2}>{t("Domain")}</Label>
+          <Label for="domain" sm={2}>
+            {t("Domain")}
+          </Label>
           <Col sm={10}>
-            <Input id="domain" disabled={!this.state.active} value={this.state.domain}
-                   onChange={this.onChange("domain", "value")}/>
+            <Input
+              id="domain"
+              disabled={!this.state.active}
+              value={this.state.domain}
+              onChange={this.onChange("domain", "value")}
+            />
           </Col>
         </FormGroup>
         <FormGroup check>
           <Label check>
-            <Input type="checkbox" disabled={!this.state.active} checked={this.state.ipv6_support}
-                   onChange={this.onChange("ipv6_support", "checked")}/>
+            <Input
+              type="checkbox"
+              disabled={!this.state.active}
+              checked={this.state.ipv6_support}
+              onChange={this.onChange("ipv6_support", "checked")}
+            />
             {t("IPv6 Support")}
           </Label>
         </FormGroup>

--- a/src/components/settings/DNSInfo.js
+++ b/src/components/settings/DNSInfo.js
@@ -14,17 +14,17 @@ import { api, ignoreCancel, makeCancelable } from "../../utils";
 
 class DNSInfo extends Component {
   state = {
-    upstream_dns: ["---"],
+    upstream_dns: [],
     conditional_forwarding: {
-      enabled: "---",
-      router_ip: "---",
-      domain: "---"
+      enabled: false,
+      router_ip: "",
+      domain: ""
     },
     options: {
-      fqdn_required: "---",
-      bogus_priv: "---",
-      dnssec: "---",
-      listening_type: "---"
+      fqdn_required: false,
+      bogus_priv: false,
+      dnssec: false,
+      listening_type: "single"
     }
   };
 
@@ -42,23 +42,7 @@ class DNSInfo extends Component {
       .then(res => {
         this.setState(res);
       })
-      .catch(ignoreCancel)
-      .catch(() => {
-        this.setState({
-          upstream_dns: ["-!-"],
-          options: {
-            fqdn_required: "-!-",
-            bogus_priv: "-!-",
-            dnssec: "-!-",
-            listening_type: "-!-"
-          },
-          conditional_forwarding: {
-            enabled: "-!-",
-            router_ip: "-!-",
-            domain: "-!-"
-          }
-        });
-      });
+      .catch(ignoreCancel);
   }
 
   componentDidMount() {

--- a/src/components/settings/FTLInfo.js
+++ b/src/components/settings/FTLInfo.js
@@ -14,9 +14,9 @@ import { api, ignoreCancel, makeCancelable } from "../../utils";
 
 class FTLInfo extends Component {
   state = {
-    filesize: "---",
-    queries: "---",
-    sqlite_version: "---"
+    filesize: 0,
+    queries: 0,
+    sqlite_version: ""
   };
 
   constructor(props) {
@@ -37,14 +37,7 @@ class FTLInfo extends Component {
           sqlite_version: res.sqlite_version
         });
       })
-      .catch(ignoreCancel)
-      .catch(() => {
-        this.setState({
-          queries: "-!-",
-          filesize: "-!-",
-          sqlite_version: "-!-"
-        });
-      });
+      .catch(ignoreCancel);
   }
 
   componentDidMount() {

--- a/src/components/settings/NetworkInfo.js
+++ b/src/components/settings/NetworkInfo.js
@@ -8,7 +8,7 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-import React, { Component, Fragment } from "react";
+import React, { Component } from "react";
 import { translate } from "react-i18next";
 import { api, ignoreCancel, makeCancelable } from "../../utils";
 import { Col, Form, FormGroup, Input, Label } from "reactstrap";

--- a/src/components/settings/NetworkInfo.js
+++ b/src/components/settings/NetworkInfo.js
@@ -65,27 +65,43 @@ class NetworkInfo extends Component {
     return (
       <Form>
         <FormGroup row>
-          <Label className="bold" for="interface" sm={4}>{t("Interface")}</Label>
+          <Label className="bold" for="interface" sm={4}>
+            {t("Interface")}
+          </Label>
           <Col sm={8}>
-            <Input plaintext id="interface">{this.state.interface}</Input>
+            <Input plaintext id="interface">
+              {this.state.interface}
+            </Input>
           </Col>
         </FormGroup>
         <FormGroup row>
-          <Label className="bold" for="ipv4_address" sm={4}>{t("IPv4 address")}</Label>
+          <Label className="bold" for="ipv4_address" sm={4}>
+            {t("IPv4 address")}
+          </Label>
           <Col sm={8}>
-            <Input plaintext id="ipv4_address">{this.state.ipv4_address}</Input>
+            <Input plaintext id="ipv4_address">
+              {this.state.ipv4_address}
+            </Input>
           </Col>
         </FormGroup>
         <FormGroup row>
-          <Label className="bold" for="ipv6_address" sm={4}>{t("IPv6 address")}</Label>
+          <Label className="bold" for="ipv6_address" sm={4}>
+            {t("IPv6 address")}
+          </Label>
           <Col sm={8}>
-            <Input plaintext id="ipv6_address">{this.state.ipv6_address}</Input>
+            <Input plaintext id="ipv6_address">
+              {this.state.ipv6_address}
+            </Input>
           </Col>
         </FormGroup>
         <FormGroup row>
-          <Label className="bold" for="hostname" sm={4}>{t("Hostname")}</Label>
+          <Label className="bold" for="hostname" sm={4}>
+            {t("Hostname")}
+          </Label>
           <Col sm={8}>
-            <Input plaintext id="hostname">{this.state.hostname}</Input>
+            <Input plaintext id="hostname">
+              {this.state.hostname}
+            </Input>
           </Col>
         </FormGroup>
       </Form>

--- a/src/components/settings/NetworkInfo.js
+++ b/src/components/settings/NetworkInfo.js
@@ -15,10 +15,10 @@ import { Col, Form, FormGroup, Input, Label } from "reactstrap";
 
 class NetworkInfo extends Component {
   state = {
-    interface: "---",
-    ipv4_address: "---",
-    ipv6_address: "---",
-    hostname: "---"
+    interface: "",
+    ipv4_address: "",
+    ipv6_address: "",
+    hostname: ""
   };
 
   constructor(props) {
@@ -40,15 +40,7 @@ class NetworkInfo extends Component {
           hostname: res.hostname
         });
       })
-      .catch(ignoreCancel)
-      .catch(() => {
-        this.setState({
-          interface: "-!-",
-          ipv4_address: "-!-",
-          ipv6_address: "-!-",
-          hostname: "-!-"
-        });
-      });
+      .catch(ignoreCancel);
   }
 
   componentDidMount() {

--- a/src/components/settings/NetworkInfo.js
+++ b/src/components/settings/NetworkInfo.js
@@ -63,50 +63,32 @@ class NetworkInfo extends Component {
     const { t } = this.props;
 
     return (
-      <Fragment>
-        <Form>
-          <FormGroup row>
-            <Label className="bold" for="interface" sm={4}>
-              {t("Interface")}
-            </Label>
-            <Col sm={8}>
-              <Input plaintext id="interface">
-                {this.state.interface}
-              </Input>
-            </Col>
-          </FormGroup>
-          <FormGroup row>
-            <Label className="bold" for="ipv4_address" sm={4}>
-              {t("IPv4 address")}
-            </Label>
-            <Col sm={8}>
-              <Input plaintext id="ipv4_address">
-                {this.state.ipv4_address}
-              </Input>
-            </Col>
-          </FormGroup>
-          <FormGroup row>
-            <Label className="bold" for="ipv6_address" sm={4}>
-              {t("IPv6 address")}
-            </Label>
-            <Col sm={8}>
-              <Input plaintext id="ipv6_address">
-                {this.state.ipv6_address}
-              </Input>
-            </Col>
-          </FormGroup>
-          <FormGroup row>
-            <Label className="bold" for="hostname" sm={4}>
-              {t("Hostname")}
-            </Label>
-            <Col sm={8}>
-              <Input plaintext id="hostname">
-                {this.state.hostname}
-              </Input>
-            </Col>
-          </FormGroup>
-        </Form>
-      </Fragment>
+      <Form>
+        <FormGroup row>
+          <Label className="bold" for="interface" sm={4}>{t("Interface")}</Label>
+          <Col sm={8}>
+            <Input plaintext id="interface">{this.state.interface}</Input>
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label className="bold" for="ipv4_address" sm={4}>{t("IPv4 address")}</Label>
+          <Col sm={8}>
+            <Input plaintext id="ipv4_address">{this.state.ipv4_address}</Input>
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label className="bold" for="ipv6_address" sm={4}>{t("IPv6 address")}</Label>
+          <Col sm={8}>
+            <Input plaintext id="ipv6_address">{this.state.ipv6_address}</Input>
+          </Col>
+        </FormGroup>
+        <FormGroup row>
+          <Label className="bold" for="hostname" sm={4}>{t("Hostname")}</Label>
+          <Col sm={8}>
+            <Input plaintext id="hostname">{this.state.hostname}</Input>
+          </Col>
+        </FormGroup>
+      </Form>
     );
   }
 }

--- a/src/components/settings/VersionInfo.js
+++ b/src/components/settings/VersionInfo.js
@@ -16,24 +16,24 @@ import VersionCard from "./VersionCard";
 class VersionInfo extends Component {
   state = {
     api: {
-      branch: "---",
-      hash: "---",
-      tag: "---"
+      branch: "unknown",
+      hash: "unknown",
+      tag: "unknown"
     },
     core: {
-      branch: "---",
-      hash: "---",
-      tag: "---"
+      branch: "unknown",
+      hash: "unknown",
+      tag: "unknown"
     },
     ftl: {
-      branch: "---",
-      hash: "---",
-      tag: "---"
+      branch: "unknown",
+      hash: "unknown",
+      tag: "unknown"
     },
     web: {
-      branch: "---",
-      hash: "---",
-      tag: "---"
+      branch: "unknown",
+      hash: "unknown",
+      tag: "unknown"
     }
   };
 
@@ -51,31 +51,7 @@ class VersionInfo extends Component {
       .then(res => {
         this.setState(res);
       })
-      .catch(ignoreCancel)
-      .catch(() => {
-        this.setState({
-          api: {
-            branch: "-!-",
-            hash: "-!-",
-            tag: "-!-"
-          },
-          core: {
-            branch: "-!-",
-            hash: "-!-",
-            tag: "-!-"
-          },
-          ftl: {
-            branch: "-!-",
-            hash: "-!-",
-            tag: "-!-"
-          },
-          web: {
-            branch: "-!-",
-            hash: "-!-",
-            tag: "-!-"
-          }
-        });
-      });
+      .catch(ignoreCancel);
   }
 
   componentDidMount() {

--- a/src/scss/_custom.scss
+++ b/src/scss/_custom.scss
@@ -178,3 +178,7 @@
   width: 100%;
   text-align: left;
 }
+
+.form-check-label {
+  margin-bottom: 10px;
+}

--- a/src/validate.js
+++ b/src/validate.js
@@ -21,7 +21,7 @@ export function isValidHostname(hostname) {
   // Must not be all numbers and periods
   const joined = segments.join("");
   // If the hostname without periods make a number, deny
-  if (isStrictNumeric(joined)) return false;
+  if (isStrictPositiveNumber(joined)) return false;
 
   return /^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*$/.test(
     hostname
@@ -36,10 +36,10 @@ export function isValidDomain(domain) {
   return isValidHostname(domain);
 }
 
-export function isStrictNumeric(input) {
+export function isStrictPositiveNumber(input) {
   // Because parseInt has limitations, e.g. parseInt("15ex") is parsed to 15
   // Caution, does not work with negative numbers, replace with /^(\-|\+)?([0-9])$/ if needed
-  return /^[0-9]*$/.test(input);
+  return /^[0-9]+$/.test(input);
 }
 
 export function isValidRegex(regex) {

--- a/src/validate.js
+++ b/src/validate.js
@@ -21,7 +21,7 @@ export function isValidHostname(hostname) {
   // Must not be all numbers and periods
   const joined = segments.join("");
   // If the hostname without periods make a number, deny
-  if (isStrictPositiveNumber(joined)) return false;
+  if (isPositiveNumber(joined)) return false;
 
   return /^([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*)+(\.([a-zA-Z0-9]+(-[a-zA-Z0-9]+)*))*$/.test(
     hostname
@@ -36,7 +36,7 @@ export function isValidDomain(domain) {
   return isValidHostname(domain);
 }
 
-export function isStrictPositiveNumber(input) {
+export function isPositiveNumber(input) {
   // Because parseInt has limitations, e.g. parseInt("15ex") is parsed to 15
   // Caution, does not work with negative numbers, replace with /^(\-|\+)?([0-9])$/ if needed
   return /^[0-9]+$/.test(input);
@@ -71,5 +71,5 @@ export function isValidIpv4(address) {
   }
 
   // All segments must be numbers (positive)
-  return segments.every(segment => isStrictPositiveNumber(segment));
+  return segments.every(segment => isPositiveNumber(segment));
 }

--- a/src/validate.js
+++ b/src/validate.js
@@ -50,3 +50,26 @@ export function isValidRegex(regex) {
   }
   return true;
 }
+
+/**
+ * Check if the string is a valid IPv4 address
+ *
+ * @param address {string} the address to check
+ * @returns {boolean} if the address is a valid IPv4 address
+ */
+export function isValidIpv4(address) {
+  const segments = address.split(".");
+
+  // Must have 4 segments
+  if (segments.length !== 4) {
+    return false;
+  }
+
+  // No segment can be longer than 3 characters or be empty
+  if (segments.some(segment => segment.length > 3 || segment.length === 0)) {
+    return false;
+  }
+
+  // All segments must be numbers (positive)
+  return segments.every(segment => isStrictPositiveNumber(segment));
+}

--- a/src/validate.js
+++ b/src/validate.js
@@ -66,10 +66,9 @@ export function isValidIpv4(address) {
   }
 
   // No segment can be longer than 3 characters or be empty
-  if (segments.some(segment => segment.length > 3 || segment.length === 0)) {
-    return false;
-  }
 
   // All segments must be numbers (positive)
-  return segments.every(segment => isPositiveNumber(segment));
+  return segments.every(
+    segment => isPositiveNumber(segment) && parseInt(segment) < 256
+  );
 }

--- a/src/validate.test.js
+++ b/src/validate.test.js
@@ -11,6 +11,7 @@
 import {
   isStrictPositiveNumber,
   isValidDomain,
+  isValidIpv4,
   isValidRegex
 } from "./validate";
 
@@ -147,6 +148,40 @@ describe("Testing the validation functions", () => {
 
     it("should not pass regex validation when missing closing bracket", () => {
       expect(isValidRegex("[0-")).toBe(false);
+    });
+  });
+
+  describe("isValidIpv4", () => {
+    it("passes 127.0.0.1", () => {
+      expect(isValidIpv4("127.0.0.1")).toBe(true);
+    });
+
+    it("passes 1.1.1.1", () => {
+      expect(isValidIpv4("1.1.1.1")).toBe(true);
+    });
+
+    it("passes 111.111.111.111", () => {
+      expect(isValidIpv4("111.111.111.111")).toBe(true);
+    });
+
+    it("fails 1111.1.1.1", () => {
+      expect(isValidIpv4("1111.1.1.1")).toBe(false);
+    });
+
+    it("fails 1.1.1.", () => {
+      expect(isValidIpv4("1.1.1.")).toBe(false);
+    });
+
+    it("fails empty string", () => {
+      expect(isValidIpv4("")).toBe(false);
+    });
+
+    it("fails 8.8", () => {
+      expect(isValidIpv4("8.8")).toBe(false);
+    });
+
+    it("fails 10. 10.1.1", () => {
+      expect(isValidIpv4("10. 10.1.1")).toBe(false);
     });
   });
 });

--- a/src/validate.test.js
+++ b/src/validate.test.js
@@ -183,5 +183,9 @@ describe("Testing the validation functions", () => {
     it("fails 10. 10.1.1", () => {
       expect(isValidIpv4("10. 10.1.1")).toBe(false);
     });
+
+    it("fails 555.666.777.888", () => {
+      expect(isValidIpv4("555.666.777.888")).toBe(false);
+    });
   });
 });

--- a/src/validate.test.js
+++ b/src/validate.test.js
@@ -9,7 +9,7 @@
 *  Please see LICENSE file for your rights under this license. */
 
 import {
-  isStrictPositiveNumber,
+  isPositiveNumber,
   isValidDomain,
   isValidIpv4,
   isValidRegex
@@ -107,24 +107,24 @@ describe("Testing the validation functions", () => {
     });
   });
 
-  describe("isStrictPositiveNumber", () => {
+  describe("isPositiveNumber", () => {
     it("passes 1234567890", () => {
-      const result = isStrictPositiveNumber("1234567890");
+      const result = isPositiveNumber("1234567890");
       expect(result).toBe(true);
     });
 
     it("fails 1234a567890", () => {
-      const result = isStrictPositiveNumber("1234a567890");
+      const result = isPositiveNumber("1234a567890");
       expect(result).toBe(false);
     });
 
     it("fails 1100101O1", () => {
-      const result = isStrictPositiveNumber("1100101O1");
+      const result = isPositiveNumber("1100101O1");
       expect(result).toBe(false);
     });
 
     it("fails empty string", () => {
-      const result = isStrictPositiveNumber("");
+      const result = isPositiveNumber("");
       expect(result).toBe(false);
     });
   });

--- a/src/validate.test.js
+++ b/src/validate.test.js
@@ -8,7 +8,11 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-import { isStrictNumeric, isValidDomain, isValidRegex } from "./validate";
+import {
+  isStrictPositiveNumber,
+  isValidDomain,
+  isValidRegex
+} from "./validate";
 
 describe("Testing the validation functions", () => {
   describe("isValidDomain", () => {
@@ -102,19 +106,24 @@ describe("Testing the validation functions", () => {
     });
   });
 
-  describe("isStrictNumeric", () => {
+  describe("isStrictPositiveNumber", () => {
     it("passes 1234567890", () => {
-      const result = isStrictNumeric("1234567890");
+      const result = isStrictPositiveNumber("1234567890");
       expect(result).toBe(true);
     });
 
     it("fails 1234a567890", () => {
-      const result = isStrictNumeric("1234a567890");
+      const result = isStrictPositiveNumber("1234a567890");
       expect(result).toBe(false);
     });
 
     it("fails 1100101O1", () => {
-      const result = isStrictNumeric("1100101O1");
+      const result = isStrictPositiveNumber("1100101O1");
+      expect(result).toBe(false);
+    });
+
+    it("fails empty string", () => {
+      const result = isStrictPositiveNumber("");
       expect(result).toBe(false);
     });
   });


### PR DESCRIPTION
The DHCP settings are now shown in an editable form and are validated. The changes are not yet sent to the API, because the API still needs to implement applying the DHCP settings.

Misc changes:
- Added `isValidIpv4`
- Renamed `isStrictNumeric` to `isPositiveNumber`
- Remove loading and error state strings in settings
- Fix bottom margin on check boxes

![image](https://user-images.githubusercontent.com/4417660/48015864-1a25db80-e0f8-11e8-95e3-7a17dedc205b.png)
