### PR TITLE
Fix require func.php

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -11,7 +11,7 @@ header('Content-type: application/json');
 require("scripts/pi-hole/php/database.php");
 require("scripts/pi-hole/php/password.php");
 require("scripts/pi-hole/php/auth.php");
-require("scripts/pi-hole/php/func.php");
+require_once("scripts/pi-hole/php/func.php");
 check_cors();
 
 // Set maximum execution time to 10 minutes


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix errors reported on discourse (https://discourse.pi-hole.net/t/tools-network-errors-in-beta/48611) due to https://github.com/pi-hole/AdminLTE/commit/03920e35956fcb7da91f16aff36217e180b582e4. The commit added `require("scripts/pi-hole/php/func.php");` to `api_db.php` but it was already required by the also included `scripts/pi-hole/php/auth.php`

**How does this PR accomplish the above?:**

Replace `require` with `require_once`

