### PR TITLE
Fixes #1227 Fix possible warning when unlinking files

### DIFF
--- a/api.php
+++ b/api.php
@@ -52,8 +52,10 @@ elseif (isset($_GET['enable']) && $auth)
 	}
 	pihole_execute('enable');
 	$data = array_merge($data, array("status" => "enabled"));
-	// Silence errors if there is a race condition with the timer
-	@unlink("../custom_disable_timer");
+	if (file_exists("../custom_disable_timer"))
+	{
+		unlink("../custom_disable_timer");
+	}
 }
 elseif (isset($_GET['disable']) && $auth)
 {
@@ -78,8 +80,10 @@ elseif (isset($_GET['disable']) && $auth)
 	else
 	{
 		pihole_execute('disable');
-		// Silence errors if there is a race condition with the timer
-		@unlink("../custom_disable_timer");
+		if (file_exists("../custom_disable_timer"))
+		{
+			unlink("../custom_disable_timer");
+		}
 	}
 	$data = array_merge($data, array("status" => "disabled"));
 }

--- a/api.php
+++ b/api.php
@@ -52,7 +52,8 @@ elseif (isset($_GET['enable']) && $auth)
 	}
 	pihole_execute('enable');
 	$data = array_merge($data, array("status" => "enabled"));
-	unlink("../custom_disable_timer");
+	// Silence errors if there is a race condition with the timer
+	@unlink("../custom_disable_timer");
 }
 elseif (isset($_GET['disable']) && $auth)
 {
@@ -77,7 +78,8 @@ elseif (isset($_GET['disable']) && $auth)
 	else
 	{
 		pihole_execute('disable');
-		unlink("../custom_disable_timer");
+		// Silence errors if there is a race condition with the timer
+		@unlink("../custom_disable_timer");
 	}
 	$data = array_merge($data, array("status" => "disabled"));
 }


### PR DESCRIPTION
Signed-off-by: Willem Stuursma-Ruwen <willem@stuursma.name>

**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This PR aims to fix #1227.

**How does this PR accomplish the above?:**

I have chosen to use the silence operator (`@`). An alternative would be to use `file_exists()`, but that still allows a race condition where the file is deleted after the `file_exists` call but before the `unlink` call.

**What documentation changes (if any) are needed to support this PR?:**

N/A.
