### PR TITLE
little typo fixes for italian translation

### DIFF
--- a/public/i18n/it/common.json
+++ b/public/i18n/it/common.json
@@ -3,7 +3,7 @@
     "Status": "Stato",
     "DNS": "DNS",
     "Donate": "Dona",
-    "Domain": "Dominî",
+    "Domain": "Domini",
     "Hits": "Nº richieste",
     "Frequency": "Frequenza",
     "Client": "Client",

--- a/public/i18n/it/dashboard.json
+++ b/public/i18n/it/dashboard.json
@@ -1,9 +1,9 @@
 {
-    "Domains On Blocklist": "Dominî nella lista dei bloccati",
+    "Domains On Blocklist": "Domini nella lista dei bloccati",
     "Query Types": "Tipi di interrogazioni",
     "Forward Destinations": "Destinazioni inviate",
-    "Top Permitted Domains": "Classifica dei dominî consentiti più richiesti",
-    "Top Blocked Domains": "Classifica dei dominî bloccati più richiesti",
+    "Top Permitted Domains": "Classifica dei domini consentiti più richiesti",
+    "Top Blocked Domains": "Classifica dei domini bloccati più richiesti",
     "Top Clients": "Classifica dei client",
     "Total Queries ({{count}} clients)": "Totale delle interrogazioni (tramite 1 client)",
     "Total Queries ({{count}} clients)_plural": "Totale delle interrogazioni (tramite {{count}} client)",

--- a/public/i18n/it/lists.json
+++ b/public/i18n/it/lists.json
@@ -3,11 +3,11 @@
     "Successfully added {{domain}}": "{{domain}} è stato aggiunto alla lista",
     "Failed to add {{domain}}": "Errore nell'aggiunta di {{domain}}",
     "Note: Whitelisting a subdomain of a wildcard blocked domain is not possible.": "Nota: inserire nella lista bianca un sottodominio di un dominio già bloccato da wildcard non è possibile.",
-    "Note: Only the domain and subdomains of the blocked domain will be blocked.": "Nota: solo il dominio e i suoi sottodominî saranno bloccati.",
+    "Note: Only the domain and subdomains of the blocked domain will be blocked.": "Nota: solo il dominio e i suoi sottodomini saranno bloccati.",
     "Add a domain or hostname (example.com or example)": "Aggiungi un dominio oppure un nome dell'host (come example.com o example)",
     "{{domain}} is already added": "{{domain}} è già stato aggiunto",
     "Failed to remove {{domain}}": "Errore nella rimozione di {{domain}}",
-    "There are no domains in this list": "Non ci sono dominî in questa lista",
+    "There are no domains in this list": "Non ci sono domini in questa lista",
     "Input a regular expression": "Inserisci un'espressione regolare",
     "Not a valid hostname": "Non è un nome dell'host valido",
     "Not a valid regular expression": "Non è un'espressione regolare valida"


### PR DESCRIPTION
**Describe the changes**
little typo fixes on italian translation with _î_ char, example:
Dominî->Domini
sottodominî->sottodomini
dominî->domini