### PR TITLE
Add "ALL" to list selector in Local DNS Records and CNAME Records 

### DIFF
--- a/scripts/pi-hole/js/customcname.js
+++ b/scripts/pi-hole/js/customcname.js
@@ -65,10 +65,10 @@ $(function () {
         }
       }
     ],
-      lengthMenu: [
-        [10, 25, 50, 100, -1],
-        [10, 25, 50, 100, "All"]
-      ],
+    lengthMenu: [
+      [10, 25, 50, 100, -1],
+      [10, 25, 50, 100, "All"]
+    ],
     drawCallback: function () {
       $(".deleteCustomCNAME").on("click", deleteCustomCNAME);
     }

--- a/scripts/pi-hole/js/customcname.js
+++ b/scripts/pi-hole/js/customcname.js
@@ -65,10 +65,10 @@ $(function () {
         }
       }
     ],
-    lengthMenu: [
-      [10, 25, 50, 100, -1],
-      [10, 25, 50, 100, "All"]
-    ],
+      lengthMenu: [
+        [10, 25, 50, 100, -1],
+        [10, 25, 50, 100, "All"]
+      ],
     drawCallback: function () {
       $(".deleteCustomCNAME").on("click", deleteCustomCNAME);
     }

--- a/scripts/pi-hole/js/customcname.js
+++ b/scripts/pi-hole/js/customcname.js
@@ -65,6 +65,10 @@ $(function () {
         }
       }
     ],
+    lengthMenu: [
+      [10, 25, 50, 100, -1],
+      [10, 25, 50, 100, "All"]
+    ],
     drawCallback: function () {
       $(".deleteCustomCNAME").on("click", deleteCustomCNAME);
     }

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -65,10 +65,10 @@ $(function () {
         }
       }
     ],
-  lengthMenu: [
-    [10, 25, 50, 100, -1],
-    [10, 25, 50, 100, "All"]
-  ],
+      lengthMenu: [
+        [10, 25, 50, 100, -1],
+        [10, 25, 50, 100, "All"]
+      ],
     drawCallback: function () {
       $(".deleteCustomDNS").on("click", deleteCustomDNS);
     }

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -65,6 +65,10 @@ $(function () {
         }
       }
     ],
+  lengthMenu: [
+    [10, 25, 50, 100, -1],
+    [10, 25, 50, 100, "All"]
+  ],
     drawCallback: function () {
       $(".deleteCustomDNS").on("click", deleteCustomDNS);
     }

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -65,10 +65,10 @@ $(function () {
         }
       }
     ],
-      lengthMenu: [
-        [10, 25, 50, 100, -1],
-        [10, 25, 50, 100, "All"]
-      ],
+    lengthMenu: [
+      [10, 25, 50, 100, -1],
+      [10, 25, 50, 100, "All"]
+    ],
     drawCallback: function () {
       $(".deleteCustomDNS").on("click", deleteCustomDNS);
     }


### PR DESCRIPTION

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
All drop-down list selectors contained 10, 25, 50, 100, ALL. In Local DNS Records ans CNAME Records "ALL" was missing.
This PR adds "ALL" to list selector in Local DNS Records and CNAME Records.

![a661e95cab62eb8ee910a6336f8454c99a6dc3b1](https://user-images.githubusercontent.com/26622301/88487901-852cdb00-cf89-11ea-8788-6a15472fa314.png)![b091c851f20988526063ec77b9c660d25ead0388](https://user-images.githubusercontent.com/26622301/88487912-983fab00-cf89-11ea-9f4f-54f0653e780f.png)


**How does this PR accomplish the above?:**

Adds explicitly `lengthMenu` (including -1) to the responsible js scripts.

**What documentation changes (if any) are needed to support this PR?:**

No.
