### PR TITLE
Fix bug with secs/mins buttons on disable menu caused by addition of theming.

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -133,7 +133,7 @@ function initCheckboxRadioStyle() {
 
   function applyCheckboxRadioStyle(style) {
     boxsheet.attr("href", getCheckboxURL(style));
-    var sel = $("input[type='radio'],input[type='checkbox']");
+    var sel = $("input[type='radio'],input[type='checkbox']").not("#selSec").not("#selMin");
     sel.parent().removeClass();
     sel.parent().addClass("icheck-" + style);
   }

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -133,6 +133,7 @@ function initCheckboxRadioStyle() {
 
   function applyCheckboxRadioStyle(style) {
     boxsheet.attr("href", getCheckboxURL(style));
+    // Get all radio/checkboxes for theming, with the exception of the two radio buttons on the custom disable timer
     var sel = $("input[type='radio'],input[type='checkbox']").not("#selSec").not("#selMin");
     sel.parent().removeClass();
     sel.parent().addClass("icheck-" + style);

--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -22,10 +22,10 @@
                         <input id="customTimeout" class="form-control" type="number" value="60">
                             <div class="input-group-btn" data-toggle="buttons">
                                 <label class="btn btn-default">
-                                    <input type="radio"> Secs
+                                    <input id="selSec" type="radio"> Secs
                                 </label>
                                 <label id="btnMins" class="btn btn-default active">
-                                    <input type="radio"> Mins
+                                    <input id="selMin" type="radio"> Mins
                                 </label>
                             </div>
                     </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fixes #1587

**How does this PR accomplish the above?:**

Exclude the mins/secs buttons from being rethemed, as they use button clases rather than iCheck in any case.

See below, checkbox/radios in background still being themed, buttons in foreground not touched.

![image](https://user-images.githubusercontent.com/1998970/93575099-1f5d3e00-f991-11ea-9dbc-05c93bcccb5d.png)


**What documentation changes (if any) are needed to support this PR?:**

none