### PR TITLE
Show "zero" delays in the Query Log

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -351,7 +351,7 @@ $(function () {
 
       $("td:eq(5)", row).html(replytext);
 
-      if (data.length > 7 && data[7] > 0) {
+      if (data.length > 7) {
         var content = $("td:eq(5)", row).html();
         $("td:eq(5)", row).html(content + " (" + (0.1 * data[7]).toFixed(1) + "ms)");
       }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

See title.

Wrong:
![Screenshot from 2020-06-02 13-21-44](https://user-images.githubusercontent.com/16748619/83514609-3d7f5b00-a4d4-11ea-8a76-22e231da6765.png)

Correct:
![Screenshot from 2020-06-02 13-22-14](https://user-images.githubusercontent.com/16748619/83514607-3c4e2e00-a4d4-11ea-93a2-3987ab560e75.png)


**How does this PR accomplish the above?:**

On fast machines, cache replies can be served within less than 100 nanoseconds. The query log should show "(0.0ms)" in this case instead of hiding the value altogether.

**What documentation changes (if any) are needed to support this PR?:**

None