### PR TITLE
Fix adlists without groups

### DIFF
--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -970,26 +970,28 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While executing DELETE statement: ' . $db->lastErrorMsg());
         }
 
-        $db->query('BEGIN TRANSACTION;');
-        foreach ($_POST['groups'] as $gid) {
-            $stmt = $db->prepare('INSERT INTO adlist_by_group (adlist_id,group_id) VALUES(:id,:gid);');
-            if (!$stmt) {
-                throw new Exception('While preparing INSERT INTO statement: ' . $db->lastErrorMsg());
-            }
+        if (!empty($_POST['groups'])) {
+            $db->query('BEGIN TRANSACTION;');
+            foreach ($_POST['groups'] as $gid) {
+                $stmt = $db->prepare('INSERT INTO adlist_by_group (adlist_id,group_id) VALUES(:id,:gid);');
+                if (!$stmt) {
+                    throw new Exception('While preparing INSERT INTO statement: ' . $db->lastErrorMsg());
+                }
 
-            if (!$stmt->bindValue(':id', intval($_POST['id']), SQLITE3_INTEGER)) {
-                throw new Exception('While binding id: ' . $db->lastErrorMsg());
-            }
+                if (!$stmt->bindValue(':id', intval($_POST['id']), SQLITE3_INTEGER)) {
+                    throw new Exception('While binding id: ' . $db->lastErrorMsg());
+                }
 
-            if (!$stmt->bindValue(':gid', intval($gid), SQLITE3_INTEGER)) {
-                throw new Exception('While binding gid: ' . $db->lastErrorMsg());
-            }
+                if (!$stmt->bindValue(':gid', intval($gid), SQLITE3_INTEGER)) {
+                    throw new Exception('While binding gid: ' . $db->lastErrorMsg());
+                }
 
-            if (!$stmt->execute()) {
-                throw new Exception('While executing INSERT INTO statement: ' . $db->lastErrorMsg());
+                if (!$stmt->execute()) {
+                    throw new Exception('While executing INSERT INTO statement: ' . $db->lastErrorMsg());
+                }
             }
+            $db->query('COMMIT;');
         }
-        $db->query('COMMIT;');
 
         $reload = true;
         JSON_success();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [ ] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ ] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

I misclicked while configuring my adlists and got an error because I selected no groups. The code still worked before but this prevents an error from showing up.

**How does this PR accomplish the above?:**

`$_POST['groups']` doesn't exist when no groups are selected (instead of being an empty array). Could probably do this in the frontend as well.
