### PR TITLE
Tweak browserslist config

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,9 +90,11 @@
     "check-format": "prettier --list-different \"src/**/*.tsx\""
   },
   "browserslist": [
+    "defaults",
     ">0.2%",
     "not dead",
-    "not ie <= 11",
+    "Explorer 11",
+    "not ExplorerMobile <= 11",
     "not op_mini all"
   ]
 }


### PR DESCRIPTION
Add `defaults` and `IE 11`

Before:

```
Browsers:
  Chrome for Android: 78
  And_qq: 1.2
  UC for Android: 12.12
  Chrome: 78, 77, 76, 75, 74, 73, 72, 63, 49
  Edge: 18, 17
  Firefox: 70, 69
  iOS: 13.0-13.1, 12.2-12.4, 12.0-12.1, 11.3-11.4
  Kaios: 2.5
  Opera: 63
  Safari: 13, 12.1, 11.1, 5.1
  Samsung: 10.1, 9.2

These browsers account for 90.22% of all users globally
```

After:

```
Browsers:
  Chrome for Android: 78
  Firefox for Android: 68
  And_qq: 1.2
  UC for Android: 12.12
  Android: 76
  Baidu: 7.12
  Chrome: 78, 77, 76, 75, 74, 73, 72, 63, 49
  Edge: 18, 17
  Firefox: 70, 69, 68
  IE: 11
  iOS: 13.2, 13.0-13.1, 12.2-12.4, 12.0-12.1, 11.3-11.4
  Kaios: 2.5
  Opera Mobile: 46
  Opera: 64, 63
  Safari: 13, 12.1, 11.1, 5.1
  Samsung: 10.1, 9.2

These browsers account for 92.59% of all users globally
```

Let me know what you guys think.