### PR TITLE
Enable comments when adding domains via api.php's list functionality

### DIFF
--- a/api.php
+++ b/api.php
@@ -142,6 +142,10 @@ elseif (isset($_GET['list']))
 		// Set POST parameters and invoke script to add domain to list
 		$_POST['domain'] = $_GET['add'];
 		$_POST['action'] = 'add_domain';
+		if (isset($_GET['comment']))
+		{
+		    $_POST['comment'] = $_GET['comment'];
+		}
 		require("scripts/pi-hole/php/groups.php");
 	}
 	elseif (isset($_GET['sub']))


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Enhancing api.php so that programatically adding domains can include comments describing those domains.
**How does this PR accomplish the above?:**

By passing through the 'comment' parameter from api.php's GET request to groups.php's POST request

**What documentation changes (if any) are needed to support this PR?:**

Updating the description of this api method to include the ability to set comments.

