### PR TITLE
Remove "API" version box

### DIFF
--- a/scripts/make-fake-data.js
+++ b/scripts/make-fake-data.js
@@ -299,17 +299,6 @@ function getFTLdb() {
 
 function getVersionInfo() {
   return {
-    api: {
-      branch: faker.random.arrayElement([
-        "master",
-        "development",
-        "FTL",
-        "beta",
-        "test"
-      ]),
-      hash: faker.internet.color().substring(1) + faker.random.number(9),
-      tag: "vDev"
-    },
     core: {
       branch: faker.random.arrayElement([
         "master",

--- a/src/components/settings/VersionInfo.tsx
+++ b/src/components/settings/VersionInfo.tsx
@@ -53,11 +53,6 @@ class VersionInfo extends Component<ApiVersions & WithTranslation, {}> {
 }
 
 export const initialData: ApiVersions = {
-  api: {
-    branch: "unknown",
-    hash: "unknown",
-    tag: "unknown"
-  },
   core: {
     branch: "unknown",
     hash: "unknown",

--- a/src/components/settings/VersionInfo.tsx
+++ b/src/components/settings/VersionInfo.tsx
@@ -20,7 +20,7 @@ class VersionInfo extends Component<ApiVersions & WithTranslation, {}> {
 
     return (
       <div className="row">
-        <div className="col-xl-3 col-md-6 col-xs-12">
+        <div className="col-xl-4 col-md-4 col-xs-12">
           <VersionCard
             name={t("Core")}
             icon="far fa-dot-circle fa-2x"
@@ -29,7 +29,7 @@ class VersionInfo extends Component<ApiVersions & WithTranslation, {}> {
             tag={this.props.core.tag}
           />
         </div>
-        <div className="col-xl-3 col-md-6 col-xs-12">
+        <div className="col-xl-4 col-md-4 col-xs-12">
           <VersionCard
             name={t("FTL")}
             icon="fa fa-industry fa-2x"
@@ -38,16 +38,7 @@ class VersionInfo extends Component<ApiVersions & WithTranslation, {}> {
             tag={this.props.ftl.tag}
           />
         </div>
-        <div className="col-xl-3 col-md-6 col-xs-12">
-          <VersionCard
-            name={t("API")}
-            icon="fa fa-bullseye fa-2x"
-            branch={this.props.api.branch}
-            hash={this.props.api.hash}
-            tag={this.props.api.tag}
-          />
-        </div>
-        <div className="col-xl-3 col-md-6 col-xs-12">
+        <div className="col-xl-4 col-md-4 col-xs-12">
           <VersionCard
             name={t("Web")}
             icon="far fa-list-alt fa-2x"

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -38,7 +38,6 @@ interface ApiVersion {
 }
 
 interface ApiVersions {
-  api: ApiVersion;
   core: ApiVersion;
   ftl: ApiVersion;
   web: ApiVersion;


### PR DESCRIPTION
API is embedded into FTL, for the purposes of this branch, so we only need three version boxes.