### PR TITLE
Add Crowdin support

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,4 @@
+commit_message: "Signed-off-by: pralor <pralor-bot@pi-hole.net>"
+files:
+  - source: /public/i18n/en/*.json
+    translation: /public/i18n/%two_letters_code%/%original_file_name%

--- a/src/util/i18n.tsx
+++ b/src/util/i18n.tsx
@@ -38,6 +38,7 @@ export function setupI18n() {
       ],
       nsSeparator: false,
       keySeparator: false,
+      returnEmptyString: false,
       debug: config.developmentMode,
       interpolation: {
         // Handled by React


### PR DESCRIPTION
This adds the crowdin.yml config file, and supports their export format. Specifically, if a string is not translated, Crowdin exports it as an empty string. The `returnEmptyString` i18next config option handles this case.