### PR TITLE
Add interpretation for Pi-hole message type RATE_LIMIT

### DIFF
--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -77,6 +77,17 @@ function renderMessage(data, type, row) {
     case "DNSMASQ_CONFIG":
       return "FTL failed to start due to " + row.message;
 
+    case "RATE_LIMIT":
+      return (
+        "Client " +
+        row.message +
+        " has been rate-limited (current config allows up to " +
+        parseInt(row.blob1, 10) +
+        " queries in " +
+        parseInt(row.blob2, 10) +
+        " seconds)"
+      );
+
     default:
       return "Unknown message type<pre>" + JSON.stringify(row) + "</pre>";
   }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Accompany https://github.com/pi-hole/FTL/pull/1155

**How does this PR accomplish the above?:**

Adding code necessary to pretty-print `RATE_LIMIT` database messages.

Example:

![Screenshot from 2021-08-06 21-34-16](https://user-images.githubusercontent.com/16748619/128563341-418019ad-298f-49b2-9219-b7745d47ada9.png)


**What documentation changes (if any) are needed to support this PR?:**

None