### PR TITLE
Use orange for unknown DNSSEC status, and improve history fake data

### DIFF
--- a/scripts/make-fake-data.js
+++ b/scripts/make-fake-data.js
@@ -51,16 +51,16 @@ function history(length) {
       return {
         timestamp: startDate + i,
         type: isIPv4 ? 1 : 2,
-        status: Math.floor(Math.random() * 6),
+        status: Math.floor(Math.random() * 6.9),
         domain: faker.internet.domainName(),
         client: isHostname
           ? faker.internet.domainWord() + ".local"
           : isIPv4
             ? faker.internet.ip()
             : faker.internet.ipv6(),
-        dnssec: Math.floor(Math.random() * 5),
-        reply: Math.floor(Math.random() * 7),
-        response_time: Math.floor(Math.random() * 100)
+        dnssec: Math.floor(Math.random() * 5.9),
+        reply: Math.floor(Math.random() * 7.9),
+        response_time: Math.floor(Math.random() * 100.9)
       };
     })
   };

--- a/src/components/log/QueryLog.tsx
+++ b/src/components/log/QueryLog.tsx
@@ -301,11 +301,11 @@ const dnssec = (t: i18next.TranslationFunction) => [
 
 const dnssecColor = [
   "", // Unspecified, which means DNSSEC is off, so the initial color should be shown
-  "green",
-  "orange",
-  "red",
-  "red",
-  "orange"
+  "green", // Secure
+  "orange", // Insecure
+  "red", // Bogus
+  "red", // Abandoned
+  "orange" // Unknown
 ];
 
 /**

--- a/src/components/log/QueryLog.tsx
+++ b/src/components/log/QueryLog.tsx
@@ -305,7 +305,7 @@ const dnssecColor = [
   "orange",
   "red",
   "red",
-  "red"
+  "orange"
 ];
 
 /**


### PR DESCRIPTION
pi-hole/AdminLTE#909 changes DNSSEC Unknown to use orange instead of red.

The fake data would only show certain values if `Math.random` returned exactly 1. This was changed so the values would have a better chance of getting shown.