### PR TITLE
Fix Whitelist buttons on query log pages

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -393,7 +393,7 @@ $(function () {
   });
   $("#all-queries tbody").on("click", "button", function () {
     var data = tableApi.row($(this).parents("tr")).data();
-    if (data[4] === 1 || data[4] === 4 || data[5] === 5) {
+    if ([1, 4, 5, 9, 10, 11].indexOf(data[4]) !== -1) {
       add(data[2], "white");
     } else {
       add(data[2], "black");


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Fix the behavior of the Whitelist button on both the short-term and long-term query log pages.
Previously, domains blocked due to cases

- 5 (exact blacklist),
- 9 (gravity),
- 10 (regex blacklist CNAME), and
- 11 (exact blacklist CNAME)

would *blacklist* the domain instead of whitelisting it when clicking the Whitelist button.

**How does this PR accomplish the above?:**
It corrects a typo of `data[5]` by using `array.indexOf` instead of several `===` checks. If `===` would be preferable, I can change that upon request.
It also corrects the omission of 3 whitelist buttons from the click event, which erroneously blacklisted a domain when clicking the "Whitelist" button.

**What documentation changes (if any) are needed to support this PR?:**
None
