### PR TITLE
Fix base path of router set to / instead of /admin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ api.loggedIn = document.cookie.includes("user_id=");
 setupI18n();
 
 ReactDOM.render(
-  <BrowserRouter>
+  <BrowserRouter basename={process.env.PUBLIC_URL}>
     <Switch>
       <Route path="/" name="Home" component={Full} />
     </Switch>


### PR DESCRIPTION
The base path of the build was set correctly to /admin, but the client side router (react-router) was using / as the base path. Now it will use the same base path as the build.