### PR TITLE
Fix sending the authentication request twice on the login screen

### DIFF
--- a/src/views/Login.tsx
+++ b/src/views/Login.tsx
@@ -58,15 +58,6 @@ class Login extends Component<LoginProps, LoginState> {
   };
 
   /**
-   * If they clicked Enter, try to authenticate them.
-   */
-  handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      this.authenticate();
-    }
-  };
-
-  /**
    * Try to authenticate the user
    */
   authenticate = (e?: FormEvent) => {
@@ -179,7 +170,6 @@ class Login extends Component<LoginProps, LoginState> {
                   className="form-control"
                   value={this.state.password}
                   onChange={this.handlePasswordChange}
-                  onKeyDown={this.handleKeyDown}
                   placeholder={t("Password")}
                   autoFocus
                 />


### PR DESCRIPTION
If you click "Enter" on your keyboard, it will fire off a form submitted event which will run the authentication code. However, it will run the authentication again with a possibly password due to the key down event handler. This event handler is no longer needed because we have the form submit handler.