### PR TITLE
Add button to remove dynamic DHCP leases

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -416,6 +416,13 @@ else
 		$data = array_merge($data, $result);
 	}
 
+	if (isset($_GET['delete_lease']) && $auth)
+	{
+		sendRequestFTL("delete-lease ".$_GET['delete_lease']);
+		$return = getResponseFTL();
+		$data["delete_lease"] = $return[0];
+	}
+
 	disconnectFTL();
 }
 ?>

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -6,6 +6,7 @@
  *  Please see LICENSE file for your rights under this license. */
 
 /* global utils:false */
+var token = $("#token").text();
 
 $(function () {
   $("[data-static]").on("click", function () {
@@ -281,5 +282,50 @@ $(function () {
 
   bargraphs.click(function () {
     localStorage.setItem("barchart_chkbox", bargraphs.prop("checked"));
+  });
+});
+
+// Delete dynamic DHCP lease
+$('button[id="removedynamic"]').on("click", function () {
+  var tr = $(this).closest("tr");
+  var ipaddr = utils.escapeHtml(tr.children("#IP").text());
+  var name = utils.escapeHtml(tr.children("#HOST").text());
+  var ipname = name + " (" + ipaddr + ")";
+
+  utils.disableAll();
+  utils.showAlert("info", "", "Deleting DHCP lease...", ipname);
+  $.ajax({
+    url: "api.php",
+    method: "get",
+    dataType: "json",
+    data: {
+      delete_lease: ipaddr,
+      token: token
+    },
+    success: function (response) {
+      utils.enableAll();
+      if (response.delete_lease.startsWith("OK")) {
+        utils.showAlert(
+          "success",
+          "far fa-trash-alt",
+          "Successfully deleted DHCP lease for ",
+          ipname
+        );
+        // Remove column on success
+        tr.remove();
+        // We have to hide the tooltips explicitly or they will stay there forever as
+        // the onmouseout event does not fire when the element is already gone
+        $.each($(".tooltip"), function () {
+          $(this).remove();
+        });
+      } else {
+        utils.showAlert("error", "Error while deleting DHCP lease for " + ipname, response);
+      }
+    },
+    error: function (jqXHR, exception) {
+      utils.enableAll();
+      utils.showAlert("error", "Error while deleting DHCP lease for " + ipname, jqXHR.responseText);
+      console.log(exception); // eslint-disable-line no-console
+    }
   });
 });

--- a/settings.php
+++ b/settings.php
@@ -717,6 +717,9 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                             <td id="IP" data-order="<?php echo bin2hex(inet_pton($lease["IP"])); ?>"><?php echo $lease["IP"]; ?></td>
                                                             <td id="HOST"><?php echo $lease["host"]; ?></td>
                                                             <td>
+                                                                <button type="button" class="btn btn-danger btn-xs" id="removedynamic">
+                                                                    <span class="fas fas fa-trash-alt"></span>
+                                                                </button>
                                                                 <button type="button" id="button" class="btn btn-warning btn-xs" data-static="alert">
                                                                     <span class="fas fas fa-file-import"></span>
                                                                 </button>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Add button to remove dynamic DHCP leases. They are immediately removed both from FTL and the `dhcp.leases` file.
FTL takes care of updating the file!) WITHOUT the need for a restart of the DHCP/DNS resolver.


See the new red trash icon on the dynamic leases table:
![Screenshot at 2020-11-23 13-40-23](https://user-images.githubusercontent.com/16748619/99963776-939dce80-2d92-11eb-81fd-2cbe94608402.png)


Clicking on the one non-blurred entry deletes the lease currently active for `dominik-desktop`. The progress is reported by a status message on the top right corner:

![Screenshot at 2020-11-23 13-37-29](https://user-images.githubusercontent.com/16748619/99963784-97315580-2d92-11eb-836a-6200cdd3a858.png)


**How does this PR accomplish the above?:**

Adds a button to call the new `delete-release` API callback in FTL (see https://github.com/pi-hole/FTL/pull/932)

**What documentation changes (if any) are needed to support this PR?:**

None