### PR TITLE
Fix TypeError if no extended DNS error is available

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -78,7 +78,7 @@ $(function () {
       var replyid = parseInt(data[5], 10);
       // DNSSEC status
       var dnssecStatus;
-      var ede = data[11];
+      var ede = data[11] ? data[11] : "";
       switch (data[6]) {
         case "1":
           dnssecStatus = '<br><span class="text-green">SECURE';


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

If no extended DNS errors are available, the "ede" variable is assigned an undefined array value, hence "ede" is undefined. Since the `length` method is not available on undefined variables, a TypeError is thrown later in the script, which breaks the DNS queries view in the admin panel. It hence needs to be assured that `.length` is never called on an undefined variable.

**How does this PR accomplish the above?:**

This commit solves the issue by assigning an empty string, if no EDE is available (`data[11]` is undefined), which seems to be the easier way, compared to changing all cases where `ede.length` is called. This way, the `ede.length > 0` checks keep returning false, if no data was passed.

**What documentation changes (if any) are needed to support this PR?:**

None

---

For reference: https://github.com/MichaIng/DietPi/issues/4573#issuecomment-895331367
Issue was observed on Debian Bullseye. But since this is JavaScript, executed in the browser, we're wondering if or why this did not appear before on Buster. Probably something on Bullseye is the reason why no extended DNS errors data is passed in the first place? However, preventing this possible TypeError is a good thing regardless.