### PR TITLE
Show date and time FTL started in settings page

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -318,7 +318,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">Time FTL started:</th>
-                                                        <td><?php print_r(get_FTL_data("start")); ?></td>
+                                                        <td><?php print_r(get_FTL_data("lstart")); ?></td>
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">User / Group:</th>


### PR DESCRIPTION
Signed-off-by: yubiuser <ckoenig@posteo.de>

**By submitting this pull request, I confirm the following:** 


- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Show date and time FTL started in settings/system instead of only date if started >1 day ago.

Fixes https://github.com/pi-hole/AdminLTE/issues/1108 by using `lstart` instead of `start`

