### PR TITLE
Pi-hole web v5.3.2

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -98,7 +98,7 @@ function getQueryTypes() {
   }
 
   if ($("#type_forwarded").prop("checked")) {
-    queryType.push(2);
+    queryType.push([2, 14]);
   }
 
   if ($("#type_cached").prop("checked")) {
@@ -271,6 +271,12 @@ $(function () {
           color = "green";
           fieldtext = "Retried <br class='hidden-lg'>(ignored)";
           buttontext = "";
+          break;
+        case 14:
+          color = "green";
+          fieldtext = "OK <br class='hidden-lg'>(already forwarded)";
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         default:
           color = "black";

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -195,6 +195,12 @@ $(function () {
           fieldtext = "Retried <br class='hidden-lg'>(ignored)";
           buttontext = "";
           break;
+        case "14":
+          colorClass = "text-green";
+          fieldtext = "OK <br class='hidden-lg'>(already forwarded)" + dnssecStatus;
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
+          break;
         default:
           colorClass = false;
           fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";


### PR DESCRIPTION
This PR fixes `Unknown (0)` queries as reported in https://github.com/pi-hole/AdminLTE/issues/1713

Reason: `dnsmasq-v2.83+` forwards multiple queries to the same destination once and stores the other queries as duplicates. They do receive the answer later on, however, this is usually not logged (when `log-queries=extra` is enabled, there will be a warning about the duplicate). FTL v5.6 introduces a new reply type `14` = "already forwarded" to fix this.