### PR TITLE
Added check for NULL value in PHP internal error handling

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -14,7 +14,7 @@ $piholeFTLConf = piholeFTLConfig();
 
 // Handling of PHP internal errors
 $last_error = error_get_last();
-if($last_error["type"] === E_WARNING || $last_error["type"] === E_ERROR)
+if($last_error && ($last_error["type"] === E_WARNING || $last_error["type"] === E_ERROR))
 {
 	$error .= "There was a problem applying your settings.<br>Debugging information:<br>PHP error (".htmlspecialchars($last_error["type"])."): ".htmlspecialchars($last_error["message"])." in ".htmlspecialchars($last_error["file"]).":".htmlspecialchars($last_error["line"]);
 }

--- a/settings.php
+++ b/settings.php
@@ -14,7 +14,7 @@ $piholeFTLConf = piholeFTLConfig();
 
 // Handling of PHP internal errors
 $last_error = error_get_last();
-if($last_error && ($last_error["type"] === E_WARNING || $last_error["type"] === E_ERROR))
+if(isset($last_error) && ($last_error["type"] === E_WARNING || $last_error["type"] === E_ERROR))
 {
 	$error .= "There was a problem applying your settings.<br>Debugging information:<br>PHP error (".htmlspecialchars($last_error["type"])."): ".htmlspecialchars($last_error["message"])." in ".htmlspecialchars($last_error["file"]).":".htmlspecialchars($last_error["line"]);
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

It prevents displaying the error
`Notice: Trying to access array offset on value of type null in /srv/pihole/admin/settings.php on line 17`
when accessing the settings page with `display_errors=On` in the PHP settings (`php.ini`)

**How does this PR accomplish the above?:**

By adding a check if $last_error is false before accessing the array values.

**What documentation changes (if any) are needed to support this PR?:**

No changes necessary