### PR TITLE
Change timePicker to 24h format in dateragepicker

### DIFF
--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -20,6 +20,7 @@ $(function () {
     {
       timePicker: true,
       timePickerIncrement: 15,
+      timePicker24Hour: true,
       locale: { format: dateformat },
       startDate: start__,
       endDate: end__,

--- a/scripts/pi-hole/js/db_lists.js
+++ b/scripts/pi-hole/js/db_lists.js
@@ -22,6 +22,7 @@ $(function () {
     {
       timePicker: true,
       timePickerIncrement: 15,
+      timePicker24Hour: true,
       locale: { format: dateformat },
       startDate: start__,
       endDate: end__,

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -40,6 +40,7 @@ $(function () {
     {
       timePicker: true,
       timePickerIncrement: 15,
+      timePicker24Hour: true,
       locale: { format: dateformat },
       startDate: start__,
       endDate: end__,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Change the time format of the time range picker within in the daterangepicker in "Long-Term data" -> Custom Range to 24h format.
Pihole uses 24h time format everywhere else, so this makes it more consistent.

Fixes pi-hole/AdminLTE#1528

**How does this PR accomplish the above?:**

Uses  `timePicker24Hour: true`

**What documentation changes (if any) are needed to support this PR?:**

No.

