### PR TITLE
Fix default setting on graph types to be "bar" not "line"

### DIFF
--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -151,7 +151,7 @@ $(function () {
   var blockedColor = "#999";
   var permittedColor = "#00a65a";
   timeLineChart = new Chart(ctx, {
-    type: "bar",
+    type: utils.getGraphType(),
     data: {
       labels: [],
       datasets: [

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -783,12 +783,9 @@ $(function () {
   var permittedColor = $(".queries-permitted").css("background-color");
   var gridColor = $(".graphs-grid").css("background-color");
   var ticksColor = $(".graphs-ticks").css("color");
-
-  var graphType = localStorage.getItem("barchart_chkbox") === "true" ? "bar" : "line";
-
   var ctx = document.getElementById("queryOverTimeChart").getContext("2d");
   timeLineChart = new Chart(ctx, {
-    type: graphType,
+    type: utils.getGraphType(),
     data: {
       labels: [],
       datasets: [
@@ -906,7 +903,7 @@ $(function () {
   if (clientsChartEl) {
     ctx = clientsChartEl.getContext("2d");
     clientsChart = new Chart(ctx, {
-      type: graphType,
+      type: utils.getGraphType(),
       data: {
         labels: [],
         datasets: [{ data: [] }]

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -207,6 +207,11 @@ function stateLoadCallback(itemName) {
   return data;
 }
 
+function getGraphType() {
+  // Only return line if `barchart_chkbox` is explicitly set to false. Else return bar
+  return localStorage.getItem("barchart_chkbox") === "false" ? "line" : "bar";
+}
+
 window.utils = (function () {
   return {
     escapeHtml: escapeHtml,
@@ -220,6 +225,7 @@ window.utils = (function () {
     validateIPv6CIDR: validateIPv6CIDR,
     setBsSelectDefaults: setBsSelectDefaults,
     stateSaveCallback: stateSaveCallback,
-    stateLoadCallback: stateLoadCallback
+    stateLoadCallback: stateLoadCallback,
+    getGraphType: getGraphType
   };
 })();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Currently if there is nothing stored in localStorage, then the graphs will default to "line" until the settings page is loaded... This flips the logic to default to the (developer desired) "bar". 

Also functionise the logic for reading it out as it is used in three places