### PR TITLE
Added the option for an automatic dark mode based on the device status

### DIFF
--- a/style/themes/custom-auto.css
+++ b/style/themes/custom-auto.css
@@ -1,0 +1,7 @@
+/* Code courtesy of https://blog.jim-nielsen.com/2019/conditional-syntax-highlighting-in-dark-mode-with-css-imports/ */
+
+/* Assume light mode by default */
+@import "default-light.css" screen;
+/* Supersede dark mode when applicable */  
+@import "default-dark.css" screen and (prefers-color-scheme: dark);
+


### PR DESCRIPTION

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

`{A detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues}`

This PR adds the ability to set the PiHole theme to auto, enabling users to have light mode when the device is in light mode and dark mode when the device is in dark moder

**How does this PR accomplish the above?:**

`{A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix}`

The PR adds an additional CSS document that applies the relevant theme on the device theme and adds the option to the themes.php file

**What documentation changes (if any) are needed to support this PR?:**

None

https://user-images.githubusercontent.com/9060360/122794224-4ea43100-d2bc-11eb-9527-89fbf3f5efd5.mov

