### PR TITLE
Make sure #ip-custom field is editable (PARSE_ARP_CACHE=false)

### DIFF
--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -32,6 +32,10 @@ function reload_client_suggestions() {
         sel.append($("<option />").val(key).text(text));
       }
 
+      if (data.length === 0) {
+        $("#ip-custom").prop("disabled", false);
+      }
+
       sel.append($("<option />").val("custom").text("Custom, specified below..."));
       if (customWasSelected) {
         sel.val("custom");


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/AdminLTE/issues/1255 

**How does this PR accomplish the above?:**

Modified `reload_client_suggestions()` function to make sure `#ip-custom` field can be edited when no suggestions are available

**What documentation changes (if any) are needed to support this PR?:**

None