### PR TITLE
Fix issue #1643 - Display retried DNS queries correctly in query log

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -185,12 +185,12 @@ $(function () {
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;
           break;
-        case 12:
+        case "12":
           colorClass = "text-green";
           fieldtext = "Retried";
           buttontext = "";
           break;
-        case 13:
+        case "13":
           colorClass = "text-green";
           fieldtext = "Retried <br class='hidden-lg'>(ignored)";
           buttontext = "";


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix for issue #1643 where retried DNS queries have status 'Unknown' in query log.

**How does this PR accomplish the above?:**

Status numbers needed to be quoted in the switch statement, otherwise cases 12 and 13 fall through to the default case and print "Unknown (<num>)" instead.

**What documentation changes (if any) are needed to support this PR?:**

None

