### PR TITLE
Necessary changes for dnsmasq v2.84

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -98,7 +98,7 @@ function getQueryTypes() {
   }
 
   if ($("#type_forwarded").prop("checked")) {
-    queryType.push(2);
+    queryType.push([2, 14]);
   }
 
   if ($("#type_cached").prop("checked")) {
@@ -271,6 +271,12 @@ $(function () {
           color = "green";
           fieldtext = "Retried <br class='hidden-lg'>(ignored)";
           buttontext = "";
+          break;
+        case 14:
+          color = "green";
+          fieldtext = "OK <br class='hidden-lg'>(already forwarded)";
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         default:
           color = "black";

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -195,6 +195,12 @@ $(function () {
           fieldtext = "Retried <br class='hidden-lg'>(ignored)";
           buttontext = "";
           break;
+        case "14":
+          colorClass = "text-green";
+          fieldtext = "OK <br class='hidden-lg'>(already forwarded)" + dnssecStatus;
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
+          break;
         default:
           colorClass = false;
           fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix `Unknown (0)` queries as reported in https://github.com/pi-hole/AdminLTE/issues/1713

**How does this PR accomplish the above?:**

`dnsmasq-v2.83+` forwards multiple queries to the same destination once and stores the other queries as duplicates. They do receive the answer later on, however, this is usually not logged (when `log-queries=extra` is enabled, there will be a warning about the duplicate). https://github.com/pi-hole/FTL/pull/1040 introduces a new reply type 14 = "already forwarded" to fix this.

*Note: This PR can be merged at any time and does not depend on the FTL PR being merged at all*

**What documentation changes (if any) are needed to support this PR?:**

https://docs.pi-hole.net/database/ftl/#supported-status-types needs updating