### PR TITLE
Use the filtered IPv6 OpenDNS servers

### DIFF
--- a/src/components/settings/preconfiguredUpstreams.tsx
+++ b/src/components/settings/preconfiguredUpstreams.tsx
@@ -25,8 +25,8 @@ export const preconfiguredUpstreams: Array<PreconfiguredUpstream> = [
     name: "OpenDNS (ECS)",
     primaryIpv4: "208.67.222.222",
     secondaryIpv4: "208.67.220.220",
-    primaryIpv6: "2620:0:ccc::2",
-    secondaryIpv6: "2620:0:ccd::2"
+    primaryIpv6: "2620:119:35::35",
+    secondaryIpv6: "2620:119:53::53"
   },
   {
     name: "Google (ECS)",


### PR DESCRIPTION
The ones we were using previously were not filtered.
See https://support.opendns.com/hc/en-us/articles/227986667-Does-OpenDNS-Support-IPv6-

See also pi-hole/pi-hole#2796