### PR TITLE
Validate target domain for CNAME records

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -303,7 +303,7 @@ function addCustomCNAMEEntry($domain="", $target="", $json=true)
             return returnError("Target must be set", $json);
 
         if (!is_valid_domain_name($target))
-            return returnError("Trget must be valid", $json);
+            return returnError("Target must be valid", $json);
 
         // Check if each submitted domain is valid
         $domains = array_map('trim', explode(",", $domain));

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -302,6 +302,9 @@ function addCustomCNAMEEntry($domain="", $target="", $json=true)
         if (empty($target))
             return returnError("Target must be set", $json);
 
+        if (!is_valid_domain_name($target))
+            return returnError("Trget must be valid", $json);
+
         // Check if each submitted domain is valid
         $domains = array_map('trim', explode(",", $domain));
         foreach ($domains as $d) {


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

When a user adds a CNAME record, the target domains is not validated. This allows adding invalid domains which can't be deleted from the web interface.

https://github.com/pi-hole/pi-hole/issues/3913#issuecomment-747320347
https://discourse.pi-hole.net/t/local-dns-cname-unable-to-remove-entries/41004

This PR ensures that also the target domain is validated. 


**How does this PR accomplish the above?:**

Re-use the already implemented validation function

