### PR TITLE
Improve visibility of dashboard debug token.

### DIFF
--- a/debug.php
+++ b/debug.php
@@ -15,6 +15,11 @@
 <p><input type="checkbox" id="upload"> Upload debug log and provide token once finished</p>
 <p>Once you click this button a debug log will be generated and can automatically be uploaded if we detect a working internet connection.</p>
 <button type="button" id="debugBtn" class="btn btn-lg btn-primary btn-block">Generate debug log</button>
+
+<div id="tokenDisplay" class="alert alert-success text-center font-weight-bold" role="alert" hidden="true">
+    <strong><span id="tokenDisplay_text"></span></strong>
+</div>
+
 <pre id="output" style="width: 100%; height: 100%;" hidden="true"></pre>
 
 <script src="scripts/pi-hole/js/debug.js"></script>

--- a/scripts/pi-hole/js/debug.js
+++ b/scripts/pi-hole/js/debug.js
@@ -56,6 +56,13 @@ function eventsource() {
     "message",
     function (e) {
       ta.append(e.data);
+
+      var debug_token = e.data.match(/Your debug token is: .*\n/);
+      if (debug_token !== null) {
+        $("#tokenDisplay_text").text(debug_token);
+        $("#tokenDisplay").show();
+        $("#debugBtn").hide();
+      }
     },
     false
   );


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Improve visibility of dashboard debug token.

**How does this PR accomplish the above?:**

Replace debug button by static token display when debug log has finished successfully.
![Screenshot_2020-05-12 Pi-hole - ubuntu-server](https://user-images.githubusercontent.com/16748619/81730015-3775fb80-948d-11ea-8ec0-c8320fd33e0e.png)


**What documentation changes (if any) are needed to support this PR?:**

None