### PR TITLE
Fix query types links on the dashboard (Query Types pie chart)

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -287,6 +287,7 @@ function updateQueriesOverTime() {
     });
 }
 
+var querytypeids = [];
 function updateQueryTypesPie() {
   $.getJSON("api.php?getQueryTypes", function (data) {
     if ("FTLnotrunning" in data) {
@@ -305,12 +306,16 @@ function updateQueryTypesPie() {
       iter = data;
     }
 
+    querytypeids = [];
     Object.keys(iter).forEach(function (key) {
       if (iter[key] > 0) {
         v.push(iter[key]);
-        c.push(THEME_COLORS[i++ % THEME_COLORS.length]);
+        c.push(THEME_COLORS[i % THEME_COLORS.length]);
         k.push(key);
+        querytypeids.push(i + 1);
       }
+
+      i++;
     });
 
     // Build a single dataset with the data to be pushed
@@ -342,7 +347,7 @@ function updateQueryTypesPie() {
         ci.update();
       } else if (e.which === 1) {
         // which == 1 is left mouse button
-        window.open("queries.php?querytype=" + ($(this).index() + 1), "_self");
+        window.open("queries.php?querytype=" + querytypeids[$(this).index()], "_self");
       }
     });
   }).done(function () {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix #1508

**How does this PR accomplish the above?:**

Use the real indices instead of the index of the current element.
This modification has the additional benefit that each type will always get the same color. Currently, the color of query types depends on its index (and this can be almost arbitrary).

**What documentation changes (if any) are needed to support this PR?:**

None