### PR TITLE
Use a custom docker build container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ version: 2
 jobs:
   build:
     docker:
-    - image: node:8
+    - image: pihole/web-build:latest
     steps:
     - checkout
     - restore_cache:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:8
+
+# Install ghr for GitHub Releases: https://github.com/tcnksm/ghr
+RUN wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz && \
+    tar -xzf ghr_*_linux_amd64.tar.gz && \
+    mv ghr_*_linux_amd64/ghr /usr/bin/ghr


### PR DESCRIPTION
The docker container is based off of `node:8`, and includes ghr for GitHub Releases.