### PR TITLE
Bugfix allowing to effectively set empty domain/client/adlist groupsets

### DIFF
--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -382,7 +382,10 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While executing DELETE statement: ' . $db->lastErrorMsg());
         }
 
-        foreach ($_POST['groups'] as $gid) {
+        $groups = array();
+        if(isset($_POST['groups']))
+            $groups = $_POST['groups'];
+        foreach ($groups as $gid) {
             $stmt = $db->prepare('INSERT INTO client_by_group (client_id,group_id) VALUES(:id,:gid);');
             if (!$stmt) {
                 throw new Exception('While preparing INSERT INTO statement: ' . $db->lastErrorMsg());
@@ -400,7 +403,9 @@ if ($_POST['action'] == 'get_groups') {
                 throw new Exception('While executing INSERT INTO statement: ' . $db->lastErrorMsg());
             }
         }
-        $db->query('COMMIT;');
+        if(!$db->query('COMMIT;')) {
+            throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
+        }
 
         $reload = true;
         JSON_success();
@@ -437,7 +442,9 @@ if ($_POST['action'] == 'get_groups') {
         if (!$stmt->execute()) {
             throw new Exception('While executing client statement: ' . $db->lastErrorMsg());
         }
-        $db->query('COMMIT;');
+        if(!$db->query('COMMIT;')) {
+            throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
+        }
 
         $reload = true;
         JSON_success();
@@ -677,7 +684,9 @@ if ($_POST['action'] == 'get_groups') {
             $added++;
         }
 
-        $db->query('COMMIT;');
+        if(!$db->query('COMMIT;')) {
+            throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
+        }
 
         $after = intval($db->querySingle("SELECT COUNT(*) FROM domainlist;"));
         $difference = $after - $before;
@@ -739,39 +748,43 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While executing: ' . $db->lastErrorMsg());
         }
 
-        if (isset($_POST['groups'])) {
-            $stmt = $db->prepare('DELETE FROM domainlist_by_group WHERE domainlist_id = :id');
+        $stmt = $db->prepare('DELETE FROM domainlist_by_group WHERE domainlist_id = :id');
+        if (!$stmt) {
+            throw new Exception('While preparing DELETE statement: ' . $db->lastErrorMsg());
+        }
+
+        if (!$stmt->bindValue(':id', intval($_POST['id']), SQLITE3_INTEGER)) {
+            throw new Exception('While binding id: ' . $db->lastErrorMsg());
+        }
+
+        if (!$stmt->execute()) {
+            throw new Exception('While executing DELETE statement: ' . $db->lastErrorMsg());
+        }
+
+        $groups = array();
+        if(isset($_POST['groups']))
+            $groups = $_POST['groups'];
+        foreach ($groups as $gid) {
+            $stmt = $db->prepare('INSERT INTO domainlist_by_group (domainlist_id,group_id) VALUES(:id,:gid);');
             if (!$stmt) {
-                throw new Exception('While preparing DELETE statement: ' . $db->lastErrorMsg());
+                throw new Exception('While preparing INSERT INTO statement: ' . $db->lastErrorMsg());
             }
 
             if (!$stmt->bindValue(':id', intval($_POST['id']), SQLITE3_INTEGER)) {
                 throw new Exception('While binding id: ' . $db->lastErrorMsg());
             }
 
+            if (!$stmt->bindValue(':gid', intval($gid), SQLITE3_INTEGER)) {
+                throw new Exception('While binding gid: ' . $db->lastErrorMsg());
+            }
+
             if (!$stmt->execute()) {
-                throw new Exception('While executing DELETE statement: ' . $db->lastErrorMsg());
+                throw new Exception('While executing INSERT INTO statement: ' . $db->lastErrorMsg());
             }
+        }
 
-            foreach ($_POST['groups'] as $gid) {
-                $stmt = $db->prepare('INSERT INTO domainlist_by_group (domainlist_id,group_id) VALUES(:id,:gid);');
-                if (!$stmt) {
-                    throw new Exception('While preparing INSERT INTO statement: ' . $db->lastErrorMsg());
-                }
-
-                if (!$stmt->bindValue(':id', intval($_POST['id']), SQLITE3_INTEGER)) {
-                    throw new Exception('While binding id: ' . $db->lastErrorMsg());
-                }
-
-                if (!$stmt->bindValue(':gid', intval($gid), SQLITE3_INTEGER)) {
-                    throw new Exception('While binding gid: ' . $db->lastErrorMsg());
-                }
-
-                if (!$stmt->execute()) {
-                    throw new Exception('While executing INSERT INTO statement: ' . $db->lastErrorMsg());
-                }
-            }
-            $db->query('COMMIT;');
+        if(!$db->query('COMMIT;')) {
+            throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
         }
 
         $reload = true;
@@ -810,7 +823,9 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While executing domainlist statement: ' . $db->lastErrorMsg());
         }
 
-        $db->query('COMMIT;');
+        if(!$db->query('COMMIT;')) {
+            throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
+        }
 
         $reload = true;
         JSON_success();
@@ -856,7 +871,9 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While executing domainlist statement: ' . $db->lastErrorMsg());
         }
 
-        $db->query('COMMIT;');
+        if(!$db->query('COMMIT;')) {
+            throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
+        }
 
         $reload = true;
         JSON_success();
@@ -937,7 +954,9 @@ if ($_POST['action'] == 'get_groups') {
             $added++;
         }
 
-        $db->query('COMMIT;');
+        if(!$db->query('COMMIT;')) {
+            throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
+        }
 
         $reload = true;
         JSON_success();
@@ -993,7 +1012,10 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While executing DELETE statement: ' . $db->lastErrorMsg());
         }
 
-        foreach ($_POST['groups'] as $gid) {
+        $groups = array();
+        if(isset($_POST['groups']))
+            $groups = $_POST['groups'];
+        foreach ($groups as $gid) {
             $stmt = $db->prepare('INSERT INTO adlist_by_group (adlist_id,group_id) VALUES(:id,:gid);');
             if (!$stmt) {
                 throw new Exception('While preparing INSERT INTO statement: ' . $db->lastErrorMsg());
@@ -1012,7 +1034,9 @@ if ($_POST['action'] == 'get_groups') {
             }
         }
 
-        $db->query('COMMIT;');
+        if(!$db->query('COMMIT;')) {
+            throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
+        }
 
         $reload = true;
         JSON_success();
@@ -1050,7 +1074,9 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While executing adlist statement: ' . $db->lastErrorMsg());
         }
 
-        $db->query('COMMIT;');
+        if(!$db->query('COMMIT;')) {
+            throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
+        }
 
         $reload = true;
         JSON_success();
@@ -1090,7 +1116,9 @@ if ($_POST['action'] == 'get_groups') {
                 $added++;
             }
 
-            $db->query('COMMIT;');
+            if(!$db->query('COMMIT;')) {
+                throw new Exception('While commiting changes to the database: ' . $db->lastErrorMsg());
+            }
 
             $after = intval($db->querySingle("SELECT COUNT(*) FROM domain_audit;"));
             $difference = $after - $before;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix deleting of all groups from domains is not possible. Also improve some other aspects, like always reporting `COMMIT` errors and don't work on a possibly non-existing `group` POST variable.

**How does this PR accomplish the above?:**


- Use empty array for `foreach()` when no group is to be set,
- Always commit when editing domains, and
- Report any errors while committing.

This PR is the successor of #1649.

**What documentation changes (if any) are needed to support this PR?:**

None