### PR TITLE
Fix sorting by reply in Query Log

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -298,7 +298,7 @@ $(function () {
       { width: "36%", render: $.fn.dataTable.render.text() },
       { width: "8%", type: "ip-address", render: $.fn.dataTable.render.text() },
       { width: "14%", orderData: 4 },
-      { width: "8%", orderData: 6 },
+      { width: "8%", orderData: 5 },
       { width: "10%", orderData: 4 }
     ],
     lengthMenu: [


### PR DESCRIPTION
Signed-off-by: Fabian Preuß <preuss_fabian@gmx.de>

**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This PR allows the Query Log to be sorted by the received reply (IP, DOMAIN, NODATA, etc).

**How does this PR accomplish the above?:**

Fixed a typo, wrong column was used to sort data.

**What documentation changes (if any) are needed to support this PR?:**

None.

