### PR TITLE
Add altKey to modifiers when clicking on query log

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -163,7 +163,7 @@ if(strlen($showing) > 0)
             <p><strong>Filtering options:</strong></p>
             <ul>
                 <li>Click a value in a column to add/remove that value to/from the filter</li>
-                <li>On a computer: Hold down <kbd>Ctrl</kbd> or <kbd>&#8984;</kbd> to allow highlighting for copying to clipboard</li>
+                <li>On a computer: Hold down <kbd>Ctrl</kbd>, <kbd>Alt</kbd>, or <kbd>&#8984;</kbd> to allow highlighting for copying to clipboard</li>
                 <li>On a mobile: Long press to highlight the text and enable copying to clipboard
             </ul><br/><button type="button" id="resetButton" class="btn btn-default btn-sm text-red hidden">Clear filters</button>
         </div>

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -506,7 +506,7 @@ function tooltipText(index, text) {
 
 function addColumnFilter(event, colID, filterstring) {
   // If the below modifier keys are held down, do nothing
-  if (event.ctrlKey || event.metaKey) {
+  if (event.ctrlKey || event.metaKey || event.altKey) {
     return;
   }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Prevents domain being added to the filter when the `alt` key ([standard behaviour for copying link text](https://www.reddit.com/r/firefox/comments/733n62/til_you_can_hold_down_alt_while_selecting_text_to/)) is held down, in addition to the existing `ctrl` or `meta` keys.