### PR TITLE
Use the generated list of languages to avoid 404 errors

### DIFF
--- a/src/util/i18n.js
+++ b/src/util/i18n.js
@@ -13,6 +13,7 @@ import XHR from "i18next-xhr-backend";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { reactI18nextModule } from "react-i18next";
 import config from "../config";
+import languages from "../languages";
 
 export function setupI18n() {
   i18n
@@ -21,6 +22,7 @@ export function setupI18n() {
     .use(reactI18nextModule)
     .init({
       fallbackLng: "en",
+      whitelist: languages,
       ns: ["common"],
       defaultNS: "common",
       fallbackNS: [


### PR DESCRIPTION
If the user's language is detected to be a language not supported (for example, en-US), then previously it would try to load the translation files for that language, and fail with 404s. Now it will only use the language if it is supported (instead of en-US, it will use en because that is in the list).