### PR TITLE
Print fatal dnsmasq errors

### DIFF
--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -73,6 +73,9 @@ function renderMessage(data, type, row) {
         "&uarr;</pre>"
       );
 
+    case "DNSMASQ_CONFIG":
+      return "FTL failed to start due to " + row.message;
+
     default:
       return "Unknown message type<pre>" + JSON.stringify(row) + "</pre>";
   }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Print fatal dnsmasq errors on the Pi-hole diagnosis system.

Example:
![Screenshot at 2020-11-17 22-41-43](https://user-images.githubusercontent.com/16748619/99455956-e148b000-2928-11eb-87b0-85caea4ef354.png)

**How does this PR accomplish the above?:**

Pretty-print the information stored by https://github.com/pi-hole/FTL/pull/926 in FTL's database.

**What documentation changes (if any) are needed to support this PR?:**

None