### PR TITLE
fix(settings): typo in conditional forwarding

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -985,7 +985,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
 	                                               requests to your DHCP server (most likely your router), but only for devices on your
 	                                               home network.  To configure this we will need to know the IP
 	                                               address of your DHCP server and which addresses belong to your local network.
-                                                   Exemplary inout is given below as placeholder in the text boxes (if empty).</p>
+                                                   Exemplary input is given below as placeholder in the text boxes (if empty).</p>
                                                 <p>If your local network spans 192.168.0.1 - 192.168.0.255, then you will have to input
                                                    <code>192.168.0.0/24</code>. If your local network is 192.168.47.1 - 192.168.47.255, it will
                                                    be <code>192.168.47.0/24</code> and similar. If your network is larger, the CIDR has to be


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix typo on the Settings/DNS page in the Conditional Forwarding paragraph.

**How does this PR accomplish the above?:**

Typo is fixed.
