### PR TITLE
Improve CI test performance by limiting the number of workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2
 .test: &test
   run:
     name: "Test"
-    command: npm run coverage
+    command: npm run coverage -- --maxWorkers=4
 
 .store_version: &store_version
   run:


### PR DESCRIPTION
Around the time of merging #264 and afterwards, the CI would sometimes freeze while running the tests. When SSHing into the box with the tests running, several node processes were running. Jest also recommends to limit the number of workers if CI performance is lacking:

https://jestjs.io/docs/en/troubleshooting.html#tests-are-extremely-slow-on-docker-and-or-continuous-integration-ci-server

This change is applied in this PR.

Normally the tests take about 30 seconds in CI. In the build for this PR, they took just **9** seconds!