### PR TITLE
Use hash_equals when comparing to pwhash from cookie

### DIFF
--- a/scripts/pi-hole/php/password.php
+++ b/scripts/pi-hole/php/password.php
@@ -42,7 +42,7 @@
         // Check for and authorize from persistent cookie 
         if (isset($_COOKIE["persistentlogin"]))
         {
-            if ($pwhash === $_COOKIE["persistentlogin"])
+            if (hash_equals($pwhash, $_COOKIE["persistentlogin"]))
             {
                 $auth = true;
                 // Refresh cookie with new expiry


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

As discussed at the Pi-hole security mailbox, opening a PR to address this: 

In the file `scripts/pi-hole/php/password.php` for the Pi-hole web user interface, I noted that most comparisons are made in a time safe manner, however there is a single authentication relevant comparison made which does not utilise this protection. Namely here https://github.com/pi-hole/AdminLTE/blob/8ac95be7c1870b3c10824fdb70ed216ad334f0aa/scripts/pi-hole/php/password.php#L45 a basic (type safe) equality is made when comparing the string stored in the cookie `persistentlogin` to the password hash stored on disk. It may therefore be possible to infer the stored password hash by carrying out a timing attack against this parameter.

This PR aims to prevent the possibility of a timing attack against the `persistentlogin` cookie to reveal the stored password hash.

**How does this PR accomplish the above?:**

Use `hash_equals` for this comparison, as is currently done in similar operations.

**What documentation changes (if any) are needed to support this PR?:**

None.
