### PR TITLE
Add hint to the web interface about the limits of CNAME records

### DIFF
--- a/cname_records.php
+++ b/cname_records.php
@@ -40,7 +40,7 @@
             </div>
             <div class="box-footer clearfix">
               <strong>Note:</strong>
-                  <p>The target of a CNAME must be a domain that the Pi-hole knows the A value for, or is authoritative for that domain.</p>
+                  <p>The target of a <code>CNAME</code> must be a domain that the Pi-hole knows the <code>A</code> value for, or is authoritative for that domain.</p>
                   <p>Pi-hole will not do additional queries if you set the target to a domain that isn't already known. It will return the information it knows at the time of the query,
                     without having to send additional queries to an upstream for resolution. That means, for example, target domains that exist as DHCP leases only will not be fully resolved until you specify an explicit DNS entry.</p>
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>

--- a/cname_records.php
+++ b/cname_records.php
@@ -40,10 +40,10 @@
             </div>
             <div class="box-footer clearfix">
               <strong>Note:</strong>
-                  <p>The target of a <code>CNAME</code> must be a domain that the Pi-hole knows the <code>A</code> value for, or is authoritative for that domain.</p>
-                  <p>Pi-hole will not do additional queries if you set the target to a domain that isn't already known. It just returns the information it knows at the time of the query.
-                    This results in certain limitations for <code>CNAME</code> targets, for instance, only <i>active</i> leases work as targets.</p>
-                    <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this would result in an invalid SSL certificate error.
+              <p>The target of a <code>CNAME</code> must be a domain that the Pi-hole already has in its cache or is authoritative for. This is an universal limitation of <code>CNAME</code> records.</p>
+              <p>The reason for this is that Pi-hole will not send additional queries upstream when serving <code>CNAME</code> replies. As consequence, if you set a target that isn't already known, the reply to the client may be incomplete. Pi-hole just returns the information it knows at the time of the query. This results in certain limitations for <code>CNAME</code> targets,
+                for instance, only <i>active</i> DHCP leases work as targets - mere DHCP <i>leases</i> aren't sufficient as they aren't (yet) valid DNS records.</p>
+                <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this could result in invalid SSL certificate errors when the target server does not serve content for the requested domain.</p>
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>
             </div>
         </div>

--- a/cname_records.php
+++ b/cname_records.php
@@ -41,8 +41,8 @@
             <div class="box-footer clearfix">
               <strong>Note:</strong>
                   <p>The target of a <code>CNAME</code> must be a domain that the Pi-hole knows the <code>A</code> value for, or is authoritative for that domain.</p>
-                  <p>Pi-hole will not do additional queries if you set the target to a domain that isn't already known. It will return the information it knows at the time of the query,
-                    without having to send additional queries to an upstream for resolution. That means, for example, target domains that exist as DHCP leases only will not be fully resolved until you specify an explicit DNS entry.</p>
+                  <p>Pi-hole will not do additional queries if you set the target to a domain that isn't already known. It just returns the information it knows at the time of the query.
+                    This results in certain limitations for <code>CNAME</code> targets, for instance, only <i>active</i> leases work as targets.</p>
                     <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this would result in an invalid SSL certificate error.
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>
             </div>

--- a/cname_records.php
+++ b/cname_records.php
@@ -43,6 +43,7 @@
                   <p>The target of a <code>CNAME</code> must be a domain that the Pi-hole knows the <code>A</code> value for, or is authoritative for that domain.</p>
                   <p>Pi-hole will not do additional queries if you set the target to a domain that isn't already known. It will return the information it knows at the time of the query,
                     without having to send additional queries to an upstream for resolution. That means, for example, target domains that exist as DHCP leases only will not be fully resolved until you specify an explicit DNS entry.</p>
+                    <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this would result in an invalid SSL certificate error.
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>
             </div>
         </div>

--- a/cname_records.php
+++ b/cname_records.php
@@ -39,10 +39,10 @@
                 </div>
             </div>
             <div class="box-footer clearfix">
-              <strong>Hints:</strong>
+              <strong>Note:</strong>
                   <p>The target of a CNAME must be a domain that the Pi-hole knows the A value for, or is authoritative for that domain.</p>
                   <p>Pi-hole will not do additional queries if you set the target to a domain that isn't already known. It will return the information it knows at the time of the query,
-                    without having to send additional queries to an upstream for resolution.</p>
+                    without having to send additional queries to an upstream for resolution. That means, for example, target domains that exist as DHCP leases only will not be fully resolved until you specify an explicit DNS entry.</p>
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>
             </div>
         </div>

--- a/cname_records.php
+++ b/cname_records.php
@@ -39,6 +39,10 @@
                 </div>
             </div>
             <div class="box-footer clearfix">
+              <strong>Hints:</strong>
+                  <p>The target of a CNAME must be a domain that the Pi-hole knows the A value for, or is authoritative for that domain.</p>
+                  <p>Pi-hole will not do additional queries if you set the target to a domain that isn't already known. It will return the information it knows at the time of the query,
+                    without having to send additional queries to an upstream for resolution.</p>
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>
             </div>
         </div>


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Pihole does not send additional queries to resolve a CNAME target if it does not know the IP for. Stating this explicite on the CNAME page might prevent additional support load.

See https://discourse.pi-hole.net/t/local-cname-resolution-is-inconsistent/41842

Thanks @dschaper for the firm summary I just copied from the discourse thread.

