### PR TITLE
WithAPIData: Don't make a request on refresh if we know the answer

### DIFF
--- a/src/components/common/EnableDisable.js
+++ b/src/components/common/EnableDisable.js
@@ -43,6 +43,29 @@ class EnableDisable extends Component {
     customMultiplier: 60
   };
 
+  /**
+   * Convert a status action into a status. ex. "enable" -> "enabled"
+   *
+   * @param action The action
+   * @returns {string} The associated status
+   */
+  getStatusFromAction = action => {
+    switch (action) {
+      case "enable":
+        return "enabled";
+      case "disable":
+        return "disabled";
+      default:
+        return "unknown";
+    }
+  };
+
+  /**
+   * Send a request to the API to update the status
+   *
+   * @param action The action to perform ("enable" or "disable")
+   * @param time The amount of time to disable for. This setting is optional.
+   */
   setStatus = (action, time = null) => {
     if (this.state.processing) {
       // Wait for the first status change to go through
@@ -56,7 +79,9 @@ class EnableDisable extends Component {
     this.updateHandler = makeCancelable(api.setStatus(action, time));
     this.updateHandler.promise
       // Refresh once we get a good response
-      .then(() => this.props.refresh())
+      .then(() =>
+        this.props.refresh({ status: this.getStatusFromAction(action) })
+      )
       // Even if it failed, allow new status changes
       .finally(() => this.setState({ processing: false }));
   };

--- a/src/components/settings/PreferenceSettings.js
+++ b/src/components/settings/PreferenceSettings.js
@@ -108,7 +108,7 @@ class PreferenceSettings extends Component {
           showAlert: true,
           processing: false
         });
-        this.props.refresh();
+        this.props.refresh(this.state.settings);
       })
       .catch(ignoreCancel)
       .catch(error => {


### PR DESCRIPTION
If a user changes a setting, we send it to the API, and it says the change was successful, then we should not have to ask the API for the settings we just saved.

This is the case for status and preferences. When we save those settings, we can update our local data with the new setting instead of making a request for it. This changes a "PUT then GET" flow into a "PUT then update local" flow, which is one less server call.