### PR TITLE
Cache the web interface preferences in local storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10965,6 +10965,12 @@
         "pretty-format": "^23.6.0"
       }
     },
+    "jest-localstorage-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.0.tgz",
+      "integrity": "sha512-/mC1JxnMeuIlAaQBsDMilskC/x/BicsQ/BXQxEOw+5b1aGZkkOAqAF3nu8yq449CpzGtp5jJ5wCmDNxLgA2m6A==",
+      "dev": true
+    },
     "jest-matcher-utils": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "fetch-mock": "^7.3.0",
     "fs-extra": "^7.0.1",
     "jest-enzyme": "^7.0.1",
+    "jest-localstorage-mock": "^2.4.0",
     "multi-progress": "^2.0.0",
     "node-fetch": "^2.3.0",
     "node-sass-chokidar": "^1.3.4",

--- a/src/components/common/LanguageApplier.tsx
+++ b/src/components/common/LanguageApplier.tsx
@@ -1,0 +1,33 @@
+/* Pi-hole: A black hole for Internet advertisements
+ * (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+ * Network-wide ad blocking via your own hardware.
+ *
+ * Web Interface
+ * Apply the web interface language preference
+ *
+ * This file is copyright under the latest version of the EUPL.
+ * Please see LICENSE file for your rights under this license. */
+
+import React from "react";
+import { PreferencesContext } from "./context";
+import i18n from "i18next";
+
+const applyLanguage = (language: string) => {
+  if (i18n.language === language) {
+    // Don't change the language if it's already correctly set
+    return;
+  }
+
+  // noinspection JSIgnoredPromiseFromCall
+  i18n.changeLanguage(language);
+};
+
+export default () => (
+  <PreferencesContext.Consumer>
+    {({ settings }) => {
+      applyLanguage(settings.language);
+
+      return null;
+    }}
+  </PreferencesContext.Consumer>
+);

--- a/src/components/common/__tests__/context.test.tsx
+++ b/src/components/common/__tests__/context.test.tsx
@@ -1,0 +1,37 @@
+/* Pi-hole: A black hole for Internet advertisements
+ * (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+ * Network-wide ad blocking via your own hardware.
+ *
+ * Web Interface
+ * React context object tests
+ *
+ * This file is copyright under the latest version of the EUPL.
+ * Please see LICENSE file for your rights under this license. */
+
+import {
+  defaultPreferences,
+  loadInitialPreferences,
+  WEB_PREFERENCES_STORAGE_KEY
+} from "../context";
+
+it("loads the default preferences if none are cached", () => {
+  const preferences = loadInitialPreferences();
+
+  expect(preferences).toEqual(defaultPreferences);
+});
+
+it("loads the cached preferences when available", () => {
+  const expectedPreferences: ApiPreferences = {
+    language: "testLang",
+    layout: "boxed"
+  };
+
+  localStorage.setItem(
+    WEB_PREFERENCES_STORAGE_KEY,
+    JSON.stringify(expectedPreferences)
+  );
+
+  const actualPreferences = loadInitialPreferences();
+
+  expect(actualPreferences).toEqual(expectedPreferences);
+});

--- a/src/containers/Full.tsx
+++ b/src/containers/Full.tsx
@@ -23,11 +23,13 @@ import {
 } from "../routes";
 import { GlobalContextProvider } from "../components/common/context";
 import LayoutApplier from "../components/common/LayoutApplier";
+import LanguageApplier from "../components/common/LanguageApplier";
 
 export default (props: any) => (
   <div className="app">
     <GlobalContextProvider>
       <LayoutApplier />
+      <LanguageApplier />
       <Header />
       <div className="app-body">
         <Sidebar items={nav} {...props} />

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -13,6 +13,7 @@ import Adapter from "enzyme-adapter-react-16";
 import "jest-enzyme";
 import api from "./util/api";
 import fetchMock from "fetch-mock";
+import "jest-localstorage-mock";
 
 // Setup enzyme
 configure({ adapter: new Adapter() });
@@ -29,11 +30,14 @@ jest.mock("react-i18next", () => ({
   }
 }));
 
-// Temporary fix to reset logged in state for each test.
-// The permanent fix would be to not use a global variable, and instead give this information to components through
-// props. Redux would be good for this, if we want to add it to the project.
 beforeEach(() => {
+  // Temporary fix to reset logged in state for each test.
+  // The permanent fix would be to not use a global variable, and instead give this information to components through
+  // props. Redux would be good for this, if we want to add it to the project.
   api.loggedIn = false;
+
+  // Clear local storage mock
+  localStorage.clear();
 });
 
 // Clear fetch mocks after each test


### PR DESCRIPTION
As part of this change, updating the language with i18n was moved from `PreferenceSettings` into a new `LanguageApplier` component. Also, the alert message translation process in `PreferenceSettings` was
refactored. A new dev dependency, `jest-localstorage-mock`, was added to help test the preferences cache implementation.

See #155