### PR TITLE
simple ldap authentication mode

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "description": "Pi-hole Dashboard for stats and more",
     "require": {
         "php": ">=5.4",
-        "phpstan/phpstan": "^0.12.42"
+        "phpstan/phpstan": "^0.12.42",
+        "ext-ldap": "*"
     },
     "license": "EUPL-1.2",
     "minimum-stability": "stable",

--- a/scripts/pi-hole/php/authentication.php
+++ b/scripts/pi-hole/php/authentication.php
@@ -1,0 +1,106 @@
+<?php
+require_once('password_authentication.php');
+require_once('ldap_authentication.php');
+
+class Authentication
+{
+
+    private $config;
+    private $passwordAuthentication;
+    private $ldapAuthentication;
+    private $ldapAuth;
+
+    public function __construct($config)
+    {
+        $this->config = $config;
+        $this->passwordAuthentication = new PasswordAuthentication($config);
+        $this->ldapAuthentication = new LdapAuthentication($config);
+        $this->ldapAuth = $this->isLdapAuth();
+    }
+
+    public function passwordHash()
+    {
+        return $this->passwordAuthentication->passwordHash();
+    }
+
+    private function isPasswordAuth()
+    {
+        return $this->passwordAuthentication->passwordHash() != '';
+    }
+
+    public function isLdapAuth()
+    {
+        $auth = $this->config['LDAP_AUTH'];
+        if (!isset($auth))
+            return false;
+        return $auth == 1;
+    }
+
+    public function isAuthEnabled()
+    {
+        return $this->isPasswordAuth() || $this->isLdapAuth();
+    }
+
+    private function authenticateLdap($username, $password)
+    {
+        return $this->ldapAuthentication->authenticate($username, $password);
+    }
+
+    private function authenticatePassword($persistentLogin, $password)
+    {
+        return $this->passwordAuthentication->authenticate($persistentLogin, $password);
+    }
+
+    private function authenticateApi($authHash)
+    {
+        return $this->passwordAuthentication->passwordHashMatches($authHash);
+    }
+
+    private function sessionExists()
+    {
+        $res = isset($_SESSION["hash"]);
+        error_log("authenticated: " . $res);
+        return $res;
+    }
+
+    private function createSession()
+    {
+        error_log("create session, ldap: " . $this->ldapAuth);
+        session_regenerate_id();
+        $_SESSION = array();
+        if ($this->ldapAuth) {
+            $hash = "ldap";
+        } else {
+            $hash = $this->passwordHash();;
+        }
+        $_SESSION["hash"] = $hash;
+        header('Location: index.php');
+        exit();
+    }
+
+    public function authenticate()
+    {
+        if ($this->isAuthEnabled() && !$this->sessionExists()) {
+            $wrongPassword = false;
+            $password = $_POST["pw"];
+            if ($this->ldapAuth) {
+                $authenticated = $this->authenticateLdap($_POST["username"], $password);
+            } else {
+                $authenticated = $this->authenticatePassword($_COOKIE["persistentlogin"], $password);
+            }
+            if ($authenticated) {
+                $this->createSession();
+            } else {
+                $wrongPassword = isset($password);
+                $authHash = $_GET["auth"];
+                if (isset($api) && isset($authHash)) {
+                    $authenticated = $this->authenticateApi($authHash);
+                }
+            }
+            return new UserAuthStatus($authenticated, $wrongPassword, $this->ldapAuth);
+        } else {
+            return new UserAuthStatus(true, false, false);
+        }
+    }
+
+}

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -290,7 +290,7 @@ if($auth) {
                                         <a class="btn-link" href="https://github.com/pi-hole/pi-hole/releases" rel="noopener" target="_blank">Updates</a>
                                     </div>
                                     <div id="sessiontimer" class="col-xs-12 text-center">
-                                        <strong>Session is valid for <span id="sessiontimercounter"><?php if($auth && strlen($pwhash) > 0){echo $maxlifetime;}else{echo "0";} ?></span></strong>
+                                        <strong>Session is valid for <span id="sessiontimercounter"><?php if($auth && $authEnabled){echo $maxlifetime;}else{echo "0";} ?></span></strong>
                                     </div>
                                 </div>
                             </li>
@@ -624,8 +624,7 @@ if($auth) {
                 </li>
                 <!-- Logout -->
                 <?php
-                // Show Logout button if $auth is set and authorization is required
-                if(strlen($pwhash) > 0) { ?>
+                if($authEnabled) { ?>
                 <li>
                     <a href="?logout">
                         <i class="fa fa-fw fa-user-times"></i> <span>Logout</span>
@@ -636,7 +635,7 @@ if($auth) {
                 <!-- Login -->
                 <?php
                 // Show Login button if $auth is *not* set and authorization is required
-                if(strlen($pwhash) > 0 && !$auth) { ?>
+                if($authEnabled && !$auth) { ?>
                 <li<?php if($scriptname === "login"){ ?> class="active"<?php } ?>>
                     <a href="index.php?login">
                         <i class="fa fa-fw fa-user"></i> <span>Login</span>

--- a/scripts/pi-hole/php/ldap_authentication.php
+++ b/scripts/pi-hole/php/ldap_authentication.php
@@ -1,0 +1,23 @@
+<?php
+require_once('user_auth_status.php');
+
+class LdapAuthentication
+{
+
+    private $config;
+
+    function __construct($config)
+    {
+        $this->config = $config;
+    }
+
+    public function authenticate($username, $password)
+    {
+        $server = $this->config['LDAP_SERVER'];
+        $ldap = ldap_connect($server);
+        ldap_set_option($ldap, LDAP_OPT_PROTOCOL_VERSION, 3);
+        ldap_set_option($ldap, LDAP_OPT_REFERRALS, 0);
+        $bindDn = sprintf($this->config['LDAP_BIND_DN'], $username);
+        return @ldap_bind($ldap, $bindDn, $password);
+    }
+}

--- a/scripts/pi-hole/php/loginpage.php
+++ b/scripts/pi-hole/php/loginpage.php
@@ -27,7 +27,10 @@
     <div class="panel-body">
       <form action="" id="loginform" method="post">
         <div class="form-group has-feedback <?php if ($wrongpassword) { ?>has-error<?php } ?>">
-          <input type="password" id="loginpw" name="pw" class="form-control" placeholder="Password" autofocus>
+          <?php if ($ldapAuth) { ?>
+          <input id="username" name="username" class="form-control" placeholder="Username" autofocus>
+          <?php } ?>
+          <input type="password" id="loginpw" name="pw" class="form-control" placeholder="Password">
           <span class="fa fa-key form-control-feedback"></span>
         </div>
         <div class="row">
@@ -62,10 +65,14 @@
                 </div>
               </div>
               <div class="box-body">
-                After installing Pi-hole for the first time, a password is generated and displayed to the user. The
-                password cannot be retrieved later on, but it is possible to set a new password (or explicitly disable
-                the password by setting an empty password) using the command
-                <pre>sudo pihole -a -p</pre>
+                  <?php if ($ldapAuth) { ?>
+                      Ask LDAP administrator to reset your password
+                  <?php } else { ?>
+                      After installing Pi-hole for the first time, a password is generated and displayed to the user. The
+                      password cannot be retrieved later on, but it is possible to set a new password (or explicitly disable
+                      the password by setting an empty password) using the command
+                      <pre>sudo pihole -a -p</pre>
+                  <?php } ?>
               </div>
             </div>
           </div>

--- a/scripts/pi-hole/php/password.php
+++ b/scripts/pi-hole/php/password.php
@@ -6,113 +6,33 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
-    require_once('func.php');
+require_once('func.php');
+require_once('authentication.php');
 
-    // Start a new PHP session (or continue an existing one)
-    // Prevents javascript XSS attacks aimed to steal the session ID
-    ini_set('session.cookie_httponly', 1);
-    // Prevent Session ID from being passed through  URLs
-    ini_set('session.use_only_cookies', 1);
-    session_start();
+// Start a new PHP session (or continue an existing one)
+// Prevents javascript XSS attacks aimed to steal the session ID
+ini_set('session.cookie_httponly', 1);
+// Prevent Session ID from being passed through  URLs
+ini_set('session.use_only_cookies', 1);
+session_start();
 
-    // Read setupVars.conf file
-    $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
-    // Try to read password hash from setupVars.conf
-    if(isset($setupVars['WEBPASSWORD']))
-    {
-        $pwhash = $setupVars['WEBPASSWORD'];
-    }
-    else
-    {
-        $pwhash = "";
-    }
+// If the user wants to log out, we free all session variables currently registered
+// and delete any persistent cookie.
+if(isset($_GET["logout"]))
+{
+    session_unset();
+    setcookie('persistentlogin', '', 1);
+    header('Location: index.php');
+    exit();
+}
 
-    // If the user wants to log out, we free all session variables currently registered
-    // and delete any persistent cookie.
-    if(isset($_GET["logout"]))
-    {
-        session_unset();
-        setcookie('persistentlogin', '', 1);
-        header('Location: index.php');
-        exit();
-    }
+$setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
+$authentication = new Authentication($setupVars);
+$status = $authentication->authenticate();
+$ldapAuth = $status->ldapAuth;
+$wrongpassword = $status->wrongPassword;
+$auth = $status->authenticated;
+$pwhash = $authentication->passwordHash();
+$authEnabled = $authentication->isAuthEnabled();
 
-    $wrongpassword = false;
-    $auth = false;
-
-    // Test if password is set
-    if(strlen($pwhash) > 0)
-    {
-        // Check for and authorize from persistent cookie
-        if (isset($_COOKIE["persistentlogin"]))
-        {
-            if (hash_equals($pwhash, $_COOKIE["persistentlogin"]))
-            {
-                $auth = true;
-                // Refresh cookie with new expiry
-                setcookie('persistentlogin', $pwhash, time()+60*60*24*7);
-            }
-            else
-            {
-                // Invalid cookie
-                $auth = false;
-                setcookie('persistentlogin', '', 1);
-            }
-        }
-        // Compare doubly hashes password input with saved hash
-        else if(isset($_POST["pw"]))
-        {
-            $postinput = hash('sha256',hash('sha256',$_POST["pw"]));
-            if(hash_equals($pwhash, $postinput))
-            {
-                // Regenerate session ID to prevent session fixation
-                session_regenerate_id();
-
-                // Clear the old session
-                $_SESSION = array();
-
-                // Set hash in new session
-                $_SESSION["hash"] = $pwhash;
-
-                // Login successful, redirect the user to the homepage to discard the POST request
-                if ($_SERVER['REQUEST_METHOD'] === 'POST' && $_SERVER['QUERY_STRING'] === 'login') {
-                    // Set persistent cookie if selected
-                    if (isset($_POST['persistentlogin']))
-                    {
-                        setcookie('persistentlogin', $pwhash, time()+60*60*24*7);
-                    }
-                    header('Location: index.php');
-                    exit();
-                }
-
-                $auth = true;
-            }
-            else
-            {
-                $wrongpassword = true;
-            }
-        }
-        // Compare auth hash with saved hash
-        else if (isset($_SESSION["hash"]))
-        {
-            if(hash_equals($pwhash, $_SESSION["hash"]))
-                $auth = true;
-        }
-        // API can use the hash to get data without logging in via plain-text password
-        else if (isset($api) && isset($_GET["auth"]))
-        {
-            if(hash_equals($pwhash, $_GET["auth"]))
-                $auth = true;
-        }
-        else
-        {
-            // Password or hash wrong
-            $auth = false;
-        }
-    }
-    else
-    {
-        // No password set
-        $auth = true;
-    }
 ?>

--- a/scripts/pi-hole/php/password_authentication.php
+++ b/scripts/pi-hole/php/password_authentication.php
@@ -1,0 +1,58 @@
+<?php
+require_once('user_auth_status.php');
+
+class PasswordAuthentication
+{
+
+    private $config;
+
+    function __construct($config)
+    {
+        $this->config = $config;
+    }
+
+    function passwordHashMatches($authHash)
+    {
+        return hash_equals($this->passwordHash(), $authHash);
+    }
+
+    public function passwordHash()
+    {
+        $password = $this->config['WEBPASSWORD'];
+        if (isset($password))
+            return $password;
+        return '';
+    }
+
+    function passwordMatches($password)
+    {
+        $hash = hash('sha256', hash('sha256', $password));
+        return hash_equals($this->passwordHash(), $hash);
+    }
+
+    function authenticate($persistentLogin, $password)
+    {
+        if (isset($persistentLogin)) {
+            $authenticated = $this->passwordHashMatches($persistentLogin);
+            if ($authenticated) {
+                setcookie('persistentlogin', $this->passwordHash(), time() + 60 * 60 * 24 * 7);
+            } else {
+                setcookie('persistentlogin', '', 1);
+            }
+            return $authenticated;
+        }
+
+        if (isset($password)) {
+            $authenticated = $this->passwordMatches($password);
+            if ($authenticated) {
+                if ($_SERVER['REQUEST_METHOD'] === 'POST' && $_SERVER['QUERY_STRING'] === 'login') {
+                    if (isset($_POST['persistentlogin'])) {
+                        setcookie('persistentlogin', $this->passwordHash(), time() + 60 * 60 * 24 * 7);
+                    }
+                }
+            }
+            return $authenticated;
+        }
+        return false;
+    }
+}

--- a/scripts/pi-hole/php/user_auth_status.php
+++ b/scripts/pi-hole/php/user_auth_status.php
@@ -1,0 +1,15 @@
+<?php
+
+class UserAuthStatus {
+
+    public $authenticated;
+    public $wrongPassword;
+    public $ldapAuth;
+
+    public function __construct($authenticated, $wrongPassword, $ldapAuth) {
+        $this->authenticated = $authenticated;
+        $this->wrongPassword = $wrongPassword;
+        $this->ldapAuth = $ldapAuth;
+    }
+
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Allows to enable LDAP for user authentication.
Sample config:
```
LDAP_AUTH=true
LDAP_SERVER=ldap://localhost
LDAP_BIND_DN="cn=%s,ou=users,dc=syncloud,dc=org"
```

**How does this PR accomplish the above?:**

Adds ldap auth code and introduces a switch.

**What documentation changes (if any) are needed to support this PR?:**

No
