### PR TITLE
Revert "Add 'seconds' to custom disable timeout modal"

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -15,7 +15,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title" id="myModalLabel">Custom disable timeout (seconds)</h4>
+                    <h4 class="modal-title" id="myModalLabel">Custom disable timeout</h4>
                 </div>
                 <div class="modal-body">
                     <div class="input-group">


### PR DESCRIPTION
This reverts commit c15a8ecde2cf487c261ecc8b90ca90a1fe053203.

Reason: Just adding a new titel didn't fix the underlying issue (e.g. https://github.com/pi-hole/pi-hole/issues/3670). The real fix must take into account what I wrote here (https://github.com/pi-hole/pi-hole/issues/3670#issuecomment-674212590)