### PR TITLE
Change lists API format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "proxy": "http://127.0.0.1:8080/admin",
   "name": "pi-hole_web",
   "version": "0.1.0",
   "private": true,

--- a/src/components/list/DomainList.tsx
+++ b/src/components/list/DomainList.tsx
@@ -38,7 +38,7 @@ const DomainList = ({ domains, onRemove, t }: DomainListProps) => {
     <li key={domain.domain} className="list-group-item">
       {api.loggedIn ? removeButton(domain.domain) : null}
       <span className="d-table-cell align-middle" style={{ height: "32px" }}>
-        {domain}
+        {domain.domain}
       </span>
     </li>
   );

--- a/src/components/list/DomainList.tsx
+++ b/src/components/list/DomainList.tsx
@@ -15,7 +15,7 @@ import { Button } from "reactstrap";
 import Alert from "../common/Alert";
 
 export interface DomainListProps extends WithTranslation {
-  domains: string[];
+  domains: Array<ApiDomainListItem>;
   onRemove: (domain: string) => void;
 }
 
@@ -34,9 +34,9 @@ const DomainList = ({ domains, onRemove, t }: DomainListProps) => {
   );
 
   // Map a domain string to a list item
-  const mapDomainsToListItems = (domain: string) => (
-    <li key={domain} className="list-group-item">
-      {api.loggedIn ? removeButton(domain) : null}
+  const mapDomainsToListItems = (domain: ApiDomainListItem) => (
+    <li key={domain.domain} className="list-group-item">
+      {api.loggedIn ? removeButton(domain.domain) : null}
       <span className="d-table-cell align-middle" style={{ height: "32px" }}>
         {domain}
       </span>

--- a/src/components/list/ListPage.tsx
+++ b/src/components/list/ListPage.tsx
@@ -31,7 +31,7 @@ export interface ListPageProps {
 }
 
 export interface ListPageState {
-  domains: string[];
+  domains: Array<ApiDomainListItem>;
   message: string;
   messageType: AlertType;
 }
@@ -56,7 +56,8 @@ export class ListPage extends Component<
 
   onEnter = (domain: string) => {
     // Check if the domain was already added
-    if (this.state.domains.includes(domain)) {
+    const domainStrings = this.state.domains.map(domain => domain.domain);
+    if (domainStrings.includes(domain)) {
       this.onAlreadyAdded(domain);
     } else {
       // Store the domains before adding the new domain, for a possible rollback
@@ -66,7 +67,8 @@ export class ListPage extends Component<
       this.addHandler = makeCancelable(this.props.onAdd(domain));
       this.addHandler.promise
         .then(() => {
-          this.onAdded(domain);
+          const item = {domain: domain, date_added: 0, date_modified: 0, enabled: false, comment: ""};
+          this.onAdded(item);
         })
         .catch(ignoreCancel)
         .catch(() => {
@@ -90,14 +92,14 @@ export class ListPage extends Component<
       messageType: "danger"
     });
 
-  onAdded = (domain: string) =>
+  onAdded = (domain: ApiDomainListItem) =>
     this.setState(prevState => ({
       domains: [...prevState.domains, domain],
-      message: this.props.t("Successfully added {{domain}}", { domain }),
+      message: this.props.t("Successfully added {{domain}}", { domain}),
       messageType: "success"
     }));
 
-  onAddFailed = (domain: string, prevDomains: string[]) =>
+  onAddFailed = (domain: string, prevDomains: Array<ApiDomainListItem>) =>
     this.setState({
       domains: prevDomains,
       message: this.props.t("Failed to add {{domain}}", { domain }),
@@ -106,10 +108,10 @@ export class ListPage extends Component<
 
   onRemoved = (domain: string) =>
     this.setState(prevState => ({
-      domains: prevState.domains.filter(item => item !== domain)
+      domains: prevState.domains.filter(item => item.domain !== domain)
     }));
 
-  onRemoveFailed = (domain: string, prevDomains: string[]) =>
+  onRemoveFailed = (domain: string, prevDomains: Array<ApiDomainListItem>) =>
     this.setState({
       domains: prevDomains,
       message: this.props.t("Failed to remove {{domain}}", { domain }),
@@ -117,7 +119,8 @@ export class ListPage extends Component<
     });
 
   onRemove = (domain: string) => {
-    if (this.state.domains.includes(domain)) {
+    const domainStrings = this.state.domains.map(domain => domain.domain);
+    if (domainStrings.includes(domain)) {
       const prevDomains = this.state.domains.slice();
 
       this.removeHandler = makeCancelable(this.props.onRemove(domain));

--- a/src/components/list/ListPage.tsx
+++ b/src/components/list/ListPage.tsx
@@ -67,7 +67,13 @@ export class ListPage extends Component<
       this.addHandler = makeCancelable(this.props.onAdd(domain));
       this.addHandler.promise
         .then(() => {
-          const item = {domain: domain, date_added: 0, date_modified: 0, enabled: false, comment: ""};
+          const item = {
+            domain: domain,
+            date_added: 0,
+            date_modified: 0,
+            enabled: false,
+            comment: ""
+          };
           this.onAdded(item);
         })
         .catch(ignoreCancel)
@@ -95,7 +101,7 @@ export class ListPage extends Component<
   onAdded = (domain: ApiDomainListItem) =>
     this.setState(prevState => ({
       domains: [...prevState.domains, domain],
-      message: this.props.t("Successfully added {{domain}}", { domain}),
+      message: this.props.t("Successfully added {{domain}}", { domain }),
       messageType: "success"
     }));
 

--- a/src/components/list/__tests__/ListPage.test.tsx
+++ b/src/components/list/__tests__/ListPage.test.tsx
@@ -94,8 +94,17 @@ it("hides the alert if closed", () => {
 });
 
 it("cancels requests when un-mounting", async () => {
+  const domains = [
+    {
+      domain: "domain",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const wrapper = renderListPage({
-    onRefresh: () => Promise.resolve(["domain"])
+    onRefresh: () => Promise.resolve(domains)
   });
 
   // Load the domains into state
@@ -137,7 +146,29 @@ it("shows a validation message as an error", () => {
 });
 
 it("loads domains after mounting", async () => {
-  const domains = ["domain1", "domain2.com", "domain3.net"];
+  const domains = [
+    {
+      domain: "domain1",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    },
+    {
+      domain: "domain2.com",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    },
+    {
+      domain: "domain3.net",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const wrapper = renderListPage({
     onRefresh: () => Promise.resolve(domains)
   });
@@ -148,7 +179,29 @@ it("loads domains after mounting", async () => {
 });
 
 it("checks if the domain was already added", async () => {
-  const domains = ["domain1", "domain2.com", "domain3.net"];
+  const domains = [
+    {
+      domain: "domain1",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    },
+    {
+      domain: "domain2.com",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    },
+    {
+      domain: "domain3.net",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const wrapper = renderListPage({
     onRefresh: () => Promise.resolve(domains)
   });
@@ -157,42 +210,66 @@ it("checks if the domain was already added", async () => {
   // Setup with domains (wait for promise to resolve)
   await tick();
 
-  wrapper.instance().onEnter(domains[0]);
+  wrapper.instance().onEnter(domains[0].domain);
 
-  expect(onAlreadyAdded).toHaveBeenCalledWith(domains[0]);
+  expect(onAlreadyAdded).toHaveBeenCalledWith(domains[0].domain);
 });
 
 it("calls the add prop when adding a domain", () => {
-  const domain = "domain";
+  const domains = [
+    {
+      domain: "domain",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const onAdd = jest.fn(ignoreAPI);
   const wrapper = renderListPage({ onAdd });
 
-  wrapper.instance().onEnter(domain);
+  wrapper.instance().onEnter(domains[0].domain);
 
-  expect(onAdd).toHaveBeenCalledWith(domain);
+  expect(onAdd).toHaveBeenCalledWith(domains[0].domain);
 });
 
 it("calls onAdding when adding a domain", () => {
-  const domain = "domain";
+  const domains = [
+    {
+      domain: "domain",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const wrapper = renderListPage();
   const onAdding = jest.spyOn(wrapper.instance(), "onAdding");
 
-  wrapper.instance().onEnter(domain);
+  wrapper.instance().onEnter(domains[0].domain);
 
-  expect(onAdding).toHaveBeenCalledWith(domain);
+  expect(onAdding).toHaveBeenCalledWith(domains[0].domain);
 });
 
 it("calls onAdded after API request succeeds", async () => {
-  const domain = "domain";
+  const domains = [
+    {
+      domain: "domain",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const wrapper = renderListPage({
     onAdd: () => Promise.resolve()
   });
   const onAdded = jest.spyOn(wrapper.instance(), "onAdded");
 
-  wrapper.instance().onEnter(domain);
+  wrapper.instance().onEnter(domains[0].domain);
   await tick();
 
-  expect(onAdded).toHaveBeenCalledWith(domain);
+  expect(onAdded).toHaveBeenCalledWith(domains[0]);
 });
 
 it("calls onAddFailed after API request fails", async () => {
@@ -209,15 +286,23 @@ it("calls onAddFailed after API request fails", async () => {
 });
 
 it("adds the domain in onAdded", async () => {
-  const domain = "domain";
+  const domains = [
+    {
+      domain: "domain",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const wrapper = renderListPage({
     onAdd: () => Promise.resolve()
   });
 
-  wrapper.instance().onEnter(domain);
+  wrapper.instance().onEnter(domains[0].domain);
   await tick();
 
-  expect(wrapper.state().domains).toEqual([domain]);
+  expect(wrapper.state().domains).toEqual(domains);
 });
 
 it("resets the domains when adding failed", async () => {
@@ -234,7 +319,15 @@ it("resets the domains when adding failed", async () => {
 
 it("does not remove the domain if it is not present", async () => {
   const domain = "domain1";
-  const domains = ["domain2"];
+  const domains = [
+    {
+      domain: "domain2",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const wrapper = renderListPage({
     onRefresh: () => Promise.resolve(domains)
   });
@@ -246,30 +339,50 @@ it("does not remove the domain if it is not present", async () => {
 });
 
 it("removes the domain from state when onRemove is called", async () => {
-  const domain = "domain";
-  const domain2 = "domain2";
-  const domains = [domain, domain2];
+  const domains = [
+    {
+      domain: "domain",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    },
+    {
+      domain: "domain2",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const wrapper = renderListPage({
     onRefresh: () => Promise.resolve(domains),
     onRemove: () => Promise.resolve()
   });
 
   await tick();
-  wrapper.instance().onRemove(domain);
+  wrapper.instance().onRemove(domains[0].domain);
 
-  expect(wrapper.state().domains).toEqual([domain2]);
+  expect(wrapper.state().domains).toEqual([domains[1]]);
 });
 
 it("resets the domains when removal failed", async () => {
-  const domain = "domain";
-  const domains = [domain];
+  const domains = [
+    {
+      domain: "domain",
+      enabled: false,
+      date_added: 0,
+      date_modified: 0,
+      comment: ""
+    }
+  ];
   const wrapper = renderListPage({
     onRefresh: () => Promise.resolve(domains),
     onRemove: () => Promise.reject()
   });
 
   await tick();
-  wrapper.instance().onRemove(domain);
+  wrapper.instance().onRemove(domains[0].domain);
   await tick();
 
   expect(wrapper.state().domains).toEqual(domains);

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -202,3 +202,11 @@ interface ApiClientData {
   ip: string;
   count: number;
 }
+
+interface ApiDomainListItem {
+  domain: string;
+  date_added: number;
+  date_modified: number;
+  comment: string;
+  enabled: boolean;
+}

--- a/src/util/api.tsx
+++ b/src/util/api.tsx
@@ -161,19 +161,19 @@ export class ApiClient {
     return this.http.get("stats/history?" + paramsToString(params));
   };
 
-  getExactWhitelist = (): Promise<Array<string>> => {
+  getExactWhitelist = (): Promise<Array<ApiDomainListItem>> => {
     return this.http.get("dns/whitelist/exact");
   };
 
-  getExactBlacklist = (): Promise<Array<string>> => {
+  getExactBlacklist = (): Promise<Array<ApiDomainListItem>> => {
     return this.http.get("dns/blacklist/exact");
   };
 
-  getRegexWhitelist = (): Promise<Array<string>> => {
+  getRegexWhitelist = (): Promise<Array<ApiDomainListItem>> => {
     return this.http.get("dns/whitelist/regex");
   };
 
-  getRegexBlacklist = (): Promise<Array<string>> => {
+  getRegexBlacklist = (): Promise<Array<ApiDomainListItem>> => {
     return this.http.get("dns/blacklist/regex");
   };
 


### PR DESCRIPTION
To be able to pass all available information from the API to the user interface, we will change the API response from a simple domain array
```
[
	"domainA",
	"domainB",
	"domainC"
]
```
to an array of objects for each entry
```
[{
		"domain":		"domainA",
		"enabled":		true,
		"date_added":		1575307146,
		"date_modified":	1575307146,
		"comment":		"Migrated from /etc/pihole/whitelist.txt"
	}, {
		"domain":		"domainB",
		"enabled":		true,
		"date_added":		1575307146,
		"date_modified":	1575307146,
		"comment":		"Migrated from /etc/pihole/whitelist.txt"
	}, {
		"domain":		"domainC",
		"enabled":		true,
		"date_added":		1575307146,
		"date_modified":	1575307146,
		"comment":		"Migrated from /etc/pihole/whitelist.txt"
}]
```

This PR updates the web interface (incl. the tests) to support this new format. Adding the display of the additional data will be subject of a follow-up PR.