### PR TITLE
Add hint for update command & documentation link

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -92,6 +92,9 @@
                         <?php if ($FTL_update) { ?> &middot; <a class="lookatme" href="<?php echo $ftlReleasesUrl . "/latest"; ?>" rel="noopener" target="_blank">Update available!</a><?php } ?>
                     </li>
                 </ul>
+                <?php if($core_update || $web_update || $FTL_update) { ?>
+                    <p>To install updates, run <a  href="https://docs.pi-hole.net/main/update/">pihole -up</a>.</p>
+                <?php } ?>
                 <?php } ?>
             </div>
         </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Clarify the update process : the flashing link to the changelog is cool, but does not remind how to install updates. 
Since I check that a few times a year at most, I often forget how to install the updates.
I always end up googling "pihole update" 🙃 

**How does this PR accomplish the above?:**

- Display a reminder of the command `pihole -up` in the footer when an update is pending
- Provide a link to the update section of the documentation

![Capture d’écran, le 2021-02-24 à 23 55 40](https://user-images.githubusercontent.com/143380/109105762-8e874d00-76fc-11eb-9f06-8f39017c1251.png)


**What documentation changes (if any) are needed to support this PR?:**

None
