### PR TITLE
Url of adlist can contain userinfo (basicauth)

### DIFF
--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -921,7 +921,7 @@ if ($_POST['action'] == 'get_groups') {
             }
 
             // this will remove first @ that is after schema and before domain
-          ￼ // $1 is optional schema, $2 is userinfo
+           // $1 is optional schema, $2 is userinfo
             $check_address = preg_replace("|([^:/]*://)?([^/]+)@|", "$1$2", $address, 1);
 
             if(preg_match("/[^a-zA-Z0-9:\/?&%=~._()-;]/", $check_address) !== 0) {

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -920,7 +920,11 @@ if ($_POST['action'] == 'get_groups') {
                 continue;
             }
 
-            if(preg_match("/[^a-zA-Z0-9:\/?&%=~._()-;]/", $address) !== 0) {
+            // this will remove first @ that is after schema and before domain
+          ￼ // $1 is optional schema, $2 is userinfo
+            $check_address = preg_replace("|([^:/]*://)?([^/]+)@|", "$1$2", $address, 1);
+
+            if(preg_match("/[^a-zA-Z0-9:\/?&%=~._()-;]/", $check_address) !== 0) {
                 throw new Exception('<strong>Invalid adlist URL ' . htmlentities($address) . '</strong><br>'.
                 'Added ' . $added . " out of ". $total . " adlists");
             }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This PR is admin page side of fix for parsing adlist urls, https://github.com/pi-hole/pi-hole/pull/3912

**How does this PR accomplish the above?:**

Similar to the pi-hole code, before validation against regex, char `@` is removed if it is inside of authority section of url. Then already existing regex is used to check if only allowed chars are present in url.

**What documentation changes (if any) are needed to support this PR?:**

No documentation is needed as this is only change of check on backend side, no user facing change.