### PR TITLE
Add forgotton target _blank

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -93,7 +93,7 @@
                     </li>
                 </ul>
                 <?php if($core_update || $web_update || $FTL_update) { ?>
-                    <p>To install updates, run <a  href="https://docs.pi-hole.net/main/update/">pihole -up</a>.</p>
+                    <p>To install updates, run <a  href="https://docs.pi-hole.net/main/update/" rel="noopener" target="_blank">pihole -up</a>.</p>
                 <?php } ?>
                 <?php } ?>
             </div>


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

https://github.com/pi-hole/AdminLTE/pull/1749 added a link to the documentation if an update is available. "target="_blank" was forgotton.

Fixes https://github.com/pi-hole/pi-hole/issues/4151
