### PR TITLE
Clarify how and when UQDN are forwarded with conditional forwarding

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -956,7 +956,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                    The local domain name must match the domain name specified
                                                    in your DHCP server for this to work. You can likely find it within the DHCP settings.</p>
                                                 <p>Enabling Conditional Fowarding will also forward all hostnames (i.e., non-FQDNs) to the router
-                                                   when "Never forward non-FQDNs" is <em>not</em> enable.</p>
+                                                   when "Never forward non-FQDNs" is <em>not</em> enabled.</p>
                                                 <div class="form-group">
                                                     <div>
                                                         <input type="checkbox" name="rev_server" id="rev_server" value="rev_server" <?php if(isset($rev_server) && ($rev_server == true)){ ?>checked<?php } ?>>

--- a/settings.php
+++ b/settings.php
@@ -904,7 +904,9 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                     <p>When there is a Pi-hole domain set and this box is
                                                     ticked, this asks FTL that this domain is purely
                                                     local and FTL may answer queries from <code>/etc/hosts</code> or DHCP leases
-                                                    but should never forward queries on that domain to any upstream servers.</p>
+                                                    but should never forward queries on that domain to any upstream servers.
+                                                    If Conditional Fowarding is enabled, unticking this box may cause a partial
+                                                    DNS loop under certain circumstances (e.g. if a client would send TLD DNSSEC queries).</p>
                                                 </div>
                                                 <div>
                                                     <input type="checkbox" name="DNSbogusPriv" id="DNSbogusPriv" title="bogus-priv" <?php if ($DNSbogusPriv){ ?>checked<?php } ?>>
@@ -953,6 +955,8 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                                    devices ending in your local domain name will not leave your network, however, this is optional.
                                                    The local domain name must match the domain name specified
                                                    in your DHCP server for this to work. You can likely find it within the DHCP settings.</p>
+                                                <p>Enabling Conditional Fowarding will also forward all hostnames (i.e., non-FQDNs) to the router
+                                                   when "Never forward non-FQDNs" is <em>not</em> enable.</p>
                                                 <div class="form-group">
                                                     <div>
                                                         <input type="checkbox" name="rev_server" id="rev_server" value="rev_server" <?php if(isset($rev_server) && ($rev_server == true)){ ?>checked<?php } ?>>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Clarify how and when UQDN are forwarded with conditional forwarding

**How does this PR accomplish the above?:**

Add more description in the corresponding sections. This is the result of https://discourse.pi-hole.net/t/also-forward-unqualified-host-names-creates-dnssec-loop/49208

**What documentation changes (if any) are needed to support this PR?:**

This is a documentation change.