### PR TITLE
Add DHCP rapid commit checkbox

### DIFF
--- a/scripts/make-fake-data.js
+++ b/scripts/make-fake-data.js
@@ -343,7 +343,8 @@ function getDHCPInfo() {
       .word()
       .toLowerCase()
       .split(" ", 2)[0],
-    ipv6_support: faker.random.boolean()
+    ipv6_support: faker.random.boolean(),
+    rapid_commit: faker.random.boolean()
   };
 }
 

--- a/src/components/settings/DHCPInfo.tsx
+++ b/src/components/settings/DHCPInfo.tsx
@@ -46,7 +46,8 @@ class DHCPInfo extends Component<WithNamespaces, DHCPInfoState> {
       router_ip: "",
       lease_time: 0,
       domain: "",
-      ipv6_support: false
+      ipv6_support: false,
+      rapid_commit: false
     }
   };
 
@@ -296,6 +297,17 @@ class DHCPInfo extends Component<WithNamespaces, DHCPInfoState> {
               onChange={this.onChange("ipv6_support", "checked")}
             />
             {t("IPv6 Support")}
+          </Label>
+        </FormGroup>
+        <FormGroup check>
+          <Label check>
+            <Input
+              type="checkbox"
+              disabled={!this.state.settings.active}
+              checked={this.state.settings.rapid_commit}
+              onChange={this.onChange("rapid_commit", "checked")}
+            />
+            {t("Rapid Commit")}
           </Label>
         </FormGroup>
         <Button

--- a/src/components/settings/DHCPInfo.tsx
+++ b/src/components/settings/DHCPInfo.tsx
@@ -47,7 +47,7 @@ class DHCPInfo extends Component<WithNamespaces, DHCPInfoState> {
       lease_time: 0,
       domain: "",
       ipv6_support: false,
-      rapid_commit: false
+      rapid_commit: true
     }
   };
 

--- a/src/components/settings/__tests__/DHCPInfo.test.tsx
+++ b/src/components/settings/__tests__/DHCPInfo.test.tsx
@@ -24,7 +24,8 @@ const fakeData = {
   router_ip: "192.168.1.1",
   lease_time: "24",
   domain: "lan",
-  ipv6_support: false
+  ipv6_support: false,
+  rapid_commit: false
 };
 
 it("retrieves settings correctly", async () => {

--- a/src/components/settings/__tests__/DHCPInfo.test.tsx
+++ b/src/components/settings/__tests__/DHCPInfo.test.tsx
@@ -25,7 +25,7 @@ const fakeData = {
   lease_time: "24",
   domain: "lan",
   ipv6_support: false,
-  rapid_commit: false
+  rapid_commit: true
 };
 
 it("retrieves settings correctly", async () => {

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -67,6 +67,7 @@ interface ApiDhcpSettings {
   lease_time: number;
   domain: string;
   ipv6_support: boolean;
+  rapid_commit: boolean;
 }
 
 interface ApiFtlDbResponse {


### PR DESCRIPTION
With this setting added, the DHCP page is on par with the PHP web interface's DHCP page, disregarding the DHCP leases section which is tracked by #177.

Requires pi-hole/api#139

![image](https://user-images.githubusercontent.com/4417660/57185434-3f658d80-6e80-11e9-9195-a9631bb057cc.png)
