### PR TITLE
Add checkbox (save state in localstorage) to toggle between bar and smooth

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -828,9 +828,11 @@ $(document).ready(function () {
   var gridColor = $(".graphs-grid").css("background-color");
   var ticksColor = $(".graphs-ticks").css("color");
 
+  var graphType = localStorage.getItem("barchart_chkbox") === "true" ? "bar" : "line";
+
   var ctx = document.getElementById("queryOverTimeChart").getContext("2d");
   timeLineChart = new Chart(ctx, {
-    type: "bar",
+    type: graphType,
     data: {
       labels: [],
       datasets: [
@@ -948,7 +950,7 @@ $(document).ready(function () {
   if (clientsChartEl) {
     ctx = clientsChartEl.getContext("2d");
     clientsChart = new Chart(ctx, {
-      type: "bar",
+      type: graphType,
       data: {
         labels: [],
         datasets: [{ data: [] }]

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -240,3 +240,21 @@ $(document).ready(function () {
   input.setAttribute("autocapitalize", "off");
   input.setAttribute("spellcheck", false);
 });
+
+// Bar/Smooth chart toggle
+$(function () {
+  var chkbox_data = localStorage.getItem("barchart_chkbox");
+
+  if (chkbox_data !== null) {
+    // Restore checkbox state
+    $("#bargraphs").prop("checked", chkbox_data === "true");
+  } else {
+    // Initialize checkbox
+    $("#bargraphs").prop("checked", true);
+    localStorage.setItem("barchart_chkbox", true);
+  }
+
+  $("#bargraphs").click(function () {
+    localStorage.setItem("barchart_chkbox", $("#bargraphs").prop("checked"));
+  });
+});

--- a/settings.php
+++ b/settings.php
@@ -1099,6 +1099,8 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                 <h4>Interface appearance</h4>
                                                 <?php theme_selection(); ?>
                                                 <input type="checkbox" name="boxedlayout" id="boxedlayout" value="yes" <?php if ($boxedlayout){ ?>checked<?php } ?>><label for="boxedlayout">Use boxed layout (for large screens)</label>
+                                                <br/>
+                                                <input type="checkbox" name="bargraphs" id="bargraphs" value="yes"><label for="bargraphs">Use new Bar charts on dashboard</label>
                                                 <h4>CPU Temperature Unit</h4>
                                                 <input type="radio" name="tempunit" value="C" id="tempunit_C" <?php if ($temperatureunit === "C"){ ?>checked<?php } ?>><label for="tempunit_C">&nbsp;Celsius</label><br>
                                                 <input type="radio" name="tempunit" value="K" id="tempunit_K" <?php if ($temperatureunit === "K"){ ?>checked<?php } ?>><label for="tempunit_K">&nbsp;Kelvin</label><br>

--- a/settings.php
+++ b/settings.php
@@ -243,6 +243,9 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                 <li role="presentation"<?php if($tab === "api"){ ?> class="active"<?php } ?>>
                     <a href="#api" aria-controls="api" aria-expanded="<?php echo $tab === "api" ? "true" : "false"; ?>" role="tab" data-toggle="tab">API / Web interface</a>
                 </li>
+                <li role="presentation"<?php if($tab === "perbrowser"){ ?> class="active"<?php } ?>>
+                    <a href="#perbrowser" aria-controls="perbrowser" aria-expanded="<?php echo $tab === "perbrowser" ? "true" : "false"; ?>" role="tab" data-toggle="tab">Per Browser Settings</a>
+                </li>
                 <li role="presentation"<?php if($tab === "privacy"){ ?> class="active"<?php } ?>>
                     <a href="#privacy" aria-controls="privacy" aria-expanded="<?php echo $tab === "privacy" ? "true" : "false"; ?>" role="tab" data-toggle="tab">Privacy</a>
                 </li>
@@ -1099,8 +1102,6 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                 <h4>Interface appearance</h4>
                                                 <?php theme_selection(); ?>
                                                 <input type="checkbox" name="boxedlayout" id="boxedlayout" value="yes" <?php if ($boxedlayout){ ?>checked<?php } ?>><label for="boxedlayout">Use boxed layout (for large screens)</label>
-                                                <br/>
-                                                <input type="checkbox" name="bargraphs" id="bargraphs" value="yes"><label for="bargraphs">Use new Bar charts on dashboard</label>
                                                 <h4>CPU Temperature Unit</h4>
                                                 <input type="radio" name="tempunit" value="C" id="tempunit_C" <?php if ($temperatureunit === "C"){ ?>checked<?php } ?>><label for="tempunit_C">&nbsp;Celsius</label><br>
                                                 <input type="radio" name="tempunit" value="K" id="tempunit_K" <?php if ($temperatureunit === "K"){ ?>checked<?php } ?>><label for="tempunit_K">&nbsp;Kelvin</label><br>
@@ -1117,6 +1118,25 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                     </div>
                                 </div>
                             </form>
+                        </div>
+                    </div>
+                </div>
+                <!-- ######################################################### Per Browser Settings (not saved in setupVars) #############################-->
+                <div id="perbrowser" class="tab-pane fade<?php if($tab === "perbrowser"){ ?> in active<?php } ?>">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <div class="box box-warning">
+                                <div class="box-header with-border">
+                                    <h3 class="box-title">UI/Interface</h3>
+                                </div>
+                                <div class="box-body">
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <input type="checkbox" name="bargraphs" id="bargraphs" value="yes"><label for="bargraphs">Use new Bar charts on dashboard</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Title

![pleasingeveryone](https://user-images.githubusercontent.com/1998970/82251706-97fdb080-9945-11ea-88dd-b972e56dc6ab.gif)

uses `localstorage` no need to save this in `setupVars`, which allows for multiple users of the dashboard (from different computers) to toggle to their preference. 

Could do the same with  boxed layout maybe... 