### PR TITLE
Less color for the Query Log

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -110,19 +110,20 @@ $(function () {
       // Query status
       var fieldtext,
         buttontext = "",
-        colorClass = false,
         isCNAME = false,
         regexLink = false;
 
       switch (data[4]) {
         case "1":
-          colorClass = "text-red";
-          fieldtext = "Blocked (gravity)";
+          fieldtext = "<span class='text-red'>Blocked (gravity)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         case "2":
-          fieldtext = replyid === 0 ? "<span class='text-green'>OK</span>, sent to " : "<span class='text-green'>OK</span>, answered by ";
+          fieldtext =
+            replyid === 0
+              ? "<span class='text-green'>OK</span>, sent to "
+              : "<span class='text-green'>OK</span>, answered by ";
           fieldtext +=
             "<br class='hidden-lg'>" +
             (data.length > 10 && data[10] !== "N/A" ? data[10] : "") +
@@ -131,13 +132,13 @@ $(function () {
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         case "3":
-          fieldtext = "<span class='text-green'>OK</span> <br class='hidden-lg'>(cache)" + dnssecStatus;
+          fieldtext =
+            "<span class='text-green'>OK</span> <br class='hidden-lg'>(cache)" + dnssecStatus;
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         case "4":
-          colorClass = "text-red";
-          fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist)";
+          fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist)";
 
           if (data.length > 9 && data[9] > 0) {
             regexLink = true;
@@ -147,36 +148,33 @@ $(function () {
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         case "5":
-          colorClass = "text-red";
-          fieldtext = "Blocked <br class='hidden-lg'>(exact blacklist)";
+          fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         case "6":
-          colorClass = "text-red";
-          fieldtext = "Blocked <br class='hidden-lg'>(external, IP)";
+          fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(external, IP)";
           buttontext = "";
           break;
         case "7":
-          colorClass = "text-red";
-          fieldtext = "Blocked <br class='hidden-lg'>(external, NULL)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NULL)</span>";
           buttontext = "";
           break;
         case "8":
-          colorClass = "text-red";
-          fieldtext = "Blocked <br class='hidden-lg'>(external, NXRA)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NXRA)</span>";
           buttontext = "";
           break;
         case "9":
-          colorClass = "text-red";
-          fieldtext = "Blocked (gravity, CNAME)";
+          fieldtext = "<span class='text-red'>Blocked (gravity, CNAME)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;
           break;
         case "10":
-          colorClass = "text-red";
-          fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist, CNAME)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist, CNAME)</span>";
 
           if (data.length > 9 && data[9] > 0) {
             regexLink = true;
@@ -187,8 +185,8 @@ $(function () {
           isCNAME = true;
           break;
         case "11":
-          colorClass = "text-red";
-          fieldtext = "Blocked <br class='hidden-lg'>(exact blacklist, CNAME)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist, CNAME)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;
@@ -200,16 +198,17 @@ $(function () {
           fieldtext = "<span class='text-green'>Retried</span> <br class='hidden-lg'>(ignored)";
           break;
         case "14":
-          fieldtext = "<span class='text-green'>OK</span> <br class='hidden-lg'>(already forwarded)" + dnssecStatus;
+          fieldtext =
+            "<span class='text-green'>OK</span> <br class='hidden-lg'>(already forwarded)" +
+            dnssecStatus;
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         case "15":
-          colorClass = "text-orange";
-          fieldtext = "Blocked <br class='hidden-lg'>(database is busy)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(database is busy)</span>";
           break;
         default:
-          colorClass = false;
           fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";
       }
 
@@ -220,10 +219,6 @@ $(function () {
       if ((data[1] === "DNSKEY" || data[1] === "DS") && data[3] === "pi.hole") buttontext = "";
 
       fieldtext += '<input type="hidden" name="id" value="' + parseInt(data[4], 10) + '">';
-
-      if (colorClass !== false) {
-        $("td:eq(4)", row).addClass(colorClass);
-      }
 
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(6)", row).html(buttontext);

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -122,8 +122,7 @@ $(function () {
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         case "2":
-          colorClass = "text-green";
-          fieldtext = replyid === 0 ? "OK, sent to " : "OK, answered by ";
+          fieldtext = replyid === 0 ? "<span class='text-green'>OK</span>, sent to " : "<span class='text-green'>OK</span>, answered by ";
           fieldtext +=
             "<br class='hidden-lg'>" +
             (data.length > 10 && data[10] !== "N/A" ? data[10] : "") +
@@ -132,8 +131,7 @@ $(function () {
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         case "3":
-          colorClass = "text-green";
-          fieldtext = "OK <br class='hidden-lg'>(cached)" + dnssecStatus;
+          fieldtext = "<span class='text-green'>OK</span> <br class='hidden-lg'>(cache)" + dnssecStatus;
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
@@ -196,16 +194,13 @@ $(function () {
           isCNAME = true;
           break;
         case "12":
-          colorClass = "text-green";
-          fieldtext = "Retried";
+          fieldtext = "<span class='text-green'>Retried</span>";
           break;
         case "13":
-          colorClass = "text-green";
-          fieldtext = "Retried <br class='hidden-lg'>(ignored)";
+          fieldtext = "<span class='text-green'>Retried</span> <br class='hidden-lg'>(ignored)";
           break;
         case "14":
-          colorClass = "text-green";
-          fieldtext = "OK <br class='hidden-lg'>(already forwarded)" + dnssecStatus;
+          fieldtext = "<span class='text-green'>OK</span> <br class='hidden-lg'>(already forwarded)" + dnssecStatus;
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
@@ -227,7 +222,7 @@ $(function () {
       fieldtext += '<input type="hidden" name="id" value="' + parseInt(data[4], 10) + '">';
 
       if (colorClass !== false) {
-        $(row).addClass(colorClass);
+        $("td:eq(4)", row).addClass(colorClass);
       }
 
       $("td:eq(4)", row).html(fieldtext);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Make the Query Log less colorful by, instead of coloring the entire rows, emphasize only the main part.
This is currently lost in the colorful noise IMO.

![Screenshot from 2021-09-01 16-49-02](https://user-images.githubusercontent.com/16748619/132746164-2f9e32df-b9af-4313-a873-2a7f775b4d4c.png)

I've also tried coloring the domain as well, but this looks somehow odd to me.

**How does this PR accomplish the above?:**

Do not colorize the entire row but only the status.

**What documentation changes (if any) are needed to support this PR?:**

None