### PR TITLE
Fix bare <i> tag showing in settings

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -676,7 +676,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
 
                                         $host = $line[3];
                                         if ($host == "*") {
-                                            $host = "<i>unknown</i>";
+                                            $host = null;
                                         }
 
                                         $clid = $line[4];
@@ -715,7 +715,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                             title="Lease type: IPv<?php echo $lease["type"]; ?><br/>Remaining lease time: <?php echo $lease["TIME"]; ?><br/>DHCP UID: <?php echo $lease["clid"]; ?>">
                                                             <td id="MAC"><?php echo $lease["hwaddr"]; ?></td>
                                                             <td id="IP" data-order="<?php echo bin2hex(inet_pton($lease["IP"])); ?>"><?php echo $lease["IP"]; ?></td>
-                                                            <td id="HOST"><?php echo htmlentities($lease["host"]); ?></td>
+                                                            <td id="HOST"><?php echo (!is_null($lease["host"]) ? htmlentities($lease["host"]) : '<i>unknown</i>'); ?></td>
                                                             <td>
                                                                 <button type="button" id="button" class="btn btn-warning btn-xs" data-static="alert">
                                                                     <span class="fas fas fa-file-import"></span>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ ] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

(Sorry, haven't tested it, couldn't work out how to get it running, but I've only changed 2 lines!)

**What does this PR aim to accomplish?:**

Fix bare HTML showing in the settings area. I think this should show it:

https://www.dropbox.com/s/c7baew7e605afuy/Screenshot_2020-08-14%20Pi-hole%20-%20neopi.png?dl=0

**How does this PR accomplish the above?:**

The html is no longer run through htmlentities if there is no host

**What documentation changes (if any) are needed to support this PR?:**

none that I know of?