### PR TITLE
Check for FTLPORT in pihole-FTL.conf

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -12,8 +12,21 @@ if(!isset($api))
 	die("Direct call to api_FTL.php is not allowed!");
 }
 
+$FTL_PORT = 4711;
+// check if /etc/pihole/pihole-FTL.conf exists and FTLPORT is set
+if (file_exists('/etc/pihole/pihole-FTL.conf')) {
+	foreach (explode("\n", file_get_contents('/etc/pihole/pihole-FTL.conf')) as $line) {
+		if (strstr($line, '=')) {
+			$data = explode('=', $line);
+			if ($data[0] == 'FTLPORT') {
+				$FTL_PORT = $data[1];
+			}
+		}
+	}
+}
+
 // $FTL_IP is defined in api.php
-$socket = connectFTL($FTL_IP);
+$socket = connectFTL($FTL_IP, $FTL_PORT);
 
 if(!is_resource($socket))
 {


### PR DESCRIPTION
Signed-off-by: Philipp Kolmann <philipp@kolmann.at>

**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
I have another process running on port 4711. Therefore I have set FTLPORT in pihole-FTL.conf. Sadly the Web API doesn't recognize this setting and therefore can't fetch any information from the FTL daemon.


**How does this PR accomplish the above?:**

It checks for the existence of /etc/pihole/pihole-FTL.conf and for FTLPORT therein and uses this setting to connect to the proper port.

**What documentation changes (if any) are needed to support this PR?:**

none.

