### PR TITLE
adds group management functionality

### DIFF
--- a/api.php
+++ b/api.php
@@ -163,6 +163,7 @@ elseif (isset($_GET['list']))
 
 // Other API functions
 require("api_FTL.php");
+require("api_FTLGroups.php");
 
 header('Content-type: application/json');
 if(isset($_GET["jsonForceObject"]))

--- a/api_FTLGroups.php
+++ b/api_FTLGroups.php
@@ -1,0 +1,89 @@
+<?php
+/*   Pi-hole: A black hole for Internet advertisements
+*    (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+*    Network-wide ad blocking via your own hardware.
+*
+*    This file is copyright under the latest version of the EUPL.
+*    Please see LICENSE file for your rights under this license */
+
+
+if(!isset($api))
+{
+	die("Direct call to api_FTLGroups.php is not allowed!");
+}
+
+if ((isset($_GET['enableGroup']) || isset($_GET['disableGroup'])) && $auth) {
+	// Enable or disable group based on name
+
+	$GRAVITYDB = getGravityDBFilename();
+	$db = SQLite3_connect($GRAVITYDB, SQLITE3_OPEN_READWRITE);
+
+	$groupname="";
+	$enabled=0;
+
+	if (isset($_GET['enableGroup'])) {
+		$groupname=$_GET['enableGroup'];
+		$enabled=1;
+	} elseif (isset($_GET['disableGroup'])) {
+
+		$groupname=$_GET['disableGroup'];
+		$enabled=0;
+	} else {
+		die("We shouldn't ever be here");
+	}
+
+	try {
+		$stmt = $db->prepare('UPDATE "group" SET enabled=:enabled WHERE name = :name');
+		if (!$stmt) {
+			throw new Exception('While preparing statement: ' . $db->lastErrorMsg());
+		}
+
+		$status = ((int) $enabled) !== 0 ? 1 : 0;
+		if (!$stmt->bindValue(':enabled', $enabled, SQLITE3_INTEGER)) {
+			throw new Exception('While binding enabled: ' . $db->lastErrorMsg());
+		}
+
+		if (!$stmt->bindValue(':name', $groupname, SQLITE3_TEXT)) {
+			throw new Exception('While binding name: ' . $db->lastErrorMsg());
+		}
+
+		if (!$stmt->execute()) {
+			throw new Exception('While executing: ' . $db->lastErrorMsg());
+		}
+		
+		pihole_execute('restartdns reload-lists');
+
+		$data=array('success' => true, 'message' => 'No exceptions thrown');	
+	} catch (\Exception $ex) {
+		$data=array('success' => false, 'message' => $ex->getMessage());
+	}
+} elseif (isset($_GET['getGroupEnabled']) && $auth) {
+	//Check status of group
+
+	$GRAVITYDB = getGravityDBFilename();
+	$db = SQLite3_connect($GRAVITYDB);
+
+	try {
+		$stmt = $db->prepare('SELECT enabled FROM "group" WHERE name = :name');
+		if (!$stmt) {
+			throw new Exception('While preparing statement: ' . $db->lastErrorMsg());
+		}
+
+		if (!$stmt->bindValue(':name', $_GET['getGroupEnabled'], SQLITE3_TEXT)) {
+			throw new Exception('While binding name: ' . $db->lastErrorMsg());
+		}
+
+		$results = $stmt->execute();
+		
+		if (is_bool($results)) {
+			throw new Exception('While executing: ' . $db->lastErrorMsg());
+		}
+
+		$data=array('success' => true, 'group' => $_GET['getGroupEnabled'], 'enabled' => (bool)($results->fetchArray())['enabled']);
+
+	} catch (\Exception $ex) {
+		$data=array('success' => false, 'message' => $ex->getMessage());
+	}
+
+}
+?>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

The current API doesn't allow for modifying the enabled state of groups or report on their enabled state. Today, the Pi-hole can be entirely disabled or enabled via the API, but not specific subsets within it, such as Groups. With an API to allow this functionality, external applications could trigger Groups to be enabled or disabled programmatically. Specifically (and my use case), allowing HomeKit/Homebridge to be able to enable and disable Groups via the API. Other home automation tools can use the same. 

The usefulness, especially in this pandemic age, is to be able to more easily control children's access to the Internet during times of their online/home learning. Being able to use home automation schedules, triggers, etc to allow a child to use the Internet, but only for school, or completely turning the Internet off at bed time.

**How does this PR accomplish the above?:**

This is a simple change to the API.  First, a require statement is in the api.php file to load the new api_FTLGroups.php file.  The api_FTLGroups.php file is a new file, that contains 2 functions, one to enable or disable a group based on its name, and the second function to get the status of enabled or disabled based on a Group name.

**What documentation changes (if any) are needed to support this PR?:**

API functionality, stating availability of the new GET strings: `enableGroup`, `disableGroup`, `getGroupEnabled`
