### PR TITLE
Properly delete the `persistentlogin` cookie

### DIFF
--- a/scripts/pi-hole/php/password.php
+++ b/scripts/pi-hole/php/password.php
@@ -28,7 +28,7 @@
     if(isset($_GET["logout"]))
     {
         session_unset();
-        setcookie('persistentlogin', '');
+        setcookie('persistentlogin', '', 1);
         header('Location: index.php');
         exit();
     }
@@ -52,7 +52,7 @@
             {
                 // Invalid cookie
                 $auth = false;
-                setcookie('persistentlogin', '');
+                setcookie('persistentlogin', '', 1);
             }
         }
         // Compare doubly hashes password input with saved hash


### PR DESCRIPTION
The previous solution did not delete the cookie.

Signed-off-by: XhmikosR <xhmikosr@gmail.com>

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

Refs https://github.com/pi-hole/AdminLTE/issues/1256#issuecomment-632687130

So, in v5.0, logging out still leaves a cookie. This patch fixes this, but maybe we should be stricter with the cookie path also?

This is after logging out with v5.0:

<img src="https://user-images.githubusercontent.com/349621/82672813-8704b600-9c49-11ea-8e8c-49dfdeb61daa.jpg" alt="2020-05-22_16-27-57" width="450">