### PR TITLE
Simplify query log filter to make it more user friendly 

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -162,8 +162,9 @@ if(strlen($showing) > 0)
             </table>
             <p><strong>Filtering options:</strong></p>
             <ul>
-                <li>Use <kbd>Ctrl</kbd> or <kbd>&#8984;</kbd> + <i class="fas fa-mouse-pointer"></i> to add columns to the current filter</li>
-                <li>Use <kbd>Shift</kbd> + <i class="fas fa-mouse-pointer"></i> to remove columns from the current filter</li>
+                <li>Click a value in a column to add/remove that value to/from the filter</li>
+                <li>On a computer: Hold down <kbd>Ctrl</kbd> or <kbd>&#8984;</kbd> to allow highlighting for copying to clipboard</li>
+                <li>On a mobile: Long press to highlight the text and enable copying to clipboard
             </ul><br/><button type="button" id="resetButton" class="btn btn-default btn-sm text-red hidden">Clear filters</button>
         </div>
         <!-- /.box-body -->

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -508,19 +508,19 @@ function tooltipText(index, text) {
   }
 
   if (index in tableFilters && tableFilters[index].length > 0) {
-    return "Clear filter on " + colTypes[index] + ' "' + text + '" using Shift + Click.';
+    return "Click to remove " + colTypes[index] + ' "' + text + '" from filter.';
   }
 
-  return "Add filter on " + colTypes[index] + ' "' + text + '" using Ctrl + Click.';
+  return "Click to add " + colTypes[index] + ' "' + text + '" to filter.';
 }
 
 function addColumnFilter(event, colID, filterstring) {
-  // Don't do anything when NOT explicitly requesting multi-selection functions
-  if (!event.ctrlKey && !event.metaKey && !event.shiftKey) {
+  // If the below modifier keys are held down, do nothing
+  if (event.ctrlKey || event.metaKey) {
     return;
   }
 
-  if (event.shiftKey) {
+  if (tableFilters[colID] === filterstring) {
     filterstring = "";
   }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

- Allows mobile users to be able to use the new filtering options as well as desktop users
- Removes need to hold down a modifier key to add or remove to/from the filter. Simply click the field to toggle it on/off
- Utilises the ctrl/meta modifier keys for desktop users to enable highlighting to copy cell text to the clipboard (mobile users can long-press the cell text to achieve the same thing)

**How does this PR accomplish the above?:**

**What documentation changes (if any) are needed to support this PR?:**

Possibly docs, I've not checked. This may need to be replicated to long term tables?