### PR TITLE
Move scripts to the footer.

### DIFF
--- a/auditlog.php
+++ b/auditlog.php
@@ -72,9 +72,11 @@
 </div>
 <!-- /.row -->
 
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/auditlog.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/auditlog.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/cname_records.php
+++ b/cname_records.php
@@ -94,9 +94,11 @@
     </div>
 </div>
 
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/customcname.js?v=<?=$cacheVer?>"></script>
-
 <?php
-require "scripts/pi-hole/php/footer.php";
+    $extra_scripts = [
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/customcname.js?v=<?=$cacheVer?>"
+    ];
+
+    require "scripts/pi-hole/php/footer.php";
 ?>

--- a/db_graph.php
+++ b/db_graph.php
@@ -67,10 +67,12 @@
   </div>
 </div>
 
-<script src="scripts/vendor/daterangepicker.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/db_graph.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/vendor/daterangepicker.min.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/db_graph.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/db_lists.php
+++ b/db_lists.php
@@ -139,10 +139,12 @@ else
     <!-- /.col -->
 </div>
 
-<script src="scripts/vendor/daterangepicker.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/db_lists.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/vendor/daterangepicker.min.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/db_lists.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/db_queries.php
+++ b/db_queries.php
@@ -194,11 +194,14 @@
     </div>
 </div>
 <!-- /.row -->
-<script src="scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/vendor/daterangepicker.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/db_queries.js?v=<?=$cacheVer?>"></script>
 
 <?php
+    $extra_scripts = [
+        "scripts/vendor/daterangepicker.min.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/db_queries.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/debug.php
+++ b/debug.php
@@ -19,8 +19,10 @@
 <button type="button" id="debugBtn" class="btn btn-lg btn-primary btn-block">Generate debug log</button>
 <pre id="output" style="width: 100%; height: 100%;" hidden></pre>
 
-<script src="scripts/pi-hole/js/debug.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/debug.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/dns_records.php
+++ b/dns_records.php
@@ -89,10 +89,12 @@
     </div>
 </div>
 
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/customdns.js?v=<?=$cacheVer?>"></script>
-
 <?php
-require "scripts/pi-hole/php/footer.php";
+    $extra_scripts = [
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/customdns.js?v=<?=$cacheVer?>"
+    ];
+
+    require "scripts/pi-hole/php/footer.php";
 ?>

--- a/gravity.php
+++ b/gravity.php
@@ -25,8 +25,10 @@
 <button type="button" id="gravityBtn" class="btn btn-lg btn-primary btn-block">Update</button>
 <pre id="output" style="width: 100%; height: 100%;" hidden></pre>
 
-<script src="scripts/pi-hole/js/gravity.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/gravity.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/groups-adlists.php
+++ b/groups-adlists.php
@@ -77,11 +77,13 @@
     </div>
 </div>
 
-<script src="scripts/vendor/bootstrap-select.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/vendor/bootstrap-toggle.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/groups-adlists.js?v=<?=$cacheVer?>"></script>
-
 <?php
-require "scripts/pi-hole/php/footer.php";
+    $extra_scripts = [
+        "scripts/vendor/bootstrap-select.min.js?v=<?=$cacheVer?>",
+        "scripts/vendor/bootstrap-toggle.min.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/groups-adlists.js?v=<?=$cacheVer?>"
+    ];
+
+    require "scripts/pi-hole/php/footer.php";
 ?>

--- a/groups-clients.php
+++ b/groups-clients.php
@@ -85,12 +85,14 @@
     </div>
 </div>
 
-<script src="scripts/vendor/bootstrap-select.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/vendor/bootstrap-toggle.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/groups-clients.js?v=<?=$cacheVer?>"></script>
-
 <?php
-require "scripts/pi-hole/php/footer.php";
+    $extra_scripts = [
+        "scripts/vendor/bootstrap-select.min.js?v=<?=$cacheVer?>",
+        "scripts/vendor/bootstrap-toggle.min.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/groups-clients.js?v=<?=$cacheVer?>"
+    ];
+
+    require "scripts/pi-hole/php/footer.php";
 ?>

--- a/groups-domains.php
+++ b/groups-domains.php
@@ -138,11 +138,13 @@
     </div>
 </div>
 
-<script src="scripts/vendor/bootstrap-select.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/vendor/bootstrap-toggle.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/groups-domains.js?v=<?=$cacheVer?>"></script>
-
 <?php
-require "scripts/pi-hole/php/footer.php";
+    $extra_scripts = [
+        "scripts/vendor/bootstrap-select.min.js?v=<?=$cacheVer?>",
+        "scripts/vendor/bootstrap-toggle.min.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/groups-domains.js?v=<?=$cacheVer?>"
+    ];
+
+    require "scripts/pi-hole/php/footer.php";
 ?>

--- a/groups.php
+++ b/groups.php
@@ -76,11 +76,13 @@
     </div>
 </div>
 
-<script src="scripts/vendor/bootstrap-select.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/vendor/bootstrap-toggle.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/groups.js?v=<?=$cacheVer?>"></script>
-
 <?php
-require "scripts/pi-hole/php/footer.php";
+    $extra_scripts = [
+        "scripts/vendor/bootstrap-select.min.js?v=<?=$cacheVer?>",
+        "scripts/vendor/bootstrap-toggle.min.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/groups.js?v=<?=$cacheVer?>"
+    ];
+
+    require "scripts/pi-hole/php/footer.php";
 ?>

--- a/index.php
+++ b/index.php
@@ -294,9 +294,11 @@ else
 <!-- /.row -->
 <?php } ?>
 
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/index.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/index.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/messages.php
+++ b/messages.php
@@ -41,9 +41,11 @@
     </div>
 </div>
 
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/messages.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/messages.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/network.php
+++ b/network.php
@@ -66,10 +66,12 @@
 </div>
 <!-- /.row -->
 
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/network.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/network.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/queries.php
+++ b/queries.php
@@ -171,10 +171,13 @@ if(strlen($showing) > 0)
     </div>
 </div>
 <!-- /.row -->
-<script src="scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/queries.js?v=<?=$cacheVer?>"></script>
 
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/ip-address-sorting.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/queries.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/queryads.php
+++ b/queryads.php
@@ -43,8 +43,10 @@
 
 <pre id="output" style="width: 100%; height: 100%;" hidden></pre>
 
-<script src="scripts/pi-hole/js/queryads.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/queryads.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -99,6 +99,23 @@
 
 </div>
 <!-- ./wrapper -->
+
+<script src="scripts/vendor/jquery.min.js?v=<?=$cacheVer?>"></script>
+<script src="style/vendor/bootstrap/js/bootstrap.min.js?v=<?=$cacheVer?>"></script>
+<script src="scripts/vendor/adminlte.min.js?v=<?=$cacheVer?>"></script>
+<script src="scripts/vendor/bootstrap-notify.min.js?v=<?=$cacheVer?>"></script>
+<script src="scripts/vendor/select2.min.js?v=<?=$cacheVer?>"></script>
+<script src="scripts/vendor/datatables.min.js?v=<?=$cacheVer?>"></script>
+<script src="scripts/vendor/moment.min.js?v=<?=$cacheVer?>"></script>
+<script src="scripts/vendor/Chart.min.js?v=<?=$cacheVer?>"></script>
+
 <script src="scripts/pi-hole/js/footer.js?v=<?=$cacheVer?>"></script>
+
+<?php if (isset($extra_scripts)) {
+    foreach($extra_scripts as $script){
+        echo "<script src=" . $script . "></script>";
+    }
+}
+?>
 </body>
 </html>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -203,15 +203,6 @@
     <link rel="stylesheet" href="style/pi-hole.css?v=<?=$cacheVer?>">
     <link rel="stylesheet" href="style/themes/<?php echo $theme; ?>.css?v=<?=$cacheVer?>">
     <noscript><link rel="stylesheet" href="style/vendor/js-warn.css?v=<?=$cacheVer?>"></noscript>
-
-    <script src="scripts/vendor/jquery.min.js?v=<?=$cacheVer?>"></script>
-    <script src="style/vendor/bootstrap/js/bootstrap.min.js?v=<?=$cacheVer?>"></script>
-    <script src="scripts/vendor/adminlte.min.js?v=<?=$cacheVer?>"></script>
-    <script src="scripts/vendor/bootstrap-notify.min.js?v=<?=$cacheVer?>"></script>
-    <script src="scripts/vendor/select2.min.js?v=<?=$cacheVer?>"></script>
-    <script src="scripts/vendor/datatables.min.js?v=<?=$cacheVer?>"></script>
-    <script src="scripts/vendor/moment.min.js?v=<?=$cacheVer?>"></script>
-    <script src="scripts/vendor/Chart.min.js?v=<?=$cacheVer?>"></script>
     <script src="style/vendor/font-awesome/js/all.min.js?v=<?=$cacheVer?>"></script>
 </head>
 <body class="hold-transition sidebar-mini <?php if($boxedlayout){ ?>layout-boxed<?php } ?>">

--- a/settings.php
+++ b/settings.php
@@ -1432,10 +1432,12 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
     </div>
 </div>
 
-<script src="scripts/vendor/jquery.confirm.min.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>"></script>
-<script src="scripts/pi-hole/js/settings.js?v=<?=$cacheVer?>"></script>
-
 <?php
-require "scripts/pi-hole/php/footer.php";
+    $extra_scripts = [
+        "scripts/vendor/jquery.confirm.min.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/utils.js?v=<?=$cacheVer?>",
+        "scripts/pi-hole/js/settings.js?v=<?=$cacheVer?>"
+    ];
+
+    require "scripts/pi-hole/php/footer.php";
 ?>

--- a/taillog-FTL.php
+++ b/taillog-FTL.php
@@ -24,8 +24,10 @@
     <label for="chk2">Automatic scrolling on update</label>
 </div>
 
-<script src="scripts/pi-hole/js/taillog-FTL.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/taillog-FTL.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>

--- a/taillog.php
+++ b/taillog.php
@@ -24,8 +24,10 @@
     <label for="chk2">Automatic scrolling on update</label>
 </div>
 
-<script src="scripts/pi-hole/js/taillog.js?v=<?=$cacheVer?>"></script>
-
 <?php
+    $extra_scripts = [
+        "scripts/pi-hole/js/taillog.js?v=<?=$cacheVer?>"
+    ];
+
     require "scripts/pi-hole/php/footer.php";
 ?>


### PR DESCRIPTION
Signed-off-by: XhmikosR <xhmikosr@gmail.com>

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

The idea behind this change is that DOM is not blocked, and when JS is loaded everything from the DOM is available which means we can stop using `$(function())` or what we previously were using `$(document ).ready()`.

Also, this makes sure all JS is in one place, like all CSS files should be in `head`.

The downside is that we need to maintain that `$extra_scripts` array but we sort of do this already.

This is mostly a POC that works, but it could be improved later as needed. For example, we could allow specifying `async` if needed, since some scripts can be made asynchronous.

This reminds me, we could probably split header.php to smaller parts later, after AdminLTE 3.x.