### PR TITLE
Enforce LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Enforce Unix newlines
+* text=auto eol=lf
+
 *.ttf binary
 *.eot binary
 *.woff binary


### PR DESCRIPTION
On Windows, `autocrlf` is set to `true` by default. This forces LF everywhere.

This requires Git >= 2.10 IIRC.