### PR TITLE
Allow for custom API URL during development

### DIFF
--- a/src/config.development.tsx
+++ b/src/config.development.tsx
@@ -10,13 +10,8 @@
 
 import { Config } from "./config";
 
-let apiUrlBase;
-
-if (process.env.REACT_APP_CUSTOM_API_URL) {
-  apiUrlBase = process.env.REACT_APP_CUSTOM_API_URL;
-} else {
-  apiUrlBase = process.env.PUBLIC_URL;
-}
+const apiUrlBase =
+  process.env.REACT_APP_CUSTOM_API_URL || process.env.PUBLIC_URL;
 
 export default {
   developmentMode: true,

--- a/src/config.development.tsx
+++ b/src/config.development.tsx
@@ -14,8 +14,7 @@ let apiUrlBase;
 
 if (process.env.REACT_APP_CUSTOM_API_URL) {
   apiUrlBase = process.env.REACT_APP_CUSTOM_API_URL;
-}
-else {
+} else {
   apiUrlBase = process.env.PUBLIC_URL;
 }
 

--- a/src/config.development.tsx
+++ b/src/config.development.tsx
@@ -10,8 +10,17 @@
 
 import { Config } from "./config";
 
+let apiUrlBase;
+
+if (process.env.REACT_APP_CUSTOM_API_URL) {
+  apiUrlBase = process.env.REACT_APP_CUSTOM_API_URL;
+}
+else {
+  apiUrlBase = process.env.PUBLIC_URL;
+}
+
 export default {
   developmentMode: true,
   fakeAPI: false,
-  apiPath: process.env.PUBLIC_URL + "/api"
+  apiPath: apiUrlBase + "/api"
 } as Config;


### PR DESCRIPTION
test for existence of REACT_APP_CUSTOM_API_URL, use that if it exists… else fallback to PUBLIC_URL

set REACT_APP_CUSTOM_API_URL in a file called `.env` in the root of the project