### PR TITLE
Remember last used sort column/direction on Local DNS Records table and CNAME table

### DIFF
--- a/scripts/pi-hole/js/customcname.js
+++ b/scripts/pi-hole/js/customcname.js
@@ -69,6 +69,14 @@ $(function () {
       [10, 25, 50, 100, -1],
       [10, 25, 50, 100, "All"]
     ],
+    order: [[0, "asc"]],
+    stateSave: true,
+    stateSaveCallback: function (settings, data) {
+      utils.stateSaveCallback("LocalCNAMETable", data);
+    },
+    stateLoadCallback: function () {
+      return utils.stateLoadCallback("LocalCNAMETable");
+    },
     drawCallback: function () {
       $(".deleteCustomCNAME").on("click", deleteCustomCNAME);
     }

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -69,6 +69,14 @@ $(function () {
       [10, 25, 50, 100, -1],
       [10, 25, 50, 100, "All"]
     ],
+    order: [[0, "asc"]],
+    stateSave: true,
+    stateSaveCallback: function (settings, data) {
+      utils.stateSaveCallback("LocalDNSTable", data);
+    },
+    stateLoadCallback: function () {
+      return utils.stateLoadCallback("LocalDNSTable");
+    },
     drawCallback: function () {
       $(".deleteCustomDNS").on("click", deleteCustomDNS);
     }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Remember the last used sort column/direction for the Local DNS Records table and CNAME table.
Fixes https://github.com/pi-hole/AdminLTE/issues/1486

**How does this PR accomplish the above?:**

Re-uses code from https://github.com/pi-hole/AdminLTE/pull/1332

**What documentation changes (if any) are needed to support this PR?:**

Nothing
