### PR TITLE
Show last update time of an adlist

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -56,8 +56,10 @@ function initTable() {
       var tooltip =
         "Added: " +
         utils.datetime(data.date_added, false) +
-        "\nLast modified: " +
+        "\nLast modified (database entry): " +
         utils.datetime(data.date_modified, false) +
+        "\nLast updated (list content): " +
+        (data.date_updated !== null ? utils.datetime(data.date_updated, false) : "N/A") +
         "\nDatabase ID: " +
         data.id;
       $("td:eq(0)", row).html(


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

![Screenshot at 2020-09-07 21-17-10](https://user-images.githubusercontent.com/16748619/92413256-85ef8a00-f14f-11ea-88fe-8f8348bc51e6.png)

**How does this PR accomplish the above?:**

Add a new `date_updated` field to `adlist` table. This field is preserved if we used a cached version and updated when we downloaded new content.

**What documentation changes (if any) are needed to support this PR?:**

Add description of additional field to the database table description (to be done separately)

This PR is connected to https://github.com/pi-hole/pi-hole/pull/3740