### PR TITLE
Changed to support comma separated

### DIFF
--- a/groups.php
+++ b/groups.php
@@ -28,7 +28,8 @@
                 <div class="row">
                     <div class="form-group col-md-6">
                         <label for="new_name">Name:</label>
-                        <input id="new_name" type="text" class="form-control" placeholder="Group name">
+                        <!-- Placeholder updated to reveal commas separated is supported -->
+                        <input id="new_name" type="text" class="form-control" placeholder="Group name (use commas to add multiple)">
                     </div>
                     <div class="form-group col-md-6">
                         <label for="new_desc">Description:</label>

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -54,7 +54,8 @@ if ($_POST['action'] == 'get_groups') {
 } elseif ($_POST['action'] == 'add_group') {
     // Add new group
     try {
-        $names = explode(' ', trim($_POST['name']));
+        // Explode (split) name string by comma to add multiple groups in one go
+        $names = explode(',', trim($_POST['name']));
         $total = count($names);
         $added = 0;
         $stmt = $db->prepare('INSERT INTO "group" (name,description) VALUES (:name,:desc)');

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -68,6 +68,7 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         foreach ($names as $name) {
+            $name = trim($name);
             if (!$stmt->bindValue(':name', $name, SQLITE3_TEXT)) {
                 throw new Exception('While binding name: <strong>' . $db->lastErrorMsg() . '</strong><br>'.
                 'Added ' . $added . " out of ". $total . " groups");


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git pu`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

To resolve bug raised whereby you can't add spaces in Group names:
https://github.com/pi-hole/pi-hole/issues/3335

The bug was introduced by this previous PR:
https://github.com/pi-hole/AdminLTE/pull/1149

This solution only addresses this issue for Groups.  I personally feel that comma delimited lists should be the default over space delimited for other input boxes that were altered in the above mentioned PR, however that is more of an issue to be discussed and agreed by the project owner.

**How does this PR accomplish the above?:**

I've changed the explode function to use a comma delimiter rather than space delimiter for Groups.

**What documentation changes (if any) are needed to support this PR?:**

You may want to mention the ability to add multiple groups in this page of the documentation, however I have set the placeholder text to also imply the behaviour: https://docs.pi-hole.net/database/gravity/example/
