### PR TITLE
Whitelist CNAME blocks correctly

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -503,7 +503,13 @@ $(document).ready(function () {
     if (data[4] === "2" || data[4] === "3") {
       add(data[2], "black");
     } else {
-      add(data[2], "white");
+      var domainToWhitelist = data[2];
+      if (data[4] === "9" || data[4] === "10" || data[4] === "11") {
+        // whitelist the CNAME on CNAME blocks
+        domainToWhitelist = data[8];
+      }
+
+      add(domainToWhitelist, "white");
     }
   });
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
In the latest version whitelisting a blocked query for domain A, which was blocked because of a CNAME block of domain B, caused domain A to be added to the whitelist. This was most likely not intended as the query for domain A is still blocked after whitelisting.

Can be e.g. with `www.der-postillon.com` which is a CNAME record of `ssl.marfeelcdn.com` which is on some blocklists: 
```
$ host www.der-postillon.com
www.der-postillon.com is an alias for ssl.marfeelcdn.com.
ssl.marfeelcdn.com is an alias for marfeel.map.fastly.net.
```

This PR uses the CNAME domain from the block which is also shown in the UI on CNAME blocks to whitelist the correct domain:
<img width="183" alt="grafik" src="https://user-images.githubusercontent.com/3075401/82379957-074bd100-9a28-11ea-8a7f-0e0062bb4c24.png">
On Whitelisting:
<img width="250" alt="grafik" src="https://user-images.githubusercontent.com/3075401/82380323-8f31db00-9a28-11ea-966e-bf650e1976dc.png">


**How does this PR accomplish the above?:**
Before calling the function to whitelist the domain I added a check if this is a CNAME record. This check uses the same checks as [further up](https://github.com/pi-hole/AdminLTE/blob/0f9f33cb1436e0088f6ba6934b4cdd2eeaf82f2b/scripts/pi-hole/js/queries.js#L229-L257) (check if `data[4]` is `"9"`, `"10"` or `"11"`] which is IMO really ugly as it duplicates the `isCNAME` logic  and uses an array with indices instead of more speaking objects where a field with value `isCNAME` could have been set.

I tested this with all three CNAME blocks (gravity, exact, regex).

As ugly as it is it is probably the easiest way to fix this and still quite consistent (similar checks are also made 2-3 lines above my changes), for a better solution there are IMO greater changes necessary, but I don't really have a clue about this codebase, but suggestions are always welcome of course.

**What documentation changes (if any) are needed to support this PR?:**
_none_