### PR TITLE
Allow preferences to be modified and persisted in fakeAPI mode

### DIFF
--- a/src/components/common/context/PreferencesContext.tsx
+++ b/src/components/common/context/PreferencesContext.tsx
@@ -11,6 +11,7 @@
 import React, { ReactNode } from "react";
 import { WithAPIData } from "../WithAPIData";
 import api from "../../../util/api";
+import config from "../../../config";
 
 /**
  * The data shared by the preferences context
@@ -56,18 +57,18 @@ export const loadInitialPreferences = (): ApiPreferences => {
 };
 
 /**
- * The context which will be used initially, until the API responds with the
- * real preferences. These preferences are loaded from cache if available.
+ * Load the context which will be used initially, until the API responds with
+ * the real preferences. These preferences are loaded from cache if available.
  */
-const initialContext: PreferencesContextType = {
+export const loadInitialContext = (): PreferencesContextType => ({
   settings: loadInitialPreferences(),
   refresh: () => {}
-};
+});
 
 /**
  * The React context which provides the preferences to consumers
  */
-export const PreferencesContext = React.createContext(initialContext);
+export const PreferencesContext = React.createContext(loadInitialContext());
 
 /**
  * Provide the web interface preferences via React context.
@@ -81,9 +82,13 @@ export const PreferencesProvider = ({
   children: ReactNode;
 }) => (
   <WithAPIData
-    apiCall={api.getPreferences}
+    apiCall={
+      config.fakeAPI
+        ? () => Promise.resolve(loadInitialPreferences())
+        : api.getPreferences
+    }
     renderInitial={() => (
-      <PreferencesContext.Provider value={initialContext} {...props}>
+      <PreferencesContext.Provider value={loadInitialContext()} {...props}>
         {children}
       </PreferencesContext.Provider>
     )}

--- a/src/components/common/context/__tests__/PreferencesContext.test.tsx
+++ b/src/components/common/context/__tests__/PreferencesContext.test.tsx
@@ -8,16 +8,20 @@
  * This file is copyright under the latest version of the EUPL.
  * Please see LICENSE file for your rights under this license. */
 
-import React from "react";
+import React, { ProviderProps } from "react";
 import {
   defaultPreferences,
   loadInitialPreferences,
-  WEB_PREFERENCES_STORAGE_KEY,
+  PreferencesContextType,
   PreferencesProvider,
-  PreferencesContextType
+  WEB_PREFERENCES_STORAGE_KEY
 } from "../PreferencesContext";
 import { shallow } from "enzyme";
 import { WithAPIData } from "../../WithAPIData";
+import config from "../../../../config";
+import api from "../../../../util/api";
+
+jest.mock("../../../../util/api");
 
 it("loads the default preferences if none are cached", () => {
   const preferences = loadInitialPreferences();
@@ -57,6 +61,27 @@ it("provides the initial settings while loading", () => {
     .renderProp("renderInitial")();
 
   expect(wrapper.props().value.settings).toEqual(expectedPreferences);
+});
+
+it("should use the cached settings instead of the API when in fakeAPI mode", async () => {
+  const expectedPreferences: ApiPreferences = {
+    language: "testLang",
+    layout: "boxed"
+  };
+
+  config.fakeAPI = true;
+  localStorage.setItem(
+    WEB_PREFERENCES_STORAGE_KEY,
+    JSON.stringify(expectedPreferences)
+  );
+
+  const wrapper = shallow(
+    <PreferencesProvider>{null}</PreferencesProvider>
+  ).dive();
+
+  const props = wrapper.props() as ProviderProps<PreferencesContextType>;
+  expect(props.value.settings).toEqual(expectedPreferences);
+  expect(api.getPreferences).not.toHaveBeenCalled();
 });
 
 it("caches the settings after loading and provides the new settings", () => {

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -15,6 +15,7 @@ import api from "./util/api";
 import fetchMock from "fetch-mock";
 import "jest-localstorage-mock";
 import i18next from "i18next";
+import config from "./config";
 
 // Setup enzyme
 configure({ adapter: new Adapter() });
@@ -35,10 +36,11 @@ jest.mock("react-i18next", () => ({
 }));
 
 beforeEach(() => {
-  // Temporary fix to reset logged in state for each test.
+  // Temporary fix to reset global state for each test.
   // The permanent fix would be to not use a global variable, and instead give this information to components through
   // props. Redux would be good for this, if we want to add it to the project.
   api.loggedIn = false;
+  config.fakeAPI = false;
 
   // Clear local storage mock
   localStorage.clear();


### PR DESCRIPTION
Fixes #301

Removed the preference loading code in `PreferenceSettings`, as it already gets the preference data from the `PreferencesContext` provider.