### PR TITLE
Add more query type names to title of Query Log instead of "type <id>"

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -59,7 +59,7 @@ else if(isset($_GET["forwarddest"]))
 }
 else if(isset($_GET["querytype"]))
 {
-	$qtypes = ["A (IPv4)", "AAAA (IPv6)", "ANY", "SRV", "SOA", "PTR", "TXT", "NAPTR"];
+	$qtypes = ["A (IPv4)", "AAAA (IPv6)", "ANY", "SRV", "SOA", "PTR", "TXT", "NAPTR", "MX", "DS", "RRSIG", "DNSKEY", "NS", "OTHER"];
 	$qtype = intval($_GET["querytype"]);
 	if($qtype > 0 && $qtype <= count($qtypes))
 		$showing .= " ".$qtypes[$qtype-1]." queries";


### PR DESCRIPTION
Signed-off-by: Fabian Preuß <preuss_fabian@gmx.de>

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This PR allows translation of all query type ids to their respective names in the title of the query log.
![grafik](https://user-images.githubusercontent.com/72616153/103179414-20551400-488c-11eb-9fd9-3089e5d23233.png)
![grafik](https://user-images.githubusercontent.com/72616153/103179415-26e38b80-488c-11eb-8845-5ebcf9913e72.png)

**How does this PR accomplish the above?:**

Added the rest of the known query types from [FTL/src/enums.h](https://github.com/pi-hole/FTL/blob/master/src/enums.h#L84) to the $qtypes array.

**What documentation changes (if any) are needed to support this PR?:**

None.
