### PR TITLE
Fixes issue with Apostrophe turning into &#039; 

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -213,7 +213,7 @@ function initTable() {
 
 function addAdlist() {
   var address = utils.escapeHtml($("#new_address").val());
-  var comment = utils.escapeHtml($("#new_comment").val());
+  var comment = $("#new_comment").val();
 
   utils.disableAll();
   utils.showAlert("info", "", "Adding adlist...", address);


### PR DESCRIPTION


**By submitting this pull request, I confirm the following:** 


- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixes issue with Apostrophe ' turning into &#039;

https://github.com/pi-hole/AdminLTE/issues/1584

**How does this PR accomplish the above?:**

Stops escaping HTML in the comment box in group-adlists page.