### PR TITLE
Handle empty "" domain in query top list correctly

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -104,6 +104,7 @@ else
 		foreach($return as $line)
 		{
 			$tmp = explode(" ",$line);
+			if(count($tmp) == 2) $tmp[2]="";
 			$domain = utf8_encode($tmp[2]);
 			$top_queries[$domain] = intval($tmp[1]);
 		}


### PR DESCRIPTION
If an empty domains requests "" in top queries we get "PHP Notice:  Undefined offset: 2 in /var/www/html/admin/api_FTL.php on line 107" in web-server logs.
This workaround suppress this error.

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

`{A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues}`

**How does this PR accomplish the above?:**

`{A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix}`

**What documentation changes (if any) are needed to support this PR?:**

`{A detailed list of any necessary changes}`

> - `{Please delete this quoted section when opening your pull request}`
> - You must follow the template instructions. Failure to do so will result in your issue being closed.
> - Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
> - Detail helps us understand an issue quicker, but please ensure it's relevant.
