### PR TITLE
Remove the proxy option from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "private": true,
   "homepage": "/admin",
-  "proxy": "http://pi.hole",
   "devDependencies": {
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",


### PR DESCRIPTION
It should only be added when testing against a real API instance. Most of the time, development is done against the fake API, or there is no real API running to test with.