### PR TITLE
Remove degree sign from kelvin temperature

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -170,7 +170,7 @@ function initCPUtemp() {
       switch (unit) {
         case "K":
           temperature += 273.15;
-          displaytemp.html(temperature.toFixed(1) + "&nbsp;&deg;K");
+          displaytemp.html(temperature.toFixed(1) + "&nbsp;K");
           break;
 
         case "F":


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Remove the degree symbol when displaying the temperature in Kelvin.
From Wikipedia https://en.wikipedia.org/wiki/Kelvin
> Unlike the degree Fahrenheit and degree Celsius, the
> kelvin is not referred to or written as a degree

**How does this PR accomplish the above?:**

By changing the javascript code that displays the temperature

**What documentation changes (if any) are needed to support this PR?:**

No changes are needed
