### PR TITLE
public/index.html: minor cleanup

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,9 +1,9 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
 <head>
     <meta charset="utf-8">
     <title>Pi-hole Web Interface</title>
-    <script type="text/javascript">
+    <script>
       // Single Page Apps for GitHub Pages
       // https://github.com/rafrex/spa-github-pages
       // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License

--- a/public/index.html
+++ b/public/index.html
@@ -2,13 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="shortcut icon" href="%PUBLIC_URL%/img/favicon.png">
     <title>Pi-hole Web Interface</title>
 
     <!-- Start Single Page Apps for GitHub Pages -->
-    <script type="text/javascript">
+    <script>
       // Single Page Apps for GitHub Pages
       // https://github.com/rafrex/spa-github-pages
       // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
@@ -42,7 +41,7 @@
 
   <body class="app header-fixed sidebar-fixed sidebar-lg-show boxcontainer background-image">
     <noscript>
-      <p align="center">Please enable JavaScript! This web interface will not work without it.</p>
+      <p style="text-align: center">Please enable JavaScript! This web interface will not work without it.</p>
     </noscript>
 
     <div id="root"></div>


### PR DESCRIPTION
* `X-UA-Compatible` is not honored by IE 11
* the type `text/javascript` is unneeded since it's the default
* replace the obsolete in HTML5 `align="center"` with inline CSS
