### PR TITLE
Fix symbol for devices that do not use Pi-hole

### DIFF
--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -95,7 +95,7 @@ $(function () {
       } else {
         // This client has never sent a query to Pi-hole, color light-red
         color = networkNever;
-        iconClasses = "fas fa-check";
+        iconClasses = "fas fa-times";
       }
 
       // Set determined background color


### PR DESCRIPTION
Signed-off-by: Kurtis <kbohlen@sfu.ca>

**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I have tested my proposed changes.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Replaces the check mark (fa-check) with an X (fa-times) for devices that do not use Pi-hole

**How does this PR accomplish the above?:**

Changes the Font Awesome symbol used

**What documentation changes (if any) are needed to support this PR?:**

None
