### PR TITLE
Add BLOB reply type

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -275,7 +275,8 @@ $(function () {
 
       $("td:eq(5)", row).html(replytext);
 
-      if (data.length > 7) {
+      // Show response time only when reply is not N/A
+      if (data.length > 7 && replyid !== 0) {
         var content = $("td:eq(5)", row).html();
         $("td:eq(5)", row).html(content + " (" + (0.1 * data[7]).toFixed(1) + "ms)");
       }

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -24,6 +24,7 @@ var replyTypes = [
   "upstream error",
   "DNSSEC",
   "NONE",
+  "BLOB",
 ];
 var colTypes = ["time", "query type", "domain", "client", "status", "reply type"];
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Add support for FTL's new `BLOB` datatype and show reply time only when meaningful (i.e., only *after* we received a reply).

**How does this PR accomplish the above?:**

*Basically the same text as above*

**What documentation changes (if any) are needed to support this PR?:**

None