### PR TITLE
Support IPv6 upstream servers

### DIFF
--- a/src/components/settings/DnsList.tsx
+++ b/src/components/settings/DnsList.tsx
@@ -12,7 +12,10 @@ import React from "react";
 import { ListGroup } from "reactstrap";
 import DnsListItem from "./DnsListItem";
 import DnsListNewItem from "./DnsListNewItem";
-import { isValidIpv4OptionalPort } from "../../util/validate";
+import {
+  isValidIpv4OptionalPort,
+  isValidIpv6OptionalPort
+} from "../../util/validate";
 
 export interface DnsListProps {
   upstreams: Array<string>;
@@ -27,8 +30,15 @@ export interface DnsListProps {
  * @param upstreams the list of current upstreams
  * @returns {boolean} if the upstream address is unique and valid
  */
-export const isAddressValid = (address: string, upstreams: Array<string>) =>
-  !upstreams.includes(address) && isValidIpv4OptionalPort(address);
+export const isAddressValid = (
+  address: string,
+  upstreams: Array<string>
+): boolean => {
+  return (
+    !upstreams.includes(address) &&
+    (isValidIpv4OptionalPort(address) || isValidIpv6OptionalPort(address))
+  );
+};
 
 const DnsList = ({ upstreams, onAdd, onRemove }: DnsListProps) => (
   <ListGroup style={{ overflowY: "scroll", maxHeight: "350px" }}>

--- a/src/util/__tests__/validate.test.tsx
+++ b/src/util/__tests__/validate.test.tsx
@@ -13,6 +13,7 @@ import {
   isValidDomain,
   isValidIpv4,
   isValidIpv4OptionalPort,
+  isValidIpv6OptionalPort,
   isValidRegex
 } from "../validate";
 
@@ -225,6 +226,38 @@ describe("Testing the validation functions", () => {
 
     it("fails 127.0.0.1#53", () => {
       expect(isValidIpv4OptionalPort("127.0.0.1#53")).toBe(false);
+    });
+  });
+
+  describe("isValidIpv6OptionalPort", () => {
+    it("passes 1fff:0:a88:85a3::ac1f", () => {
+      expect(isValidIpv6OptionalPort("1fff:0:a88:85a3::ac1f")).toBe(true);
+    });
+
+    it("passes ::1", () => {
+      expect(isValidIpv6OptionalPort("::1")).toBe(true);
+    });
+
+    it("passes [::1]:5353", () => {
+      expect(isValidIpv6OptionalPort("[::1]:5353")).toBe(true);
+    });
+
+    it("passes [1fff:0:a88:85a3::ac1f]:8001", () => {
+      expect(isValidIpv6OptionalPort("[1fff:0:a88:85a3::ac1f]:8001")).toBe(
+        true
+      );
+    });
+
+    it("fails 192.168.1.1", () => {
+      expect(isValidIpv6OptionalPort("192.168.1.1")).toBe(false);
+    });
+
+    it("fails 192.168.1.1:53", () => {
+      expect(isValidIpv6OptionalPort("192.168.1.1:53")).toBe(false);
+    });
+
+    it("fails [::1]", () => {
+      expect(isValidIpv6OptionalPort("[::1]")).toBe(false);
     });
   });
 });

--- a/src/util/validate.tsx
+++ b/src/util/validate.tsx
@@ -8,7 +8,7 @@
  * This file is copyright under the latest version of the EUPL.
  * Please see LICENSE file for your rights under this license. */
 
-export function isValidHostname(hostname: string) {
+export function isValidHostname(hostname: string): boolean {
   // Must not exceed 253 characters total
   if (hostname.length > 253) return false;
   // Each segment must not exceed 63 characters
@@ -28,7 +28,7 @@ export function isValidHostname(hostname: string) {
   );
 }
 
-export function isValidDomain(domain: string) {
+export function isValidDomain(domain: string): boolean {
   // Make sure it's a fully qualified domain
   const split = domain.split(".");
   // Has to have at least 2 segments, of at least 1 character each
@@ -36,13 +36,13 @@ export function isValidDomain(domain: string) {
   return isValidHostname(domain);
 }
 
-export function isPositiveNumber(input: string) {
+export function isPositiveNumber(input: string): boolean {
   // Because parseInt has limitations, e.g. parseInt("15ex") is parsed to 15
   // Caution, does not work with negative numbers, replace with /^(\-|\+)?([0-9])$/ if needed
   return /^[0-9]+$/.test(input);
 }
 
-export function isValidRegex(regex: string) {
+export function isValidRegex(regex: string): boolean {
   try {
     new RegExp(regex);
   } catch (e) {
@@ -57,7 +57,7 @@ export function isValidRegex(regex: string) {
  * @param address {string} the address to check
  * @returns {boolean} if the address is a valid IPv4 address
  */
-export function isValidIpv4(address: string) {
+export function isValidIpv4(address: string): boolean {
   const segments = address.split(".");
 
   // Must have 4 segments
@@ -80,7 +80,7 @@ export function isValidIpv4(address: string) {
  * @returns {boolean} if the address is a valid IPv4 address and the port
  * (if it exists) is valid.
  */
-export function isValidIpv4OptionalPort(address: string) {
+export function isValidIpv4OptionalPort(address: string): boolean {
   const split = address.split(":");
   const ipv4 = split[0];
 

--- a/src/util/validate.tsx
+++ b/src/util/validate.tsx
@@ -94,3 +94,17 @@ export function isValidIpv4OptionalPort(address: string): boolean {
     split.length === 1 || (split.length === 2 && isPositiveNumber(split[1]))
   );
 }
+
+/**
+ * Check if the string is a valid IPv6 address, and it can contain an optional
+ * port. This function does not do a thorough check of the IPv6 address; the
+ * backend will check it in detail.
+ * Examples:
+ * 1fff:0:a88:85a3::ac1f
+ * [1fff:0:a88:85a3::ac1f]:8001
+ *
+ * @param address The IPv6 address
+ */
+export function isValidIpv6OptionalPort(address: string): boolean {
+  return /^(\[[a-fA-F0-9:]+]:\d+|[a-fA-F0-9:]+)$/.test(address);
+}


### PR DESCRIPTION
Fixes #203. This is both a bugfix and a feature, as the fix for the bug is to add the feature.

See pi-hole/api#160 for the backend changes (merge before this PR).

The IPv6 addresses are not extensively validated on the web interface, as their validation is very complex. The backend will handle that complexity and return an error if the address passes the frontend validation but is actually invalid (something like `abcdefabcdef`).