### PR TITLE
Extend warning shown on server-side data processing errors

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -142,7 +142,11 @@ function handleAjaxError(xhr, textStatus) {
   } else if (xhr.responseText.indexOf("Connection refused") !== -1) {
     alert("An error occurred while loading the data: Connection refused. Is FTL running?");
   } else {
-    alert("An unknown error occurred while loading the data.\n" + xhr.responseText);
+    alert(
+      "An unknown error occurred while loading the data.\n" +
+        xhr.responseText +
+        "\nCheck the server's log files (/var/log/lighttpd/error.log when you're using the default Pi-hole web server) for details. You may need to increase the memory available for Pi-hole in case you requested a lot of data."
+    );
   }
 
   $("#all-queries_processing").hide();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Improve error message commonly seen when long-term queries lead to PHP running out of memory. This has been discussed on Discourse.

![Screenshot from 2020-06-04 14-44-49](https://user-images.githubusercontent.com/16748619/83759009-36428380-a673-11ea-9d9e-da65d7557550.png)


**How does this PR accomplish the above?:**

Extend warning shown on server-side data processing errors.

**What documentation changes (if any) are needed to support this PR?:**

None