### PR TITLE
Summarize the names of DNS servers which support DNSSEC

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -970,8 +970,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                     queries, Pi-hole requests the DNSSEC records needed to validate
                                                     the replies. If a domain fails validation or the upstream does not
                                                     support DNSSEC, this setting can cause issues resolving domains.
-                                                    Use Google, Cloudflare, DNS.WATCH, Quad9, or another DNS
-                                                    server which supports DNSSEC when activating DNSSEC. Note that
+                                                    Use an upstream DNS server which supports DNSSEC when activating DNSSEC. Note that
                                                     the size of your log might increase significantly
                                                     when enabling DNSSEC. A DNSSEC resolver test can be found
                                                     <a href="https://dnssec.vs.uni-due.de/" rel="noopener" target="_blank">here</a>.</p>


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Simplifies and summarized the names of the upstream DNS servers that allow DNSSEC. If more servers support DNSSEC in the future the text doesn't need to be changed again.

Should go along with https://github.com/pi-hole/pi-hole/pull/3863.
