### PR TITLE
Fix teleporter bug on hosts with . in their names

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -540,7 +540,7 @@ if(isset($_POST["action"]))
 }
 else
 {
-	$hostname = gethostname() ? gethostname()."-" : "";
+	$hostname = gethostname() ? str_replace(".", "_", gethostname())."-" : "";
 	$tarname = "pi-hole-".$hostname."teleporter_".date("Y-m-d_H-i-s").".tar";
 	$filename = $tarname.".gz";
 	$archive_file_name = sys_get_temp_dir() ."/". $tarname;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix #1497 #1503 and maybe more

**How does this PR accomplish the above?:**

Replace "." by "_" in hostnames to work around a PHP Phar bug introduced in https://github.com/pi-hole/AdminLTE/issues/1497

**What documentation changes (if any) are needed to support this PR?:**

None