### PR TITLE
Only show query types for which the count is larger than zero

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -306,9 +306,11 @@ function updateQueryTypesPie() {
     }
 
     Object.keys(iter).forEach(function (key) {
-      v.push(iter[key]);
-      c.push(THEME_COLORS[i++ % THEME_COLORS.length]);
-      k.push(key);
+      if (iter[key] > 0) {
+        v.push(iter[key]);
+        c.push(THEME_COLORS[i++ % THEME_COLORS.length]);
+        k.push(key);
+      }
     });
 
     // Build a single dataset with the data to be pushed


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

This is to avoid showing query types which have not be seen. This cleans up the dashboard

**before**
![Screenshot at 2020-06-28 21-38-43](https://user-images.githubusercontent.com/16748619/85956803-a5687a80-b988-11ea-8d26-c616f03737a8.png)


**after**
![Screenshot at 2020-06-28 21-38-55](https://user-images.githubusercontent.com/16748619/85956808-a7cad480-b988-11ea-91e5-0683e27d5a4d.png)

The reason for this PR is https://github.com/pi-hole/FTL/pull/819

**How does this PR accomplish the above?:**

Only show query types for which the count is larger than zero

**What documentation changes (if any) are needed to support this PR?:**

None