### PR TITLE
Ignore TypeScript type errors while mocking in HTTP client test

### DIFF
--- a/src/util/__tests__/http.test.tsx
+++ b/src/util/__tests__/http.test.tsx
@@ -111,6 +111,7 @@ describe("HttpClient", () => {
   describe("HTTP functions", () => {
     it("should make a GET request and call handleResponse", async () => {
       fetchMock.get(testEndpointFull, { body: data });
+      // @ts-ignore
       httpClient.handleResponse = jest.fn(() => Promise.resolve(data));
 
       await expect(httpClient.get(testEndpoint)).resolves.toEqual(data);
@@ -122,6 +123,7 @@ describe("HttpClient", () => {
 
     it("should make a POST request and call handleResponse", async () => {
       fetchMock.post(testEndpointFull, { body: data });
+      // @ts-ignore
       httpClient.handleResponse = jest.fn(() => Promise.resolve(data));
 
       await expect(httpClient.post(testEndpoint, data)).resolves.toEqual(data);
@@ -134,6 +136,7 @@ describe("HttpClient", () => {
 
     it("should make a PUT request and call handleResponse", async () => {
       fetchMock.put(testEndpointFull, { body: data });
+      // @ts-ignore
       httpClient.handleResponse = jest.fn(() => Promise.resolve(data));
 
       await expect(httpClient.put(testEndpoint, data)).resolves.toEqual(data);
@@ -146,6 +149,7 @@ describe("HttpClient", () => {
 
     it("should make a DELETE request and call handleResponse", async () => {
       fetchMock.delete(testEndpointFull, { body: data });
+      // @ts-ignore
       httpClient.handleResponse = jest.fn(() => Promise.resolve(data));
 
       await expect(httpClient.delete(testEndpoint)).resolves.toEqual(data);


### PR DESCRIPTION
The error:
```
Error:(125, 7) TS2322: Type 'Mock<Promise<{ test: boolean; }>, []>' is not assignable to type '<T extends any>(response: Response) => Promise<T>'.
```