### PR TITLE
Allow spaces in groups when wrapping names in "..."

### DIFF
--- a/groups-adlists.php
+++ b/groups-adlists.php
@@ -28,7 +28,7 @@
                 <div class="row">
                     <div class="form-group col-md-6">
                         <label for="new_address">Address:</label>
-                        <input id="new_address" type="text" class="form-control" placeholder="http://..., https://..., file://..." autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                        <input id="new_address" type="text" class="form-control" placeholder="URL or space-separated URLs" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                     </div>
                     <div class="form-group col-md-6">
                         <label for="new_comment">Comment:</label>
@@ -37,7 +37,11 @@
                 </div>
             </div>
             <div class="box-footer clearfix">
-                <strong>Hint:</strong>&nbsp;Please run <code>pihole -g</code> or update your gravity list <a href="gravity.php">online</a> after modifying your adlists.
+                <strong>Hints:</strong>
+                <ol>
+                    <li>Please run <code>pihole -g</code> or update your gravity list <a href="gravity.php">online</a> after modifying your adlists.</li>
+                    <li>Multiple adlists can be added by separating each <i>unique</i> URL with a space</li>
+                </ol>
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>
             </div>
         </div>

--- a/groups.php
+++ b/groups.php
@@ -28,7 +28,7 @@
                 <div class="row">
                     <div class="form-group col-md-6">
                         <label for="new_name">Name:</label>
-                        <input id="new_name" type="text" class="form-control" placeholder="Group name">
+                        <input id="new_name" type="text" class="form-control" placeholder="Group name or space-separated group names">
                     </div>
                     <div class="form-group col-md-6">
                         <label for="new_desc">Description:</label>
@@ -37,6 +37,11 @@
                 </div>
             </div>
             <div class="box-footer clearfix">
+                <strong>Hints:</strong>
+                <ol>
+                    <li>Multiple groups can be added by separating each group name with a space</li>
+                    <li>Group names can have spaces if entered in quotes. e.g "My New Group"</li>
+                </ol>
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>
             </div>
         </div>

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -39,6 +39,37 @@ function JSON_error($message = null)
     echo json_encode($response);
 }
 
+function space_aware_explode($input)
+{
+    $ret = array();
+    $quoted = false;
+    $pos = 0;
+
+    // Loop over input string
+    for ($i = 0; $i < strlen($input); $i++)
+    {
+        // Get current character
+        $c = $input[$i];
+
+        // If current character is a space (or comma) and we're outside
+        // of a quoted region, we accept this character as separator
+        if (($c == ' ' || $c == ',') && !$quoted) {
+            $ret[] = str_replace('"', '', substr($input, $pos, $i - $pos));
+            $pos = $i+1;
+        }
+        elseif($c == '"' && !$quoted)
+            $quoted = true; // Quotation begins
+        elseif($c == '"' && $quoted)
+            $quoted = false; // Quotation ends here
+    }
+    // Get last element of the string
+    if ($pos > 0) {
+        $ret[] = substr($input, $pos);
+    }
+
+    return $ret;
+}
+
 if ($_POST['action'] == 'get_groups') {
     // List all available groups
     try {
@@ -54,7 +85,7 @@ if ($_POST['action'] == 'get_groups') {
 } elseif ($_POST['action'] == 'add_group') {
     // Add new group
     try {
-        $names = explode(' ', trim($_POST['name']));
+        $names = space_aware_explode(trim($_POST['name']));
         $total = count($names);
         $added = 0;
         $stmt = $db->prepare('INSERT INTO "group" (name,description) VALUES (:name,:desc)');

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -275,3 +275,9 @@ code.breakall {
 .input-group-addon {
 	padding: 0 12px;
 }
+
+.form-inline .form-control {
+    display: inline-block;
+    width: 100%;
+	vertical-align: middle;
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Provide an alternative solution for the issue discussed in https://github.com/pi-hole/pi-hole/issues/3335
Note that there is already an alternative solution proposed in #1290, however, this involves changing the item separator from spaces (which had been used for a long time) to commas.

**How does this PR accomplish the above?:**

Allow adding groups with spaces in them when wrapping groups names in quotation marks.

Example:
```plain
ABC "Group with spaces can be added with quotation marks" DEF GHI
```

Resulting in:
![Screenshot at 2020-05-14 18-09-56](https://user-images.githubusercontent.com/16748619/81958334-21437900-960e-11ea-8a92-fe9b30a9d892.png)

**What documentation changes (if any) are needed to support this PR?:**

None