### PR TITLE
Add ability to manage custom DNS records

### DIFF
--- a/custom_dns.php
+++ b/custom_dns.php
@@ -1,0 +1,85 @@
+<?php /*
+*    Pi-hole: A black hole for Internet advertisements
+*    (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+*    Network-wide ad blocking via your own hardware.
+*
+*    This file is copyright under the latest version of the EUPL.
+*    Please see LICENSE file for your rights under this license. */
+    require "scripts/pi-hole/php/header.php";
+
+?>
+
+<!-- Title -->
+<div class="page-header">
+    <h1>Custom DNS</h1>
+</div>
+
+<!-- Domain Input -->
+<form class="form-inline" >
+    <div class="form-group">
+        <input id="domain" type="text" class="form-control" placeholder="Add a domain (example.com or sub.example.com)">
+    </div>
+    <div class="form-group">
+        <input id="ip" type="text" class="form-control" placeholder="Define an associate IP">
+    </div>
+    <div class="form-group">
+        <button id="btnAdd" class="btn btn-default" type="button">Add</button>
+    </div>
+</form>
+
+<!-- Alerts -->
+<div id="alInfo" class="alert alert-info alert-dismissible fade in" role="alert" hidden="true">
+    <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    Adding the custom DNS entry...
+</div>
+<div id="alSuccess" class="alert alert-success alert-dismissible fade in" role="alert" hidden="true">
+    <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    Success! The list will refresh.
+</div>
+<div id="alFailure" class="alert alert-danger alert-dismissible fade in" role="alert" hidden="true">
+    <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    Failure! Something went wrong, see output below:<br/><br/><pre><span id="err"></span></pre>
+</div>
+<div id="alWarning" class="alert alert-warning alert-dismissible fade in" role="alert" hidden="true">
+    <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    At least one domain was already present, see output below:<br/><br/><pre><span id="warn"></span></pre>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        <div class="box" id="recent-queries">
+            <div class="box-header with-border">
+                <h3 class="box-title">
+                    List of custom DNS domains
+                </h3>
+            </div>
+            <!-- /.box-header -->
+            <div class="box-body">
+                <table id="customDNSTable" class="display table table-striped table-bordered" cellspacing="0" width="100%">
+                    <thead>
+                    <tr>
+                        <th>Domain</th>
+                        <th>IP</th>
+                        <th>Action</th>
+                    </tr>
+                    </thead>
+                    <tfoot>
+                    <tr>
+                        <th>Domain</th>
+                        <th>IP</th>
+                        <th>Action</th>
+                    </tr>
+                    </tfoot>
+                </table>
+                <button type="button" id="resetButton" hidden="true">Clear Filters</button>
+            </div>
+            <!-- /.box-body -->
+        </div>
+        <!-- /.box -->
+    </div>
+</div>
+
+<script src="scripts/pi-hole/js/customdns.js"></script>
+
+<?php
+require "scripts/pi-hole/php/footer.php";
+?>

--- a/custom_dns.php
+++ b/custom_dns.php
@@ -30,7 +30,7 @@
 <!-- Alerts -->
 <div id="alInfo" class="alert alert-info alert-dismissible fade in" role="alert" hidden="true">
     <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-    Adding the custom DNS entry...
+    Updating the custom DNS entries...
 </div>
 <div id="alSuccess" class="alert alert-success alert-dismissible fade in" role="alert" hidden="true">
     <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -62,13 +62,6 @@
                         <th>Action</th>
                     </tr>
                     </thead>
-                    <tfoot>
-                    <tr>
-                        <th>Domain</th>
-                        <th>IP</th>
-                        <th>Action</th>
-                    </tr>
-                    </tfoot>
                 </table>
                 <button type="button" id="resetButton" hidden="true">Clear Filters</button>
             </div>

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -1,5 +1,26 @@
 var table;
 
+function showAlert(type, message)
+{
+    var alertElement = null;
+    var messageElement = null;
+
+    switch (type)
+    {
+        case 'info':    alertElement = $('#alInfo');                                    break;
+        case 'success': alertElement = $('#alSuccess');                                 break;
+        case 'warning': alertElement = $('#alWarning'); messageElement = $('#warn');    break;
+        case 'error':   alertElement = $('#alFailure'); messageElement = $('#err');     break;
+        default: return;
+    }
+
+    if (messageElement != null)
+        messageElement.html(message);
+
+    alertElement.fadeIn(200);
+    alertElement.delay(8000).fadeOut(2000);
+}
+
 $(document).ready(function() {
 
     $('#btnAdd').on('click', addCustomDNS);
@@ -25,19 +46,22 @@ function addCustomDNS()
     var ip = $('#ip').val();
     var domain = $('#domain').val();
 
+    showAlert('info');
     $.ajax({
         url: "scripts/pi-hole/php/customdns.php",
         method: "post",
         dataType: 'json',
         data: {"action":"add", "ip" : ip, "domain": domain},
         success: function(response) {
-            if (response.success)
+            if (response.success) {
+                showAlert('success');
                 table.ajax.reload();
+            }
             else
-                alert(response.message);
+                showAlert('error', response.message);
         },
         error: function(jqXHR, exception) {
-            alert("Error while adding this custom DNS entry")
+            showAlert('error', "Error while adding this custom DNS entry");
         }
     });
 }
@@ -47,19 +71,22 @@ function deleteCustomDNS()
     var ip = $(this).attr("data-ip");
     var domain = $(this).attr("data-domain");
 
+    showAlert('info');
     $.ajax({
         url: "scripts/pi-hole/php/customdns.php",
         method: "post",
         dataType: 'json',
         data: {"action":"delete", "domain": domain, "ip": ip},
         success: function(response) {
-            if (response.success)
+            if (response.success) {
+                showAlert('success');
                 table.ajax.reload();
+            }
             else
-                alert(response.message);
+                showAlert('error', response.message);
         },
         error: function(jqXHR, exception) {
-            alert("Error while deleting this custom DNS entry");
+            showAlert('error', "Error while deleting this custom DNS entry");
             console.log(exception);
         }
     });

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
         "columnDefs": [ {
             "targets": 2,
             "render": function ( data, type, row ) {
-                return "<button id=\"" + row[0] + "\" class=\"btn btn-danger btn-xs deleteCustomDNS\" type=\"button\">" +
+                return "<button class=\"btn btn-danger btn-xs deleteCustomDNS\" type=\"button\" data-domain='"+row[0]+"' data-ip='"+row[1]+"'>" +
                            "<span class=\"glyphicon glyphicon-trash\"></span>" +
                        "</button>";
             }
@@ -44,11 +44,14 @@ function addCustomDNS()
 
 function deleteCustomDNS()
 {
+    var ip = $(this).attr("data-ip");
+    var domain = $(this).attr("data-domain");
+
     $.ajax({
         url: "scripts/pi-hole/php/customdns.php",
         method: "post",
         dataType: 'json',
-        data: {"action":"delete", "domain": $(this).prop('id')},
+        data: {"action":"delete", "domain": domain, "ip": ip},
         success: function(response) {
             if (response.success)
                 table.ajax.reload();

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -44,8 +44,6 @@ function addCustomDNS()
 
 function deleteCustomDNS()
 {
-    var thisCell = $(this);
-
     $.ajax({
         url: "scripts/pi-hole/php/customdns.php",
         method: "post",

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -1,0 +1,65 @@
+var table;
+
+$(document).ready(function() {
+
+    $('#btnAdd').on('click', addCustomDNS);
+
+    table = $("#customDNSTable").DataTable( {
+        "ajax": "scripts/pi-hole/php/customdns.php?action=get",
+        "columnDefs": [ {
+            "targets": 2,
+            "render": function ( data, type, row ) {
+                return "<button id=\"" + row[0] + "\" class=\"btn btn-danger btn-xs deleteCustomDNS\" type=\"button\">" +
+                           "<span class=\"glyphicon glyphicon-trash\"></span>" +
+                       "</button>";
+            }
+        } ],
+        "drawCallback": function( settings ) {
+            $('.deleteCustomDNS').on('click', deleteCustomDNS);
+        }
+    });
+});
+
+function addCustomDNS()
+{
+    var ip = $('#ip').val();
+    var domain = $('#domain').val();
+
+    $.ajax({
+        url: "scripts/pi-hole/php/customdns.php",
+        method: "post",
+        dataType: 'json',
+        data: {"action":"add", "ip" : ip, "domain": domain},
+        success: function(response) {
+            if (response.success)
+                table.ajax.reload();
+            else
+                alert(response.message);
+        },
+        error: function(jqXHR, exception) {
+            alert("Error while adding this custom DNS entry")
+        }
+    });
+}
+
+function deleteCustomDNS()
+{
+    var thisCell = $(this);
+
+    $.ajax({
+        url: "scripts/pi-hole/php/customdns.php",
+        method: "post",
+        dataType: 'json',
+        data: {"action":"delete", "domain": $(this).prop('id')},
+        success: function(response) {
+            if (response.success)
+                table.ajax.reload();
+            else
+                alert(response.message);
+        },
+        error: function(jqXHR, exception) {
+            alert("Error while deleting this custom DNS entry");
+            console.log(exception);
+        }
+    });
+}

--- a/scripts/pi-hole/php/customdns.php
+++ b/scripts/pi-hole/php/customdns.php
@@ -82,7 +82,6 @@
                         return errorJsonResponse("This domain already has a custom DNS entry for an IPv" . $ipType);
 
             exec("sudo pihole -a addcustomdns ".$ip." ".$domain);
-            exec("sudo pihole -a restartdns");
 
             return successJsonResponse();
         }
@@ -119,7 +118,6 @@
                 return errorJsonResponse("This domain/ip association does not exist");
 
             exec("sudo pihole -a removecustomdns ".$ip." ".$domain);
-            exec("sudo pihole -a restartdns");
 
             return successJsonResponse();
         }

--- a/scripts/pi-hole/php/customdns.php
+++ b/scripts/pi-hole/php/customdns.php
@@ -1,0 +1,123 @@
+<?php
+
+    require_once "func.php";
+
+    $customDNSFile = "/etc/pihole/custom.list";
+
+    switch ($_REQUEST['action'])
+    {
+        case 'get':     echo json_encode(echoCustomDNSEntries());    break;
+        case 'add':     echo json_encode(addCustomDNSEntry());      break;
+        case 'delete':  echo json_encode(deleteCustomDNSEntry());   break;
+        default:
+            die("Wrong action");
+    }
+
+    function echoCustomDNSEntries()
+    {
+        $entries = getCustomDNSEntries();
+
+        $data = [];
+
+        foreach ($entries as $domain => $ip)
+            $data[] = [ $domain, $ip ];
+
+        return [ "data" => $data ];
+    }
+
+    function getCustomDNSEntries()
+    {
+        global $customDNSFile;
+
+        $entries = [];
+
+        $handle = fopen($customDNSFile, "r");
+        if ($handle)
+        {
+            while (($line = fgets($handle)) !== false) {
+                $line = str_replace("\r","", $line);
+                $line = str_replace("\n","", $line);
+                $explodedLine = explode (" ", $line);
+
+                if (count($explodedLine) != 2)
+                    continue;
+
+                $entries[$explodedLine[1]] = $explodedLine[0];
+            }
+
+            fclose($handle);
+        }
+
+        return $entries;
+    }
+
+    function addCustomDNSEntry()
+    {
+        try
+        {
+            $ip = !empty($_REQUEST['ip']) ? $_REQUEST['ip']: "";
+            $domain = !empty($_REQUEST['domain']) ? $_REQUEST['domain']: "";
+
+            if (empty($ip))
+                return errorJsonResponse("IP must be set");
+
+            if (!filter_var($ip, FILTER_VALIDATE_IP))
+                return errorJsonResponse("IP must be valid");
+
+            if (empty($domain))
+                return errorJsonResponse("Domain must be set");
+
+            if (!is_valid_domain_name($domain))
+                return errorJsonResponse("Domain must be valid");
+
+            $existingEntries = getCustomDNSEntries();
+
+            if (array_key_exists($domain, $existingEntries))
+                return errorJsonResponse("This domain already has a custom DNS entry");
+
+            exec("sudo pihole -a addcustomdns ".$ip." ".$domain);
+            exec("sudo pihole -a restartdns");
+
+            return successJsonResponse();
+        }
+        catch (\Exception $ex)
+        {
+            return errorJsonResponse($ex->getMessage());
+        }
+    }
+
+    function deleteCustomDNSEntry()
+    {
+        try
+        {
+            $domain = !empty($_REQUEST['domain']) ? $_REQUEST['domain']: "";
+
+            if (empty($domain))
+                return errorJsonResponse("Domain must be set");
+
+            $existingEntries = getCustomDNSEntries();
+
+            if (!array_key_exists($domain, $existingEntries))
+                return errorJsonResponse("This domain does not have a custom DNS entry");
+
+            exec("sudo pihole -a removecustomdns ".$domain);
+            exec("sudo pihole -a restartdns");
+
+            return successJsonResponse();
+        }
+        catch (\Exception $ex)
+        {
+            return errorJsonResponse($ex->getMessage());
+        }
+    }
+
+    function successJsonResponse($message = "")
+    {
+        return [ "success" => true, "message" => $message ];
+    }
+
+    function errorJsonResponse($message = "")
+    {
+        return [ "success" => false, "message" => $message ];
+    }
+?>

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -13,6 +13,13 @@ function is_valid_domain_name($domain_name)
         preg_match("/^[^\.]{1,63}(\.[^\.]{1,63})*$/", $domain_name)); // Length of each label
 }
 
+function get_ip_type($ip)
+{
+    return  filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) ? 4 :
+           (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ? 6 :
+            0);
+}
+
 function checkfile($filename) {
     if(is_readable($filename))
     {

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -480,6 +480,12 @@ if($auth) {
                         <i class="fa fa-ban"></i> <span>Blacklist</span>
                     </a>
                 </li>
+                <!-- Custom DNS -->
+                <li<?php if($scriptname === "custom_dns.php"){ ?> class="active"<?php } ?>>
+                    <a href="custom_dns.php">
+                        <i class="fa fa-address-book"></i> <span>Custom DNS</span>
+                    </a>
+                </li>
                 <!-- Toggle -->
 
                 <li id="pihole-disable" class="treeview"<?php if ($pistatus == "0") { ?> hidden="true"<?php } ?>>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This new page will take advantage of the two commands added in core PR https://github.com/pi-hole/pi-hole/pull/2978 to allow users to add and delete custom DNS records

This intend to correctly fix core issue https://github.com/pi-hole/pi-hole/issues/975

**How does this PR accomplish the above?:**

This interface use datatable to manage the custom records, using the two new commands in order to add/delete records from the custom.list file

**What documentation changes (if any) are needed to support this PR?:**

Probably a bunch of screenshot to update since this PR add a new navbar entry.
