### PR TITLE
Store NULL for empty descriptions and comments in the groups database tables

### DIFF
--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -66,7 +66,12 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While preparing statement: ' . $db->lastErrorMsg());
         }
 
-        if (!$stmt->bindValue(':desc', $_POST['desc'], SQLITE3_TEXT)) {
+        $desc = $_POST['desc'];
+        if (strlen($desc) === 0) {
+            // Store NULL in database for empty descriptions
+            $desc = null;
+        }
+        if (!$stmt->bindValue(':desc', $desc, SQLITE3_TEXT)) {
             throw new Exception('While binding desc: ' . $db->lastErrorMsg());
         }
 
@@ -106,7 +111,7 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         $desc = $_POST['desc'];
-        if (strlen($desc) == 0) {
+        if (strlen($desc) === 0) {
             // Store NULL in database for empty descriptions
             $desc = null;
         }
@@ -259,7 +264,7 @@ if ($_POST['action'] == 'get_groups') {
             }
 
             $comment = $_POST['comment'];
-            if (strlen($comment) == 0) {
+            if (strlen($comment) === 0) {
                     // Store NULL in database for empty comments
                     $comment = null;
             }
@@ -289,7 +294,7 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         $comment = $_POST['comment'];
-        if (strlen($comment) == 0) {
+        if (strlen($comment) === 0) {
                 // Store NULL in database for empty comments
                 $comment = null;
         }
@@ -468,7 +473,12 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While binding type: ' . $db->lastErrorMsg());
         }
 
-        if (!$stmt->bindValue(':comment', $_POST['comment'], SQLITE3_TEXT)) {
+        $comment = $_POST['comment'];
+        if (strlen($comment) === 0) {
+            // Store NULL in database for empty comments
+            $comment = null;
+        }
+        if (!$stmt->bindValue(':comment', $comment, SQLITE3_TEXT)) {
             throw new Exception('While binding comment: ' . $db->lastErrorMsg());
         }
 
@@ -548,7 +558,7 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         $comment = $_POST['comment'];
-        if (strlen($comment) == 0) {
+        if (strlen($comment) === 0) {
                 // Store NULL in database for empty comments
                 $comment = null;
         }
@@ -725,7 +735,12 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While preparing statement: ' . $db->lastErrorMsg());
         }
 
-        if (!$stmt->bindValue(':comment', $_POST['comment'], SQLITE3_TEXT)) {
+        $comment = $_POST['comment'];
+        if (strlen($comment) === 0) {
+            // Store NULL in database for empty comments
+            $comment = null;
+        }
+        if (!$stmt->bindValue(':comment', $comment, SQLITE3_TEXT)) {
             throw new Exception('While binding comment: ' . $db->lastErrorMsg());
         }
 
@@ -770,7 +785,7 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         $comment = $_POST['comment'];
-        if (strlen($comment) == 0) {
+        if (strlen($comment) === 0) {
                 // Store NULL in database for empty comments
                 $comment = null;
         }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Empty comments and descriptions should be stored as `NULL` in the database.

**How does this PR accomplish the above?:**

Check if the input fields are empty and, if so, store `NULL`. Storing `NULL` through `bindValue()` with `SQLITE3_TEXT` is explicitly supported and what we're doing already when editing. The code has just been missing for newly added entries.

You can check whether adding a new group with `NULL` descriptions worked using, e.g.,
```plain
sqlite3 /etc/pihole/gravity.db "SELECT * FROM \"group\" WHERE description IS NULL;"
```

**What documentation changes (if any) are needed to support this PR?:**

None