### PR TITLE
Improvement to readability of footer "update" command text

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -93,7 +93,7 @@
                     </li>
                 </ul>
                 <?php if($core_update || $web_update || $FTL_update) { ?>
-                    <p>To install updates, run <a  href="https://docs.pi-hole.net/main/update/">pihole -up</a>.</p>
+                    <p>To install updates, run <code><a href="https://docs.pi-hole.net/main/update/">pihole -up</a></code>.</p>
                 <?php } ?>
                 <?php } ?>
             </div>


### PR DESCRIPTION
Signed-off-by: Sean F Quinn <sean@esqew.com>

**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Fix for pi-hole/AdminLTE#1796 (readability and standardization for the Pi-Hole update command in the interface)

**How does this PR accomplish the above?:**
Wrapped the command text in a `<code></code>` element.
![image](https://user-images.githubusercontent.com/836198/117345197-427f2400-ae74-11eb-9fe3-edb22ac7c5aa.png)

**What documentation changes (if any) are needed to support this PR?:**
None!