### PR TITLE
Fix auto-login always refreshing in fake API mode by migrating to a Saga

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,23 +28,6 @@ import { Provider } from "react-redux";
 // will set loggedIn to false if necessary
 api.loggedIn = document.cookie.includes("user_id=");
 
-// Verify the loggedIn status with the server. If we thought we were logged out
-// but the API does not require authentication, refresh the page so we start
-// in logged-in mode.
-//
-// An alternative to refreshing the page is to provide the loggedIn status via
-// React context or some other mechanism. With the current infrastructure of
-// the web interface, it is very messy to use React context for this as
-// `api.loggedIn` is used in a few hard to reach spots. We should look into
-// Redux for a cleaner approach.
-api.checkAuthStatus().then(() => {
-  if (!api.loggedIn) {
-    // No authentication is required for this API. Refresh the page so we start
-    // in logged-in mode
-    window.location.reload();
-  }
-});
-
 setupI18n();
 store.runSaga();
 

--- a/src/redux/sagas/__tests__/autoLogin.test.tsx
+++ b/src/redux/sagas/__tests__/autoLogin.test.tsx
@@ -1,0 +1,87 @@
+/* Pi-hole: A black hole for Internet advertisements
+ * (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+ * Network-wide ad blocking via your own hardware.
+ *
+ * Web Interface
+ * Auto-login saga tests
+ *
+ * This file is copyright under the latest version of the EUPL.
+ * Please see LICENSE file for your rights under this license. */
+
+import { call } from "redux-saga/effects";
+import { expectSaga, testSaga } from "redux-saga-test-plan";
+import { autoLogin } from "../autoLogin";
+import api from "../../../util/api";
+import { throwError } from "redux-saga-test-plan/providers";
+import config from "../../../config";
+
+const unauthorizedError = {
+  key: "unauthorized",
+  message: "Unauthorized",
+  data: null
+} as any;
+
+const unknownError = {
+  key: "test_error",
+  message: "Not the unauthorized error",
+  data: null
+} as any;
+
+describe("autoLogin", () => {
+  it("should not reload when not authorized", () => {
+    return expectSaga(autoLogin)
+      .provide([[call(api.checkAuthStatus), throwError(unauthorizedError)]])
+      .not.call([window.location, "reload"])
+      .run();
+  });
+
+  it("should reload when authorized but not logged in", () => {
+    api.loggedIn = false;
+
+    return expectSaga(autoLogin)
+      .provide([
+        [call(api.checkAuthStatus), { status: "success" }],
+        // @ts-ignore
+        // It tries to use the deprecated reload which takes a boolean argument
+        [call([window.location, "reload"]), undefined]
+      ])
+      .call([window.location, "reload"])
+      .run();
+  });
+
+  it("should set the cookie manually when in fake API mode", async () => {
+    api.loggedIn = false;
+    config.fakeAPI = true;
+    document.cookie = "";
+
+    await expectSaga(autoLogin)
+      .provide([
+        [call(api.checkAuthStatus), { status: "success" }],
+        // @ts-ignore
+        // It tries to use the deprecated reload which takes a boolean argument
+        [call([window.location, "reload"]), undefined]
+      ])
+      .run();
+
+    expect(document.cookie).toContain("user_id=");
+  });
+
+  it("should throw unexpected exceptions from the API", () => {
+    expect(() =>
+      testSaga(autoLogin)
+        .next()
+        .call(api.checkAuthStatus)
+        .throw(unknownError)
+    ).toThrow(unknownError);
+
+    // Below code is commented out until the testing library supports catching
+    // errors thrown in catch blocks. See
+    // https://github.com/jfairbank/redux-saga-test-plan/issues/296
+    // Once this is fixed, the above code will be replaced with the below code.
+    //
+    // return expectSaga(autoLogin)
+    //   .provide([[call(api.checkAuthStatus), throwError(unknownError)]])
+    //   .throws(unknownError)
+    //   .run();
+  });
+});

--- a/src/redux/sagas/autoLogin.tsx
+++ b/src/redux/sagas/autoLogin.tsx
@@ -1,0 +1,55 @@
+/* Pi-hole: A black hole for Internet advertisements
+ * (c) 2019 Pi-hole, LLC (https://pi-hole.net)
+ * Network-wide ad blocking via your own hardware.
+ *
+ * Web Interface
+ * Auto-login Saga
+ *
+ * This file is copyright under the latest version of the EUPL.
+ * Please see LICENSE file for your rights under this license. */
+
+import { call } from "redux-saga/effects";
+import api from "../../util/api";
+import config from "../../config";
+
+/**
+ * A saga to automatically log in.
+ *
+ * Steps:
+ * 1. Verify the logged in status with the server.
+ * 2. If we thought we were logged out but the API does not require
+ *    authentication, refresh the page so we start in logged-in mode.
+ *
+ * An alternative to refreshing the page is to provide the logged in state via
+ * Redux. Until then, we have to refresh the page to update everything that uses
+ * it.
+ */
+export function* autoLogin() {
+  try {
+    // Check if we are logged in
+    yield call(api.checkAuthStatus);
+  } catch (e) {
+    if (e.key === "unauthorized") {
+      // The API requires authentication and we are not already logged in
+      return;
+    }
+
+    // An unexpected error occurred while checking our logged in state
+    throw e;
+  }
+
+  if (!api.loggedIn) {
+    if (config.fakeAPI) {
+      // When using the fake API, set the cookie ourselves
+      document.cookie = "user_id=;";
+    }
+
+    // No authentication is required for this API (we got a successful response
+    // and have a valid cookie), but we initialized assuming we are not logged
+    // in. Refresh the page so we start in logged-in mode.
+
+    // @ts-ignore
+    // It tries to use the deprecated reload which takes a boolean argument
+    yield call([window.location, "reload"]);
+  }
+}

--- a/src/redux/sagas/index.tsx
+++ b/src/redux/sagas/index.tsx
@@ -10,10 +10,12 @@
 
 import { spawn } from "redux-saga/effects";
 import { watchPreferences } from "./preferences";
+import { autoLogin } from "./autoLogin";
 
 /**
  * The root saga which sets up all other sagas
  */
 export function* rootSaga() {
   yield spawn(watchPreferences);
+  yield spawn(autoLogin);
 }


### PR DESCRIPTION
The original auto-login code was written before Redux and was planned to be migrated. This migrates the code into a Redux Saga and adds a test suite. In the process, #365 is fixed.

In the future, the logged in state will be distributed via Redux, but until then we still have to refresh the page. The saga continues the refreshing behavior, but it will be easy to change this to emit Redux store updates once the logged in state moves to Redux.

One test is implemented sub-optimally due to a bug in the saga test library:
https://github.com/jfairbank/redux-saga-test-plan/issues/296
I have proposed a fix here:
https://github.com/jfairbank/redux-saga-test-plan/pull/298

Fixes #365