### PR TITLE
Add notes about order of locally stored DNS records

### DIFF
--- a/dns_records.php
+++ b/dns_records.php
@@ -39,6 +39,15 @@
                 </div>
             </div>
             <div class="box-footer clearfix">
+              <strong>Note:</strong>
+              <p>The order of locally defined DNS records is: </p>
+              <ol>
+                  <li>Configured in a config file in <code>/etc/dnsmasq.d/</code></li>
+                  <li>Read from <code>/etc/hosts</code></li>
+                  <li>Read from the list containing the device's host name and pi.hole (stored in <code>/etc/pihole/local.list</code>)</li>
+                  <li>Read from the "Local (custom) DNS" list (stored in <code>/etc/pihole/custom.list</code>)</li>
+              </ol>
+              <p>Only the first record will trigger an address-to-name association.</p>
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>
             </div>
         </div>

--- a/dns_records.php
+++ b/dns_records.php
@@ -42,10 +42,10 @@
               <strong>Note:</strong>
               <p>The order of locally defined DNS records is: </p>
               <ol>
+                  <li>Read from the list containing the device's host name and pi.hole (stored in <code>/etc/pihole/local.list</code>)</li>
                   <li>Configured in a config file in <code>/etc/dnsmasq.d/</code></li>
                   <li>Read from <code>/etc/hosts</code></li>
-                  <li>Read from the list containing the device's host name and pi.hole (stored in <code>/etc/pihole/local.list</code>)</li>
-                  <li>Read from the "Local (custom) DNS" list (stored in <code>/etc/pihole/custom.list</code>)</li>
+                                    <li>Read from the "Local (custom) DNS" list (stored in <code>/etc/pihole/custom.list</code>)</li>
               </ol>
               <p>Only the first record will trigger an address-to-name association.</p>
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>

--- a/dns_records.php
+++ b/dns_records.php
@@ -42,10 +42,10 @@
               <strong>Note:</strong>
               <p>The order of locally defined DNS records is: </p>
               <ol>
-                  <li>Read from the list containing the device's host name and pi.hole (stored in <code>/etc/pihole/local.list</code>)</li>
+                  <li>The device's host name and <code>pi.hole</code></li>
                   <li>Configured in a config file in <code>/etc/dnsmasq.d/</code></li>
                   <li>Read from <code>/etc/hosts</code></li>
-                                    <li>Read from the "Local (custom) DNS" list (stored in <code>/etc/pihole/custom.list</code>)</li>
+                  <li>Read from the "Local (custom) DNS" list (stored in <code>/etc/pihole/custom.list</code>)</li>
               </ol>
               <p>Only the first record will trigger an address-to-name association.</p>
                 <button type="button" id="btnAdd" class="btn btn-primary pull-right">Add</button>


### PR DESCRIPTION
`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Fixes https://github.com/pi-hole/pi-hole/issues/3370.

Adds a note to the local DNS records page about the order in wich different sources of locally stored DNS information are used. Info taken from https://discourse.pi-hole.net/t/custom-dns-observations/27533/18?u=yubiuser.

I'm not sure about #3 since this PR https://github.com/pi-hole/pi-hole/pull/4131

**How does this PR accomplish the above?:**

Only adds text
