### PR TITLE
Re-enable builds on Crowdin branches and fix DCO email issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,10 +89,7 @@ workflows:
   version: 2
   build:
     jobs:
-    - build:
-        filters:
-          branches:
-            ignore: /^l10n_.*$/
+    - build
     - deploy:
         filters:
           branches:

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,4 +1,4 @@
-commit_message: "Signed-off-by: pralor <pralor-bot@pi-hole.net>"
+commit_message: "Signed-off-by: pralor <36384445+pralor@users.noreply.github.com>"
 files:
   - source: /public/i18n/en/*.json
     translation: /public/i18n/%two_letters_code%/%original_file_name%


### PR DESCRIPTION
Crowdin synchronization has been limited to run once every three hours, so it is safe to re-enable CI builds. Pralor's GitHub email will be used for the DCO sign-off, as DCO bot doesn't like the pi-hole.net address.