### PR TITLE
Typo fixed in save settings

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -727,7 +727,7 @@ function addStaticDHCPLease($mac, $ip, $hostname) {
 					}
 					else
 					{
-						$success .= "The privacy level has been not been changed";
+						$success .= "The privacy level has not been changed";
 					}
 				}
 				else


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixes a user-facing typo in the settings screen.

**How does this PR accomplish the above?:**

**What documentation changes (if any) are needed to support this PR?:**