### PR TITLE
Remove an error log output that was presumably leftover from debugging

### DIFF
--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -36,9 +36,13 @@ function connectFTL($address, $port=4711)
 	{
 		$config = piholeFTLConfig();
 		// Read port
-		$portfile = file_get_contents($config["PORTFILE"]);
-		if(is_numeric($portfile))
-			$port = intval($portfile);
+		$portfileName = isset($config['PORTFILE']) ? $config['PORTFILE'] : '';
+		if ($portfileName != '')
+		{
+			$portfileContents = file_get_contents($portfileName);
+			if(is_numeric($portfileContents))
+				$port = intval($portfileContents);
+		}
 	}
 
 	// Open Internet socket connection
@@ -46,6 +50,7 @@ function connectFTL($address, $port=4711)
 
 	return $socket;
 }
+
 function sendRequestFTL($requestin)
 {
 	global $socket;

--- a/scripts/pi-hole/php/theme.php
+++ b/scripts/pi-hole/php/theme.php
@@ -42,7 +42,6 @@ $theme = $available_themes[$webtheme][2];
 $checkbox_theme_name = $available_themes[$webtheme][3];
 $checkbox_theme_variant = $available_themes[$webtheme][4];
 
-error_log(print_r($available_themes,true));
 function theme_selection() {
     global $available_themes, $webtheme;
     foreach ($available_themes as $key => $value) {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

With this line, this gets printed to the error log every time the page is loaded, looks to just be debug output, I might be wrong!

```
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr: Array
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr: (
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:     [default-light2] => Array
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:         (
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [0] => Pi-hole default theme (light, default)
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [1] =>
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [2] => default-light
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [3] => minimal
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [4] => blue
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:         )
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:     [default-dark] => Array
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:         (
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [0] => Pi-hole midnight theme (dark)
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [1] => 1
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [2] => default-dark
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [3] => polaris
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [4] => polaris
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:         )
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:     [default-dark2] => Array
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:         (
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [0] => Pi-hole afternoon theme (dark)
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [1] => 1
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [2] => default-dark
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [3] => futurico
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:             [4] => futurico
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr:         )
2020-05-18 16:57:14: (mod_fastcgi.c.421) FastCGI-stderr: )
```