### PR TITLE
Fix doughnut charts acting weird when resized

### DIFF
--- a/src/components/dashboard/GenericDoughnutChart.js
+++ b/src/components/dashboard/GenericDoughnutChart.js
@@ -79,7 +79,12 @@ export class GenericDoughnutChart extends Component {
               data={{
                 datasets: [
                   {
-                    data: this.props.data,
+                    // Make a copy of the data here. ChartJS does weird things
+                    // to the data, which React doesn't catch. This can cause
+                    // oddities such as one chart showing the other chart's
+                    // data. This behavior is fixed by sending ChartJS its own
+                    // copy of the data.
+                    data: [...this.props.data],
                     backgroundColor: this.props.colors
                   }
                 ],


### PR DESCRIPTION
The charts would start using and displaying data from other charts, and would have graphical glitches. The glitches are fixed by giving the chart its own copy of the dataset. See jerairrest/react-chartjs-2#250.

Examples of the glitches:
![doughnut-crash](https://user-images.githubusercontent.com/4417660/50050413-3d18b780-00c8-11e9-8d31-6306d995af15.gif)
![resize-issue](https://user-images.githubusercontent.com/4417660/50050415-3f7b1180-00c8-11e9-877f-6b00c8f92406.gif)
