### PR TITLE
Improve `theme-color` and `background-color` for different themes

### DIFF
--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -181,7 +181,13 @@
     <link rel="shortcut icon" href="img/favicons/favicon.ico">
     <meta name="msapplication-TileColor" content="#367fa9">
     <meta name="msapplication-TileImage" content="img/favicons/mstile-150x150.png">
+<?php if ($theme == "default-light") { ?>
     <meta name="theme-color" content="#367fa9">
+<?php } elseif ($theme == "default-dark") { ?>
+    <meta name="theme-color" content="#272c30">
+<?php } elseif ($theme == "default-darker") { ?>
+    <meta name="theme-color" content="#2e6786">
+<?php } ?>
 
 <?php if ($darkmode) { ?>
     <style>

--- a/style/themes/default-dark.css
+++ b/style/themes/default-dark.css
@@ -9,6 +9,7 @@
 *  https://github.com/anvyst/adminlte-skin-midnight */
 
 body {
+  background-color: #353c42;
   color: #bec5cb;
 }
 h4 {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

The `theme-color` sets the color of the browser interface at the top of the window and some other UI elements for some browsers (namely I've seen it on the navigation bar at the top of the screen on Safari 15 beta, but I believe the same also applies for the address bar in Chrome on Android).

Currently it is always set to the same blue color behind the "Pi-hole" text in the upper left corner on desktop and top of the page in mobile (when in light mode):

<img width="258" alt="Screen Shot 2021-06-19 at 1 07 44 AM" src="https://user-images.githubusercontent.com/79120643/122631609-4b425700-d0bc-11eb-92b5-56929591aeef.png">

However, `theme-color` does not change even if the theme changes. The color behind the "Pi-hole" text is gray on dark mode and a darker blue in darker mode, so the color of the browser no longer matches this correctly, and thus doesn't "flow" well with the webpage on themes other than light mode. This aims to improve on this.

Also, the `background-color` for dark mode seems to be missing, which is noticeable on Safari 15 on iOS because the address bar takes a white background color when it is collapsed.

Unfortunately, I don't think I'm able to show screenshots of these changes on Safari 15 (Apple beta NDAs are weird), and I don't have an Android device to test Chrome. You should be able to check this by changing the themes between light/dark/darker modes and observing the address bar's color.

**How does this PR accomplish the above?:**

Changes the `theme-color` to match the color behind the "Pi-hole" text as shown above depending on theme, as well as changes the `background-color` to be gray in `default-dark.css`

**What documentation changes (if any) are needed to support this PR?:**

None
