### PR TITLE
Add correct IP sorting for the Custom DNS table

### DIFF
--- a/custom_dns.php
+++ b/custom_dns.php
@@ -89,6 +89,7 @@
     </div>
 </div>
 
+<script src="scripts/pi-hole/js/ip-address-sorting.js"></script>
 <script src="scripts/pi-hole/js/customdns.js"></script>
 
 <?php

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -41,7 +41,7 @@ $(document).ready(function() {
 
   table = $("#customDNSTable").DataTable({
     ajax: "scripts/pi-hole/php/customdns.php?action=get",
-    columns: [{}, {}, { orderable: false, searchable: false }],
+    columns: [{}, { type: "ip-address" }, { orderable: false, searchable: false }],
     columnDefs: [
       {
         targets: 2,


### PR DESCRIPTION
Based on this work: https://github.com/pi-hole/AdminLTE/pull/948

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

The current custom-dns page sorts the IP addresses incorrectly. This patch solves that issue by re-using the patch from #948 

**How does this PR accomplish the above?:**

Changing the type of the IP address column to `ip-address` and loading the `ip-address` sorter.

**What documentation changes (if any) are needed to support this PR?:**
