### PR TITLE
Remember last state of the "Apply filtering" checkbox on the Query Log page

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -155,7 +155,7 @@ if(strlen($showing) > 0)
                     </tr>
                 </tfoot>
             </table>
-            <label><input type="checkbox" id="autofilter" checked="true">&nbsp;Apply filtering on click on Type, Domain, and Clients</label><br/>
+            <label><input type="checkbox" id="autofilter">&nbsp;Apply filtering on click on Type, Domain, and Clients</label><br/>
             <button type="button" id="resetButton" hidden="true">Clear Filters</button>
         </div>
         <!-- /.box-body -->

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -108,7 +108,7 @@ function handleAjaxError(xhr, textStatus) {
 }
 
 function autofilter() {
-  return document.getElementById("autofilter").checked;
+  return $("#autofilter").prop("checked");
 }
 
 $(document).ready(function() {
@@ -507,5 +507,19 @@ $(document).ready(function() {
   $("#resetButton").click(function() {
     tableApi.search("").draw();
     $("#resetButton").hide();
+  });
+
+  var chkbox_data = localStorage.getItem("query_log_filter_chkbox");
+  if (chkbox_data !== null) {
+    // Restore checkbox state
+    $("#autofilter").prop("checked", chkbox_data === "true");
+  } else {
+    // Initialize checkbox
+    $("#autofilter").prop("checked", true);
+    localStorage.setItem("query_log_filter_chkbox", true);
+  }
+
+  $("#autofilter").click(function() {
+    localStorage.setItem("query_log_filter_chkbox", $("#autofilter").prop("checked"));
   });
 });


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Remember last state of the "Apply filtering" checkbox on the Query Log page.

**How does this PR accomplish the above?:**

Store the state in the local browser storage. This ensures this is a browser- and not server-wise settings so individual users can use their own preferred settings.

**What documentation changes (if any) are needed to support this PR?:**

None