### PR TITLE
Reset version to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hole_web",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "private": true,
   "homepage": ".",
   "devDependencies": {


### PR DESCRIPTION
This aligns the version with the API, so both components start at the same version. The reason it was 1.0.0 was due to basing the project on CoreUI, which used 1.0.0-alpha.6 as the version.