### PR TITLE
Add IPv6 support for network table

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -73,10 +73,17 @@ if(isset($_GET["network"]) && $auth)
 	while($results !== false && $res = $results->fetchArray(SQLITE3_ASSOC))
 	{
 		$id = $res["id"];
+		// Backup IP column of this request in case we want to reuse it further down
+		$resip = $res["ip"];
+		// Empty array for holding the IP addresses
 		$res["ip"] = array();
+		// Get IP addresses for this device
 		$ips = $db->query("SELECT ip FROM network_addresses WHERE network_id = $id ORDER BY lastSeen DESC");
 		while($ips !== false && $ip = $ips->fetchArray(SQLITE3_ASSOC))
 			array_push($res["ip"],$ip["ip"]);
+		// If the network_addresses table does not contain any IPs for this client, we use the IP stored in the network table
+		if(count($res) < 1)
+			array_push($res["ip"],$resip);
 		array_push($network, $res);
 	}
 

--- a/api_db.php
+++ b/api_db.php
@@ -74,7 +74,7 @@ if(isset($_GET["network"]) && $auth)
 	{
 		$id = $res["id"];
 		$ipaddr = array();
-		$ips = $db->query("SELECT ip FROM network_addresses WHERE id = $id");
+		$ips = $db->query("SELECT ip FROM network_addresses WHERE network_id = $id");
 		while($ips !== false && $ip = $ips->fetchArray(SQLITE3_ASSOC))
 			array_push($ipaddr,$ip["ip"]);
 		if(count($ipaddr) > 0)

--- a/api_db.php
+++ b/api_db.php
@@ -73,12 +73,10 @@ if(isset($_GET["network"]) && $auth)
 	while($results !== false && $res = $results->fetchArray(SQLITE3_ASSOC))
 	{
 		$id = $res["id"];
-		$ipaddr = array();
+		$res["ip"] = array();
 		$ips = $db->query("SELECT ip FROM network_addresses WHERE network_id = $id ORDER BY lastSeen DESC");
 		while($ips !== false && $ip = $ips->fetchArray(SQLITE3_ASSOC))
-			array_push($ipaddr,$ip["ip"]);
-		if(count($ipaddr) > 0)
-			$res["ip"] = $ipaddr;
+			array_push($res["ip"],$ip["ip"]);
 		array_push($network, $res);
 	}
 

--- a/api_db.php
+++ b/api_db.php
@@ -82,7 +82,7 @@ if(isset($_GET["network"]) && $auth)
 		while($ips !== false && $ip = $ips->fetchArray(SQLITE3_ASSOC))
 			array_push($res["ip"],$ip["ip"]);
 		// If the network_addresses table does not contain any IPs for this client, we use the IP stored in the network table
-		if(count($res) < 1)
+		if(count($res["ip"]) < 1)
 			array_push($res["ip"],$resip);
 		array_push($network, $res);
 	}

--- a/api_db.php
+++ b/api_db.php
@@ -73,17 +73,12 @@ if(isset($_GET["network"]) && $auth)
 	while($results !== false && $res = $results->fetchArray(SQLITE3_ASSOC))
 	{
 		$id = $res["id"];
-		// Backup IP column of this request in case we want to reuse it further down
-		$resip = $res["ip"];
 		// Empty array for holding the IP addresses
 		$res["ip"] = array();
 		// Get IP addresses for this device
-		$ips = $db->query("SELECT ip FROM network_addresses WHERE network_id = $id ORDER BY lastSeen DESC");
-		while($ips !== false && $ip = $ips->fetchArray(SQLITE3_ASSOC))
+		$network_addresses = $db->query("SELECT ip FROM network_addresses WHERE network_id = $id ORDER BY lastSeen DESC");
+		while($network_addresses !== false && $ip = $network_addresses->fetchArray(SQLITE3_ASSOC))
 			array_push($res["ip"],$ip["ip"]);
-		// If the network_addresses table does not contain any IPs for this client, we use the IP stored in the network table
-		if(count($res["ip"]) < 1)
-			array_push($res["ip"],$resip);
 		array_push($network, $res);
 	}
 

--- a/api_db.php
+++ b/api_db.php
@@ -71,7 +71,16 @@ if(isset($_GET["network"]) && $auth)
 	$results = $db->query('SELECT * FROM network');
 
 	while($results !== false && $res = $results->fetchArray(SQLITE3_ASSOC))
+	{
+		$id = $res["id"];
+		$ipaddr = array();
+		$ips = $db->query("SELECT ip FROM network_addresses WHERE id = $id");
+		while($ips !== false && $ip = $ips->fetchArray(SQLITE3_ASSOC))
+			array_push($ipaddr,$ip["ip"]);
+		if(count($ipaddr) > 0)
+			$res["ip"] = $ipaddr;
 		array_push($network, $res);
+	}
 
 	$data = array_merge($data, array('network' => $network));
 }

--- a/api_db.php
+++ b/api_db.php
@@ -74,7 +74,7 @@ if(isset($_GET["network"]) && $auth)
 	{
 		$id = $res["id"];
 		$ipaddr = array();
-		$ips = $db->query("SELECT ip FROM network_addresses WHERE network_id = $id");
+		$ips = $db->query("SELECT ip FROM network_addresses WHERE network_id = $id ORDER BY lastSeen DESC");
 		while($ips !== false && $ip = $ips->fetchArray(SQLITE3_ASSOC))
 			array_push($ipaddr,$ip["ip"]);
 		if(count($ipaddr) > 0)

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -8,6 +8,9 @@ var tableApi;
 
 var APIstring = "api_db.php?network";
 
+// How many IPs do we show at most per device?
+var MAXIPDISPLAY = 3;
+
 function refreshData() {
     tableApi.ajax.url(APIstring).load();
 }
@@ -113,12 +116,15 @@ $(document).ready(function() {
              // Set number of queries to localized string (add thousand separators)
              $("td:eq(6)", row).html(data["numQueries"].toLocaleString());
 
-            // Client -> jump to Query Log on click
-            $("td:eq(0)", row).click( function () { openInNewTab("/admin/queries.php?client="+this.innerHTML); } );
-            $("td:eq(0)", row).css("cursor","pointer");
-            $("td:eq(0)", row).hover(
-              function () { this.title="Click to show recent queries made by "+this.innerHTML; this.style.color="#72afd2"; },
-              function () { this.style.color=""; } );
+            var ips = data["ip"];
+            var shortips = ips;
+            if(ips.length > MAXIPDISPLAY)
+            {
+                shortips = ips.slice(0,MAXIPDISPLAY-1);
+                shortips.push("...");
+            }
+            $("td:eq(0)", row).html(shortips.join("<br>"));
+            $("td:eq(0)", row).hover(function () { this.title=ips.join("\n");});
 
             // MAC + Vendor field if available
             if(data["macVendor"] && data["macVendor"].length > 0)

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -142,7 +142,7 @@ $(document).ready(function() {
         "processing": true,
         "order" : [[5, "desc"]],
         "columns": [
-            {data: "ip", "type": "ip-address", "width" : "10%", "render": $.fn.dataTable.render.text() },
+            {data: "ip", "width" : "10%", "render": $.fn.dataTable.render.text(), "orderable": false },
             {data: "hwaddr", "width" : "10%", "render": $.fn.dataTable.render.text() },
             {data: "interface", "width" : "4%", "render": $.fn.dataTable.render.text() },
             {data: "name", "width" : "15%", "render": $.fn.dataTable.render.text() },


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

Add frontend support for changes in https://github.com/pi-hole/FTL/pull/591
The FTL PR has to be merged first, the AdminLTE branch can be merged at any later time (the current AdminLTE still works even with updated FTL)

**How does this PR accomplish the above?:**

Include all known IP addresses for a given device in the API response + display them correctly. If more than three addresses are known per device, the list is abbreviated to avoid explosions of the table in environments with frequently changing IPv6 prefixes. We still list all IP addresses when hovering over the abbreviated text.

![Screenshot from 2019-06-14 19-20-58](https://user-images.githubusercontent.com/16748619/59527198-3504cd80-8edb-11e9-9f25-5430709366a8.png)

Example for an on-hover tool tip showing all known addresses for this device:
![Screenshot from 2019-06-14 19-26-10](https://user-images.githubusercontent.com/16748619/59527240-4d74e800-8edb-11e9-88b3-fb1765a00b4e.png)

