### PR TITLE
Set default sort on DHCP lease tables to that of Hostname for ease of Access

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -173,7 +173,8 @@ $(document).ready(function () {
       paging: false,
       scrollCollapse: true,
       scrollY: "200px",
-      scrollX: true
+      scrollX: true,
+      order: [[2, "asc"]]
     });
   }
 
@@ -184,7 +185,8 @@ $(document).ready(function () {
       paging: false,
       scrollCollapse: true,
       scrollY: "200px",
-      scrollX: true
+      scrollX: true,
+      order: [[2, "asc"]]
     });
   }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

See [FR on Discourse](https://discourse.pi-hole.net/t/better-dhcp-admin/22115/9)

Thought about it, and it makes sense. One is more likely to sort by hostname or IP immediately upon loading the page. I don't think I know anybody that knows all of the devices on their network by MAC address 😏 