### PR TITLE
Fix UI Remaining Disabled in Groups & Adlists Pages

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -219,6 +219,8 @@ function addAdlist() {
   utils.showAlert("info", "", "Adding adlist...", address);
 
   if (address.length === 0) {
+    // enable the ui elements again
+    utils.enableAll();
     utils.showAlert("warning", "", "Warning", "Please specify an adlist address");
     return;
   }

--- a/scripts/pi-hole/js/groups.js
+++ b/scripts/pi-hole/js/groups.js
@@ -134,6 +134,8 @@ function addGroup() {
   utils.showAlert("info", "", "Adding group...", name);
 
   if (name.length === 0) {
+    // enable the ui elements again
+    utils.enableAll();
     utils.showAlert("warning", "", "Warning", "Please specify a group name");
     return;
   }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

After clicking `Add` on the Group Management Groups or Adlists pages the UI elements remain disabled if the input was empty.

Example:
![Add new Adlist](https://user-images.githubusercontent.com/11299264/95419642-e4468e80-08ee-11eb-8922-4c430ea45020.png)

**How does this PR accomplish the above?:**

Enable the UI elements in the cases that validate the input of the boxes before showing an alert and returning.

After the change:
![Add new Adlist](https://user-images.githubusercontent.com/11299264/95420350-202e2380-08f0-11eb-8f80-3ac78f326a8a.png)

**What documentation changes (if any) are needed to support this PR?:**

None

