### PR TITLE
Simple typo fix:  static release -> static lease.

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -230,7 +230,7 @@ function addStaticDHCPLease($mac, $ip, $hostname) {
 		foreach($dhcp_static_leases as $lease) {
 			if($lease["hwaddr"] === $mac)
 			{
-				throw new Exception("Static release for MAC address (".htmlspecialchars($mac).") already defined!<br>", 4);
+				throw new Exception("Static lease for MAC address (".htmlspecialchars($mac).") already defined!<br>", 4);
 			}
 			if($ip !== "noip" && $lease["IP"] === $ip)
 			{


### PR DESCRIPTION
Signed-off-by: Will Cooke <will@whizzy.org>

**By submitting this pull request, I confirm the following:** 


- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ ] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixes a simple typo when creating a static DHCP lease for an existing MAC address:

![image](https://user-images.githubusercontent.com/6552931/109391080-3ecba000-790d-11eb-9d30-aeb182960ef3.png)


**How does this PR accomplish the above?:**

Simple typo fix.

**What documentation changes (if any) are needed to support this PR?:**

N/A

