### PR TITLE
Fixes formatting of unknown host in DHCP leases table

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -674,7 +674,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                             $type = 4;
                                         }
 
-                                        $host = $line[3];
+                                        $host = htmlentities($line[3]);
                                         if ($host == "*") {
                                             $host = "<i>unknown</i>";
                                         }
@@ -715,7 +715,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                             title="Lease type: IPv<?php echo $lease["type"]; ?><br/>Remaining lease time: <?php echo $lease["TIME"]; ?><br/>DHCP UID: <?php echo $lease["clid"]; ?>">
                                                             <td id="MAC"><?php echo $lease["hwaddr"]; ?></td>
                                                             <td id="IP" data-order="<?php echo bin2hex(inet_pton($lease["IP"])); ?>"><?php echo $lease["IP"]; ?></td>
-                                                            <td id="HOST"><?php echo htmlentities($lease["host"]); ?></td>
+                                                            <td id="HOST"><?php echo $lease["host"]; ?></td>
                                                             <td>
                                                                 <button type="button" id="button" class="btn btn-warning btn-xs" data-static="alert">
                                                                     <span class="fas fas fa-file-import"></span>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** ]}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixes an issue raised on discourse https://discourse.pi-hole.net/t/unknown-clients-comes-up-as-i-unknown-i-for-dhcp-leases/35663 where unknown clients in the DHCP lease table are shown as `<i>unknown</i>`

Fixes #1513, Fixes #1524, Fixes https://github.com/pi-hole/web/issues/753

**How does this PR accomplish the above?:**

Uses `htmlentities` on host(name) before introducing formatting code for unknown hosts and removes `htmlentities` when string is printed.
