### PR TITLE
Removed padding from cards on dashboard that contain a table

### DIFF
--- a/src/components/dashboard/TopTable.tsx
+++ b/src/components/dashboard/TopTable.tsx
@@ -33,27 +33,33 @@ export class TopTable<T> extends Component<TopTableInnerProps<T>, {}> {
   };
 
   /**
-   * Generate the table
+   * Generate the card containing the table
    *
-   * @returns {*} a React element for the table, or an empty message
+   * @returns {*} a React element for the card
    */
-  generateTable = () => {
+  generateCard = () => {
     // If there is no data, just show a message
     if (this.props.isEmpty(this.props.data)) {
-      return this.props.emptyMessage;
+      return <div className="card-body">{this.props.emptyMessage}</div>;
     }
 
     return (
-      <table className="table table-bordered">
-        <tbody>
-          <tr>
-            {this.props.headers.map((header, i) => (
-              <th key={i}>{header}</th>
-            ))}
-          </tr>
-          {this.props.generateRows(this.props.data)}
-        </tbody>
-      </table>
+      <div className="card-body p-0">
+        <div style={{ overflowX: "auto" }}>
+          <table className="table m-0">
+            <tbody>
+              <tr>
+                {this.props.headers.map((header, i) => (
+                  <th className="border-top-0" key={i}>
+                    {header}
+                  </th>
+                ))}
+              </tr>
+              {this.props.generateRows(this.props.data)}
+            </tbody>
+          </table>
+        </div>
+      </div>
     );
   };
 
@@ -61,9 +67,7 @@ export class TopTable<T> extends Component<TopTableInnerProps<T>, {}> {
     return (
       <div className="card">
         <div className="card-header">{this.props.title}</div>
-        <div className="card-body">
-          <div style={{ overflowX: "auto" }}>{this.generateTable()}</div>
-        </div>
+        {this.generateCard()}
         {this.props.loading ? (
           <div
             className="card-img-overlay"


### PR DESCRIPTION
**Describe the changes**
Removed padding from cards on dashboard that contain a table.

This maximises the screen real estate. generateTable renamed to generateCard, as this method also renders the card surrounding the table, which is necessary to still render the card with padding when the "no items found" message is shown

**Screenshots**
New layout:
<img width="1252" alt="Screenshot 2020-05-12 at 14 01 12" src="https://user-images.githubusercontent.com/1194964/81694497-4cd13280-9459-11ea-934e-d786bf8fd7bc.png">

Previous layout:
<img width="1252" alt="Screenshot 2020-05-12 at 14 01 51" src="https://user-images.githubusercontent.com/1194964/81694522-53f84080-9459-11ea-8083-93808658e67a.png">

**Additional context**
N/A