### PR TITLE
Require `:` between IP address and ports instead of `#`

### DIFF
--- a/src/util/__tests__/validate.test.tsx
+++ b/src/util/__tests__/validate.test.tsx
@@ -195,32 +195,36 @@ describe("Testing the validation functions", () => {
       expect(isValidIpv4OptionalPort("127.0.0.1")).toBe(true);
     });
 
-    it("passes 127.0.0.1#53", () => {
-      expect(isValidIpv4OptionalPort("127.0.0.1#53")).toBe(true);
+    it("passes 127.0.0.1:53", () => {
+      expect(isValidIpv4OptionalPort("127.0.0.1:53")).toBe(true);
     });
 
-    it("passes 8.8.8.8#5353", () => {
-      expect(isValidIpv4OptionalPort("8.8.8.8#5353")).toBe(true);
+    it("passes 8.8.8.8:5353", () => {
+      expect(isValidIpv4OptionalPort("8.8.8.8:5353")).toBe(true);
     });
 
-    it("fails 1111.1.1.1#53", () => {
-      expect(isValidIpv4OptionalPort("1111.1.1.1#53")).toBe(false);
+    it("fails 1111.1.1.1:53", () => {
+      expect(isValidIpv4OptionalPort("1111.1.1.1:53")).toBe(false);
     });
 
-    it("fails 8.8.8.8#", () => {
-      expect(isValidIpv4OptionalPort("8.8.8.8#")).toBe(false);
+    it("fails 8.8.8.8:", () => {
+      expect(isValidIpv4OptionalPort("8.8.8.8:")).toBe(false);
     });
 
-    it("fails 8.8.8.8##", () => {
-      expect(isValidIpv4OptionalPort("8.8.8.8##")).toBe(false);
+    it("fails 8.8.8.8::", () => {
+      expect(isValidIpv4OptionalPort("8.8.8.8::")).toBe(false);
     });
 
-    it("fails 8.8.8.8#53#", () => {
-      expect(isValidIpv4OptionalPort("8.8.8.8#53#")).toBe(false);
+    it("fails 8.8.8.8:53:", () => {
+      expect(isValidIpv4OptionalPort("8.8.8.8:53:")).toBe(false);
     });
 
-    it("fails 8.8.8.8#abc", () => {
-      expect(isValidIpv4OptionalPort("8.8.8.8#abc")).toBe(false);
+    it("fails 8.8.8.8:abc", () => {
+      expect(isValidIpv4OptionalPort("8.8.8.8:abc")).toBe(false);
+    });
+
+    it("fails 127.0.0.1#53", () => {
+      expect(isValidIpv4OptionalPort("127.0.0.1#53")).toBe(false);
     });
   });
 });

--- a/src/util/validate.tsx
+++ b/src/util/validate.tsx
@@ -73,15 +73,15 @@ export function isValidIpv4(address: string) {
 
 /**
  * Check if the string is a valid IPv4 address, and it can contain an optional
- * port after the address, separated with a #.
- * Example: 127.0.0.1#5353
+ * port after the address, separated with a :.
+ * Example: 127.0.0.1:5353
  *
  * @param address {string} the address to check
  * @returns {boolean} if the address is a valid IPv4 address and the port
  * (if it exists) is valid.
  */
 export function isValidIpv4OptionalPort(address: string) {
-  const split = address.split("#");
+  const split = address.split(":");
   const ipv4 = split[0];
 
   // Check the IPv4 address


### PR DESCRIPTION
The API requires `:` and is how ports are commonly associated with IP addresses. The only reason `#` was used was to more easily insert it into dnsmasq's config (when PHP and Bash were used for the API).

Fixes #174 (for the API side, see pi-hole/api#134)