### PR TITLE
Remember last used sort column/direction on DHCP lease tables

### DIFF
--- a/groups-domains.php
+++ b/groups-domains.php
@@ -40,7 +40,7 @@
                         <li role="presentation">
                             <a href="#tab_regex" aria-controls="tab_regex" aria-expanded="false" role="tab" data-toggle="tab">RegEx filter</a>
                         </li>
-                    </ul>        
+                    </ul>
                     <div class="tab-content">
                         <!-- Domain tab -->
                         <div id="tab_domain" class="tab-pane active fade in">

--- a/network.php
+++ b/network.php
@@ -77,5 +77,6 @@ $token = $_SESSION['token'];
     require "scripts/pi-hole/php/footer.php";
 ?>
 
+<script src="scripts/pi-hole/js/utils.js"></script>
 <script src="scripts/pi-hole/js/ip-address-sorting.js"></script>
 <script src="scripts/pi-hole/js/network.js"></script>

--- a/queries.php
+++ b/queries.php
@@ -156,6 +156,7 @@ if(strlen($showing) > 0)
 </div>
 <!-- /.row -->
 
+<script src="scripts/pi-hole/js/utils.js"></script>
 <script src="scripts/pi-hole/js/queries.js"></script>
 
 <?php

--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -172,22 +172,10 @@ function initTable() {
     ],
     stateSave: true,
     stateSaveCallback: function (settings, data) {
-      // Store current state in client's local storage area
-      localStorage.setItem("groups-adlists-table", JSON.stringify(data));
+      utils.stateSaveCallback("groups-adlists-table", data);
     },
     stateLoadCallback: function () {
-      // Receive previous state from client's local storage area
-      var data = localStorage.getItem("groups-adlists-table");
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
-      data = JSON.parse(data);
-      // Always start on the first page to show most recent queries
-      data.start = 0;
-      // Always start with empty search field
-      data.search.search = "";
+      var data = utils.stateLoadCallback("groups-adlists-table");
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Apply loaded state to table

--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -206,22 +206,10 @@ function initTable() {
     ],
     stateSave: true,
     stateSaveCallback: function (settings, data) {
-      // Store current state in client's local storage area
-      localStorage.setItem("groups-clients-table", JSON.stringify(data));
+      utils.stateSaveCallback("groups-clients-table", data);
     },
     stateLoadCallback: function () {
-      // Receive previous state from client's local storage area
-      var data = localStorage.getItem("groups-clients-table");
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
-      data = JSON.parse(data);
-      // Always start on the first page to show most recent queries
-      data.start = 0;
-      // Always start with empty search field
-      data.search.search = "";
+      var data = utils.stateLoadCallback("groups-clients-table");
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Apply loaded state to table

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -247,22 +247,10 @@ function initTable() {
     ],
     stateSave: true,
     stateSaveCallback: function (settings, data) {
-      // Store current state in client's local storage area
-      localStorage.setItem("groups-domains-table", JSON.stringify(data));
+      utils.stateSaveCallback("groups-domains-table", data);
     },
     stateLoadCallback: function () {
-      // Receive previous state from client's local storage area
-      var data = localStorage.getItem("groups-domains-table");
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
-      data = JSON.parse(data);
-      // Always start on the first page to show most recent queries
-      data.start = 0;
-      // Always start with empty search field
-      data.search.search = "";
+      var data = utils.stateLoadCallback("groups-domains-table");
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Show group assignment column only on full page

--- a/scripts/pi-hole/js/groups.js
+++ b/scripts/pi-hole/js/groups.js
@@ -87,22 +87,10 @@ $(document).ready(function () {
     ],
     stateSave: true,
     stateSaveCallback: function (settings, data) {
-      // Store current state in client's local storage area
-      localStorage.setItem("groups-table", JSON.stringify(data));
+      utils.stateSaveCallback("groups-table", data);
     },
     stateLoadCallback: function () {
-      // Receive previous state from client's local storage area
-      var data = localStorage.getItem("groups-table");
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
-      data = JSON.parse(data);
-      // Always start on the first page to show most recent queries
-      data.start = 0;
-      // Always start with empty search field
-      data.search.search = "";
+      var data = utils.stateLoadCallback("groups-table");
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Apply loaded state to table

--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -95,23 +95,10 @@ $(document).ready(function () {
     },
     stateSave: true,
     stateSaveCallback: function (settings, data) {
-      // Store current state in client's local storage area
-      localStorage.setItem("messages-table", JSON.stringify(data));
+      utils.stateSaveCallback("messages-table", data);
     },
     stateLoadCallback: function () {
-      // Receive previous state from client's local storage area
-      var data = localStorage.getItem("messages-table");
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
-      // Parse loaded data
-      data = JSON.parse(data);
-      // Always start on the first page to show most recent queries
-      data.start = 0;
-      // Always start with empty search field
-      data.search.search = "";
+      var data = utils.stateLoadCallback("messages-table");
       // Reset visibility of ID and blob columns
       var hiddenCols = [0, 4, 5, 6, 7, 8];
       for (var key in hiddenCols) {

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license.  */
 
-/* global moment:false */
+/* global moment:false, utils:false */
 
 var tableApi;
 
@@ -186,24 +186,10 @@ $(document).ready(function () {
     ],
     stateSave: true,
     stateSaveCallback: function (settings, data) {
-      // Store current state in client's local storage area
-      localStorage.setItem("network_table", JSON.stringify(data));
+      utils.stateSaveCallback("network_table", data);
     },
     stateLoadCallback: function () {
-      // Receive previous state from client's local storage area
-      var data = localStorage.getItem("network_table");
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
-      data = JSON.parse(data);
-      // Always start on the first page
-      data.start = 0;
-      // Always start with empty search field
-      data.search.search = "";
-      // Apply loaded state to table
-      return data;
+      return utils.stateLoadCallback("network_table");
     },
     columnDefs: [
       {

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license.  */
 
-/* global moment:false */
+/* global moment:false, utils:false */
 
 var tableApi;
 
@@ -399,24 +399,10 @@ $(document).ready(function () {
     ],
     stateSave: true,
     stateSaveCallback: function (settings, data) {
-      // Store current state in client's local storage area
-      localStorage.setItem("query_log_table", JSON.stringify(data));
+      utils.stateSaveCallback("query_log_table", data);
     },
     stateLoadCallback: function () {
-      // Receive previous state from client's local storage area
-      var data = localStorage.getItem("query_log_table");
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
-      data = JSON.parse(data);
-      // Always start on the first page to show most recent queries
-      data.start = 0;
-      // Always start with empty search field
-      data.search.search = "";
-      // Apply loaded state to table
-      return data;
+      return utils.stateLoadCallback("query_log_table");
     },
     columnDefs: [
       {

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -174,7 +174,8 @@ $(document).ready(function () {
       scrollCollapse: true,
       scrollY: "200px",
       scrollX: true,
-      order: [[2, "asc"]]
+      order: [[2, "asc"]],
+      stateSave: true
     });
   }
 
@@ -186,7 +187,8 @@ $(document).ready(function () {
       scrollCollapse: true,
       scrollY: "200px",
       scrollX: true,
-      order: [[2, "asc"]]
+      order: [[2, "asc"]],
+      stateSave: true
     });
   }
 

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -175,7 +175,27 @@ $(document).ready(function () {
       scrollY: "200px",
       scrollX: true,
       order: [[2, "asc"]],
-      stateSave: true
+      stateSave: true,
+      stateSaveCallback: function(settings, data) {
+        // Store current state in client's local storage area
+        localStorage.setItem("activeDhcpLeaseTable", JSON.stringify(data));
+      },
+      stateLoadCallback: function() {
+        // Receive previous state from client's local storage area
+        var data = localStorage.getItem("activeDhcpLeaseTable");
+        // Return if not available
+        if (data === null) {
+          return null;
+        }
+
+        data = JSON.parse(data);
+        // Always start on the first page to show most recent queries
+        data.start = 0;
+        // Always start with empty search field
+        data.search.search = "";
+        // Apply loaded state to table
+        return data;
+      }
     });
   }
 
@@ -188,7 +208,27 @@ $(document).ready(function () {
       scrollY: "200px",
       scrollX: true,
       order: [[2, "asc"]],
-      stateSave: true
+      stateSave: true,
+      stateSaveCallback: function(settings, data) {
+        // Store current state in client's local storage area
+        localStorage.setItem("staticDhcpLeaseTable", JSON.stringify(data));
+      },
+      stateLoadCallback: function() {
+        // Receive previous state from client's local storage area
+        var data = localStorage.getItem("staticDhcpLeaseTable");
+        // Return if not available
+        if (data === null) {
+          return null;
+        }
+
+        data = JSON.parse(data);
+        // Always start on the first page to show most recent queries
+        data.start = 0;
+        // Always start with empty search field
+        data.search.search = "";
+        // Apply loaded state to table
+        return data;
+      }
     });
   }
 

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -5,6 +5,8 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
+/* global utils:false */
+
 $(function () {
   $("[data-static]").on("click", function () {
     var row = $(this).closest("tr");
@@ -176,25 +178,11 @@ $(document).ready(function () {
       scrollX: true,
       order: [[2, "asc"]],
       stateSave: true,
-      stateSaveCallback: function(settings, data) {
-        // Store current state in client's local storage area
-        localStorage.setItem("activeDhcpLeaseTable", JSON.stringify(data));
+      stateSaveCallback: function (settings, data) {
+        utils.stateSaveCallback("activeDhcpLeaseTable", data);
       },
-      stateLoadCallback: function() {
-        // Receive previous state from client's local storage area
-        var data = localStorage.getItem("activeDhcpLeaseTable");
-        // Return if not available
-        if (data === null) {
-          return null;
-        }
-
-        data = JSON.parse(data);
-        // Always start on the first page to show most recent queries
-        data.start = 0;
-        // Always start with empty search field
-        data.search.search = "";
-        // Apply loaded state to table
-        return data;
+      stateLoadCallback: function () {
+        return utils.stateLoadCallback("activeDhcpLeaseTable");
       }
     });
   }
@@ -209,25 +197,11 @@ $(document).ready(function () {
       scrollX: true,
       order: [[2, "asc"]],
       stateSave: true,
-      stateSaveCallback: function(settings, data) {
-        // Store current state in client's local storage area
-        localStorage.setItem("staticDhcpLeaseTable", JSON.stringify(data));
+      stateSaveCallback: function (settings, data) {
+        utils.stateSaveCallback("staticDhcpLeaseTable", data);
       },
-      stateLoadCallback: function() {
-        // Receive previous state from client's local storage area
-        var data = localStorage.getItem("staticDhcpLeaseTable");
-        // Return if not available
-        if (data === null) {
-          return null;
-        }
-
-        data = JSON.parse(data);
-        // Always start on the first page to show most recent queries
-        data.start = 0;
-        // Always start with empty search field
-        data.search.search = "";
-        // Apply loaded state to table
-        return data;
+      stateLoadCallback: function () {
+        return utils.stateLoadCallback("staticDhcpLeaseTable");
       }
     });
   }

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -149,6 +149,27 @@ function setBsSelectDefaults() {
   };
 }
 
+function stateSaveCallback(itemName, data) {
+  localStorage.setItem(itemName, JSON.stringify(data));
+}
+
+function stateLoadCallback(itemName) {
+  // Receive previous state from client's local storage area
+  var data = localStorage.getItem(itemName);
+  // Return if not available
+  if (data === null) {
+    return null;
+  }
+
+  data = JSON.parse(data);
+  // Always start on the first page to show most recent queries
+  data.start = 0;
+  // Always start with empty search field
+  data.search.search = "";
+  // Apply loaded state to table
+  return data;
+}
+
 window.utils = (function () {
   return {
     showAlert: showAlert,
@@ -157,6 +178,8 @@ window.utils = (function () {
     enableAll: enableAll,
     validateIPv4CIDR: validateIPv4CIDR,
     validateIPv6CIDR: validateIPv6CIDR,
-    setBsSelectDefaults: setBsSelectDefaults
+    setBsSelectDefaults: setBsSelectDefaults,
+    stateSaveCallback: stateSaveCallback,
+    stateLoadCallback: stateLoadCallback
   };
 })();

--- a/settings.php
+++ b/settings.php
@@ -1256,6 +1256,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
 </div>
 
 <script src="scripts/vendor/jquery.confirm.min.js"></script>
+<script src="scripts/pi-hole/js/utils.js"></script>
 <script src="scripts/pi-hole/js/settings.js"></script>
 
 <?php


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Reference [here](https://discourse.pi-hole.net/t/better-dhcp-admin/22115/13?u=promofaux).

Remember the last used sort column/direction for the DHCP lease tables. Does what it says on the tin.

Is there any value in adding this flag to other datatables, do you think?