### PR TITLE
Use REPLACE into instead of INSERT into when adding a black/whitelist item

### DIFF
--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -443,7 +443,7 @@ if ($_POST['action'] == 'get_groups') {
         $domains = explode(' ', trim($_POST['domain']));
         $total = count($domains);
         $added = 0;
-        $stmt = $db->prepare('INSERT INTO domainlist (domain,type,comment) VALUES (:domain,:type,:comment)');
+        $stmt = $db->prepare('REPLACE INTO domainlist (domain,type,comment) VALUES (:domain,:type,:comment)');
         if (!$stmt) {
             throw new Exception('While preparing statement: ' . $db->lastErrorMsg());
         }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

If a domain is on a (user) black or whitelist, this allows them to add it to the opposite list without first removing it.

I.e 

`test.com` is on the user blacklist, and shows in the query log as blocked. Currently when they press the whitelist button on the query log, nothing actually happens because of the UNIQUE constraint (although the interface says it was added)

With this proposal, the domain is simply swapped to the whitelist.

Not 100% married to the idea, but figured it would be good to discuss