### PR TITLE
Lessen chance of elements being blocked by browser blockers

### DIFF
--- a/index.php
+++ b/index.php
@@ -47,7 +47,7 @@
         <div class="small-box bg-aqua">
             <div class="inner">
                 <p>Queries Blocked</p>
-                <h3 class="statistic"><span id="ads_blocked_today">---</span></h3>
+                <h3 class="statistic"><span id="queries_blocked_today">---</span></h3>
             </div>
             <div class="icon">
                 <i class="fas fa-hand-paper"></i>
@@ -60,7 +60,7 @@
         <div class="small-box bg-yellow">
             <div class="inner">
                 <p>Percent Blocked</p>
-                <h3 class="statistic"><span id="ads_percentage_today">---</span></h3>
+                <h3 class="statistic"><span id="percentage_blocked_today">---</span></h3>
             </div>
             <div class="icon">
                 <i class="fas fa-chart-pie"></i>

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -777,15 +777,24 @@ function updateSummaryData(runOnce) {
       updateTopLists();
     }
 
-    ["ads_blocked_today", "dns_queries_today", "ads_percentage_today", "unique_clients"].forEach(
-      function (today) {
-        var $todayElement = $("span#" + today);
-
-        if ($todayElement.text() !== data[today] && $todayElement.text() !== data[today] + "%") {
-          $todayElement.addClass("glow");
-        }
+    //Element name might have a different name to the property of the API so we split it at |
+    [
+      "ads_blocked_today|queries_blocked_today",
+      "dns_queries_today",
+      "ads_percentage_today|percentage_blocked_today",
+      "unique_clients",
+      "domains_being_blocked"
+    ].forEach(function (arrayItem, idx) {
+      var apiElName = arrayItem.split("|");
+      var apiName = apiElName[0];
+      var elName = apiElName[1];
+      var $todayElement = elName === null ? $("span#" + apiName) : $("span#" + elName);
+      var textData = idx === 2 && data[apiName] !== "to" ? data[apiName] + "%" : data[apiName];
+      if ($todayElement.text() !== textData && $todayElement.text() !== textData + "%") {
+        $todayElement.addClass("glow");
+        $todayElement.text(textData);
       }
-    );
+    });
 
     if (Object.prototype.hasOwnProperty.call(data, "dns_queries_all_types")) {
       $("#total_queries").prop(
@@ -795,16 +804,6 @@ function updateSummaryData(runOnce) {
     }
 
     window.setTimeout(function () {
-      [
-        "ads_blocked_today",
-        "dns_queries_today",
-        "domains_being_blocked",
-        "ads_percentage_today",
-        "unique_clients"
-      ].forEach(function (header, idx) {
-        var textData = idx === 3 && data[header] !== "to" ? data[header] + "%" : data[header];
-        $("span#" + header).text(textData);
-      });
       $("span.glow").removeClass("glow");
     }, 500);
   })


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Per https://github.com/pi-hole/AdminLTE/issues/1295 and [this thread on discourse](https://discourse.pi-hole.net/t/empty-values-for-queries-and-percentage-blocked-in-the-dashboard/32457)

Whilst technically "not our problem" it's simple enough to do and saves the occasional confusion when these two elements have no information in them.

Of course, we could also just change the names of the API properties, BUT that is more destructive to those that are using the API externally.