### PR TITLE
Ensure empty clients/groups/adlists/audits cannot be added

### DIFF
--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -77,6 +77,11 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         foreach ($names as $name) {
+            // Silently skip this entry when it is empty or not a string (e.g. NULL)
+            if(!is_string($name) || strlen($name) == 0) {
+                continue;
+            }
+
             if (!$stmt->bindValue(':name', $name, SQLITE3_TEXT)) {
                 throw new Exception('While binding name: <strong>' . $db->lastErrorMsg() . '</strong><br>'.
                 'Added ' . $added . " out of ". $total . " groups");
@@ -306,6 +311,11 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         foreach ($ips as $ip) {
+            // Silently skip this entry when it is empty or not a string (e.g. NULL)
+            if(!is_string($ip) || strlen($ip) == 0) {
+                continue;
+            }
+
             if (!$stmt->bindValue(':ip', $ip, SQLITE3_TEXT)) {
                 throw new Exception('While binding ip: ' . $db->lastErrorMsg());
             }
@@ -531,6 +541,11 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         foreach ($domains as $domain) {
+            // Silently skip this entry when it is empty or not a string (e.g. NULL)
+            if(!is_string($domain) || strlen($domain) == 0) {
+                continue;
+            }
+
             $input = $domain;
             // Convert domain name to IDNA ASCII form for international domains
             if (extension_loaded("intl")) {
@@ -808,6 +823,11 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         foreach ($addresses as $address) {
+            // Silently skip this entry when it is empty or not a string (e.g. NULL)
+            if(!is_string($address) || strlen($address) == 0) {
+                continue;
+            }
+
             if(preg_match("/[^a-zA-Z0-9:\/?&%=~._()-;]/", $address) !== 0) {
                 throw new Exception('<strong>Invalid adlist URL ' . htmlentities($address) . '</strong><br>'.
                 'Added ' . $added . " out of ". $total . " adlists");
@@ -950,7 +970,10 @@ if ($_POST['action'] == 'get_groups') {
             }
 
             foreach ($domains as $domain) {
-                $input = $domain;
+                // Silently skip this entry when it is empty or not a string (e.g. NULL)
+                if(!is_string($domain) || strlen($domain) == 0) {
+                    continue;
+                }
 
                 if (!$stmt->bindValue(':domain', $domain, SQLITE3_TEXT)) {
                     throw new Exception('While binding domain: <strong>' . $db->lastErrorMsg() . '</strong><br>'.


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Ensure empty clients/groups/adlists/audits cannot be added

**How does this PR accomplish the above?:**

Whenever an empty entry is found, it is skipped. As empty entries may result from (unintentional) double spaces, we do not stop here as an error, but just continue processing the rest of the arguments.

**What documentation changes (if any) are needed to support this PR?:**

None