### PR TITLE
Replace custom httpGet() with $.ajax()

### DIFF
--- a/scripts/pi-hole/js/debug.js
+++ b/scripts/pi-hole/js/debug.js
@@ -5,31 +5,6 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global ActiveXObject: false */
-
-// Credit: http://stackoverflow.com/a/10642418/2087442
-function httpGet(ta, theUrl) {
-  var xmlhttp;
-  if (window.XMLHttpRequest) {
-    // code for IE7+
-    xmlhttp = new XMLHttpRequest();
-  } else {
-    // code for IE6, IE5
-    xmlhttp = new ActiveXObject("Microsoft.XMLHTTP");
-  }
-
-  xmlhttp.onreadystatechange = function () {
-    if (xmlhttp.readyState === 4 && xmlhttp.status === 200) {
-      ta.show();
-      ta.empty();
-      ta.append(xmlhttp.responseText);
-    }
-  };
-
-  xmlhttp.open("GET", theUrl, false);
-  xmlhttp.send();
-}
-
 function eventsource() {
   var ta = $("#output");
   var upload = $("#upload");
@@ -42,7 +17,15 @@ function eventsource() {
 
   // IE does not support EventSource - load whole content at once
   if (typeof EventSource !== "function") {
-    httpGet(ta, "scripts/pi-hole/php/debug.php?IE&token=" + token + "&" + checked);
+    $.ajax({
+      method: "GET",
+      url: "scripts/pi-hole/php/debug.php?IE&token=" + token + "&" + checked,
+      async: false
+    }).done(function (data) {
+      ta.show();
+      ta.empty();
+      ta.append(data);
+    });
     return;
   }
 

--- a/scripts/pi-hole/js/queryads.js
+++ b/scripts/pi-hole/js/queryads.js
@@ -5,8 +5,6 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global ActiveXObject: false */
-
 var exact = "";
 
 function quietfilter(ta, data) {
@@ -19,33 +17,6 @@ function quietfilter(ta, data) {
       ta.append(shortstring + "\n");
     }
   }
-}
-
-// Credit: http://stackoverflow.com/a/10642418/2087442
-function httpGet(ta, quiet, theUrl) {
-  var xmlhttp;
-  if (window.XMLHttpRequest) {
-    // code for IE7+
-    xmlhttp = new XMLHttpRequest();
-  } else {
-    // code for IE6, IE5
-    xmlhttp = new ActiveXObject("Microsoft.XMLHTTP");
-  }
-
-  xmlhttp.onreadystatechange = function () {
-    if (xmlhttp.readyState === 4 && xmlhttp.status === 200) {
-      ta.show();
-      ta.empty();
-      if (!quiet) {
-        ta.append(xmlhttp.responseText);
-      } else {
-        quietfilter(ta, xmlhttp.responseText);
-      }
-    }
-  };
-
-  xmlhttp.open("GET", theUrl, false);
-  xmlhttp.send();
 }
 
 function eventsource() {
@@ -65,11 +36,19 @@ function eventsource() {
 
   // IE does not support EventSource - load whole content at once
   if (typeof EventSource !== "function") {
-    httpGet(
-      ta,
-      quiet,
-      "scripts/pi-hole/php/queryads.php?domain=" + domain.toLowerCase() + exact + "&IE"
-    );
+    $.ajax({
+      method: "GET",
+      url: "scripts/pi-hole/php/queryads.php?domain=" + domain.toLowerCase() + exact + "&IE",
+      async: false
+    }).done(function (data) {
+      ta.show();
+      ta.empty();
+      if (!quiet) {
+        ta.append(data);
+      } else {
+        quietfilter(ta, data);
+      }
+    });
     return;
   }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Remove custom code using `XMLHttpRequest` in favor of using jQuery
Resolves #1349

**How does this PR accomplish the above?:**

Utilize `$.ajax()` to make GET request rather than creating/using `XMLHttpRequest`

Note: Comments in the code suggested `ActiveXObject` was being used in order to maintain IE5/IE6 compatibility, however the admin portal seemed not to function below IE9 so I did not take this into consideration.

**What documentation changes (if any) are needed to support this PR?:**

None
