### PR TITLE
Allow IPv6 loopback address to be added

### DIFF
--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -150,7 +150,7 @@ function validateIPv6CIDR(ip) {
   var ipv6validator = new RegExp(
     "^(((?:" +
       ipv6elem +
-      "))((?::" +
+      "))*((?::" +
       ipv6elem +
       "))*::((?:" +
       ipv6elem +


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Allow IPv6 loopback address to be added

**How does this PR accomplish the above?:**

Do not require first element of the IP address to be a hex value at any costs. It may also be a `:` in the valid address `::1`

**What documentation changes (if any) are needed to support this PR?:**

None