### PR TITLE
Fix regression introduced in group entry changes

### DIFF
--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -41,37 +41,6 @@ function JSON_error($message = null)
     echo json_encode($response);
 }
 
-function space_aware_explode($input)
-{
-    $ret = array();
-    $quoted = false;
-    $pos = 0;
-
-    // Loop over input string
-    for ($i = 0; $i < strlen($input); $i++)
-    {
-        // Get current character
-        $c = $input[$i];
-
-        // If current character is a space (or comma) and we're outside
-        // of a quoted region, we accept this character as separator
-        if (($c == ' ' || $c == ',') && !$quoted) {
-            $ret[] = str_replace('"', '', substr($input, $pos, $i - $pos));
-            $pos = $i+1;
-        }
-        elseif($c == '"' && !$quoted)
-            $quoted = true; // Quotation begins
-        elseif($c == '"' && $quoted)
-            $quoted = false; // Quotation ends here
-    }
-    // Get last element of the string
-    if ($pos > 0) {
-        $ret[] = substr($input, $pos);
-    }
-
-    return $ret;
-}
-
 if ($_POST['action'] == 'get_groups') {
     // List all available groups
     try {
@@ -89,7 +58,7 @@ if ($_POST['action'] == 'get_groups') {
 } elseif ($_POST['action'] == 'add_group') {
     // Add new group
     try {
-        $names = space_aware_explode(trim($_POST['name']));
+        $names = str_getcsv(trim($_POST['name']), ' ');
         $total = count($names);
         $added = 0;
         $stmt = $db->prepare('INSERT INTO "group" (name,description) VALUES (:name,:desc)');


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Something missed in testing - currently on `devel` one cannot enter a single group name, in digging into the `space_aware_explode` function, I came across this PHP builtin (5.3 +):

https://www.php.net/manual/en/function.str-getcsv.php

Does the intended job, and even accounts for quoted group names