### PR TITLE
Run prettier for all js and tsx files

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,8 +86,8 @@
     "test": "react-scripts test --env=jsdom",
     "coverage": "react-scripts test --env=jsdom --coverage",
     "eject": "react-scripts eject",
-    "format": "prettier --write \"src/**/*.tsx\"",
-    "check-format": "prettier --list-different \"src/**/*.tsx\""
+    "format": "prettier --write \"**/*.{js,tsx}\"",
+    "check-format": "prettier --list-different \"**/*.{js,tsx}\""
   },
   "browserslist": [
     ">0.2%",

--- a/scripts/generate-language-list.js
+++ b/scripts/generate-language-list.js
@@ -15,9 +15,9 @@ const ISO6391 = require("iso-639-1");
 const languages = fs.readdirSync("public/i18n");
 const languageMap = languages.map(lang => {
   return {
-    "code": lang,
-    "name": ISO6391.getName(lang)
-  }
+    code: lang,
+    name: ISO6391.getName(lang)
+  };
 });
 
 // Save the language list so the web interface knows what's available

--- a/scripts/make-fake-data.js
+++ b/scripts/make-fake-data.js
@@ -56,8 +56,8 @@ function history(length) {
         client: isHostname
           ? faker.internet.domainWord() + ".local"
           : isIPv4
-            ? faker.internet.ip()
-            : faker.internet.ipv6(),
+          ? faker.internet.ip()
+          : faker.internet.ipv6(),
         dnssec: Math.floor(Math.random() * 5.9),
         reply: Math.floor(Math.random() * 7.9),
         response_time: Math.floor(Math.random() * 100.9)
@@ -381,7 +381,7 @@ function getPreferences() {
   return {
     layout: "boxed",
     language: "en"
-  }
+  };
 }
 
 console.log("Deleting old fake API data...");
@@ -412,14 +412,20 @@ write("public/fakeAPI/stats/top_domains", topDomains(10));
 write("public/fakeAPI/stats/top_clients", topClients(10));
 write("public/fakeAPI/stats/top_blocked_clients", topBlockedClients(10));
 write("public/fakeAPI/stats/database/overTime/history", historyOverTime(144));
-write("public/fakeAPI/stats/database/overTime/clients", clientsOverTime(144, 5));
+write(
+  "public/fakeAPI/stats/database/overTime/clients",
+  clientsOverTime(144, 5)
+);
 write("public/fakeAPI/stats/database/summary", summary());
 write("public/fakeAPI/stats/database/query_types", queryTypes());
 write("public/fakeAPI/stats/database/upstreams", upstreams(3));
 write("public/fakeAPI/stats/database/top_blocked", topBlockedDomains(10));
 write("public/fakeAPI/stats/database/top_domains", topDomains(10));
 write("public/fakeAPI/stats/database/top_clients", topClients(10));
-write("public/fakeAPI/stats/database/top_blocked_clients", topBlockedClients(10));
+write(
+  "public/fakeAPI/stats/database/top_blocked_clients",
+  topBlockedClients(10)
+);
 write("public/fakeAPI/auth", auth());
 write("public/fakeAPI/version", getVersionInfo());
 


### PR DESCRIPTION
<details><summary>Log</summary>

```
> pi-hole_web@0.1.0 format C:\Users\xmr\Desktop\web
> prettier --write "**/*.{js,tsx}"

scripts\generate-language-list.js 48ms
scripts\make-fake-data.js 163ms
src\components\common\__tests__\Alert.test.tsx 196ms
src\components\common\__tests__\EnableDisable.test.tsx 152ms
src\components\common\__tests__\Footer.test.tsx 14ms
src\components\common\__tests__\FooterDonateLink.test.tsx 14ms
src\components\common\__tests__\FooterUpdateStatus.test.tsx 16ms
src\components\common\__tests__\Header.test.tsx 28ms
src\components\common\__tests__\NavButton.test.tsx 17ms
src\components\common\__tests__\NavDropdown.test.tsx 18ms
src\components\common\__tests__\Sidebar.test.tsx 86ms
src\components\common\__tests__\StatusBadge.test.tsx 16ms
src\components\common\__tests__\WithAPIData.test.tsx 75ms
src\components\common\Alert.tsx 17ms
src\components\common\context\__tests__\index.test.tsx 10ms
src\components\common\context\__tests__\StatusContext.test.tsx 28ms
src\components\common\context\__tests__\TimeRangeContext.test.tsx 27ms
src\components\common\context\index.tsx 25ms
src\components\common\context\StatusContext.tsx 31ms
src\components\common\context\TimeRangeContext.tsx 26ms
src\components\common\EnableDisable.tsx 110ms
src\components\common\Footer.tsx 11ms
src\components\common\FooterDonateLink.tsx 8ms
src\components\common\FooterUpdateStatus.tsx 10ms
src\components\common\Header.tsx 21ms
src\components\common\NavButton.tsx 11ms
src\components\common\NavDropdown.tsx 28ms
src\components\common\Sidebar.tsx 70ms
src\components\common\StatusBadge.tsx 30ms
src\components\common\WithAPIData.tsx 39ms
src\components\dashboard\__tests__\ClientsGraph.test.tsx 92ms
src\components\dashboard\__tests__\GenericDoughnutChart.test.tsx 16ms
src\components\dashboard\__tests__\SummaryStats.test.tsx 28ms
src\components\dashboard\__tests__\TopBlockedClients.test.tsx 36ms
src\components\dashboard\__tests__\TopBlockedDomains.test.tsx 34ms
src\components\dashboard\__tests__\TopClients.test.tsx 27ms
src\components\dashboard\__tests__\TopDomains.test.tsx 28ms
src\components\dashboard\__tests__\TopTable.test.tsx 31ms
src\components\dashboard\ChartTooltip.tsx 34ms
src\components\dashboard\ClientsGraph.tsx 95ms
src\components\dashboard\GenericDoughnutChart.tsx 42ms
src\components\dashboard\QueriesGraph.tsx 66ms
src\components\dashboard\QueryTypesChart.tsx 18ms
src\components\dashboard\SummaryStats.tsx 31ms
src\components\dashboard\TimeRangeSelector.tsx 24ms
src\components\dashboard\TopBlockedClients.tsx 38ms
src\components\dashboard\TopBlockedDomains.tsx 50ms
src\components\dashboard\TopClients.tsx 56ms
src\components\dashboard\TopDomains.tsx 55ms
src\components\dashboard\TopTable.tsx 42ms
src\components\dashboard\UpstreamsChart.tsx 12ms
src\components\list\__tests__\DomainInput.test.tsx 78ms
src\components\list\__tests__\DomainList.test.tsx 32ms
src\components\list\__tests__\ListPage.test.tsx 60ms
src\components\list\DomainInput.tsx 26ms
src\components\list\DomainList.tsx 25ms
src\components\list\ListPage.tsx 56ms
src\components\log\QueryLog.tsx 125ms
src\components\login\__tests__\ForgotPassword.test.tsx 20ms
src\components\login\ForgotPassword.tsx 16ms
src\components\settings\__tests__\DHCPInfo.test.tsx 35ms
src\components\settings\ConditionalForwardingSettings.tsx 38ms
src\components\settings\DHCPInfo.tsx 67ms
src\components\settings\DNSInfo.tsx 76ms
src\components\settings\DnsList.tsx 13ms
src\components\settings\DnsListItem.tsx 8ms
src\components\settings\DnsListNewItem.tsx 31ms
src\components\settings\DnsOptionSettings.tsx 30ms
src\components\settings\FTLInfo.tsx 31ms
src\components\settings\NetworkInfo.tsx 45ms
src\components\settings\preconfiguredUpstreams.tsx 35ms
src\components\settings\PreferenceSettings.tsx 63ms
src\components\settings\VersionCard.tsx 31ms
src\components\settings\VersionInfo.tsx 27ms
src\config.development.tsx 10ms
src\config.production.tsx 21ms
src\config.tsx 7ms
src\containers\Full.tsx 24ms
src\index.tsx 19ms
src\redux\actions\index.tsx 7ms
src\redux\reducers\index.tsx 17ms
src\redux\sagas\__tests__\applyLanguage.test.tsx 8ms
src\redux\sagas\__tests__\applyLayout.test.tsx 20ms
src\redux\sagas\__tests__\autoLogin.test.tsx 22ms
src\redux\sagas\__tests__\preferences.test.tsx 13ms
src\redux\sagas\applyLanguage.tsx 18ms
src\redux\sagas\applyLayout.tsx 8ms
src\redux\sagas\autoLogin.tsx 18ms
src\redux\sagas\index.tsx 7ms
src\redux\sagas\preferences.tsx 21ms
src\redux\state\__tests__\preferences.test.tsx 18ms
src\redux\state\index.tsx 6ms
src\redux\state\preferences.tsx 19ms
src\redux\store.tsx 9ms
src\routes.tsx 32ms
src\setupTests.tsx 11ms
src\util\__tests__\api.test.tsx 116ms
src\util\__tests__\basePath.test.tsx 8ms
src\util\__tests__\CancelablePromise.test.tsx 19ms
src\util\__tests__\graphUtils.test.tsx 11ms
src\util\__tests__\http.test.tsx 38ms
src\util\__tests__\i18n.test.tsx 19ms
src\util\__tests__\result.test.tsx 19ms
src\util\__tests__\validate.test.tsx 59ms
src\util\api.tsx 63ms
src\util\CancelablePromise.tsx 21ms
src\util\dateRanges.tsx 13ms
src\util\graphUtils.tsx 16ms
src\util\http.tsx 39ms
src\util\i18n.tsx 19ms
src\util\validate.tsx 30ms
src\views\Dashboard.tsx 25ms
src\views\ExactBlacklist.tsx 29ms
src\views\ExactWhitelist.tsx 23ms
src\views\Login.tsx 62ms
src\views\Logout.tsx 7ms
src\views\Networking.tsx 28ms
src\views\Preferences.tsx 24ms
src\views\RegexBlacklist.tsx 8ms
src\views\RegexWhitelist.tsx 10ms
src\views\Versions.tsx 6ms
```

</summary>
