### PR TITLE
Add "Rapid Commit" to i18n strings

### DIFF
--- a/public/i18n/en/settings.json
+++ b/public/i18n/en/settings.json
@@ -26,5 +26,6 @@
     "Processing...": "Processing...",
     "Successfully saved settings": "Successfully saved settings",
     "Detected custom upstream server": "Detected custom upstream server",
-    "DNS Options": "DNS Options"
+    "DNS Options": "DNS Options",
+    "Rapid Commit": "Rapid Commit"
 }


### PR DESCRIPTION
This was missing from the i18n strings, which caused warnings when it was passed to the translate function.

This will be picked up by Crowdin once it's merged to dev.