### PR TITLE
Stop timer when user reenabled blocking early

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -46,6 +46,11 @@ function countDown() {
   var target = new Date(parseInt(enaT.html(), 10));
   var seconds = Math.round((target.getTime() - Date.now()) / 1000);
 
+  //Stop and remove timer when user enabled early
+  if ($("#pihole-enable").is(":hidden")) {
+    ena.text("Enable");
+    return;
+  }
   if (seconds > 0) {
     setTimeout(countDown, 1000);
     ena.text("Enable (" + secondsTimeSpanToHMS(seconds) + ")");

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -51,6 +51,7 @@ function countDown() {
     ena.text("Enable");
     return;
   }
+
   if (seconds > 0) {
     setTimeout(countDown, 1000);
     ena.text("Enable (" + secondsTimeSpanToHMS(seconds) + ")");


### PR DESCRIPTION
- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix https://github.com/pi-hole/pi-hole/issues/3829

TL,DR:
When disabling blocking for any amount of time, then enabling blocking before the timer ends, and then disabling blocking for an *indefinite* amount of time, the previously set timer will still be displayed. After the now wrong timer has run out, the dashboard will display blocking to be active. 

This is purely cosmetic. Blocking will still be disabled indefinitely, the dashboard will simply display wrong information and show the wrong button for enabling/disabling.

**How does this PR accomplish the above?:**

Stop the timer and remove it from the display by checking if the element displaying the timer was hidden in the meantime.

**What documentation changes (if any) are needed to support this PR?:**

None.