### PR TITLE
Use pgrep file instead pidof. Fix HTML rendering issue.

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -23,14 +23,14 @@ function piholeChanged(action) {
 
   switch (action) {
     case "enabled":
-      status.html("<i class='fa fa-circle text-green-light'></i> Active");
+      status.html("<i class='fa fa-circle text-green-light'></i> Enabled");
       ena.hide();
       dis.show();
       dis.removeClass("active");
       break;
 
     case "disabled":
-      status.html("<i class='fa fa-circle text-red'></i> Offline");
+      status.html("<i class='fa fa-circle text-orange'></i> Disabled");
       ena.show();
       dis.hide();
       break;

--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -6,7 +6,347 @@
 *  This file is copyright under the latest version of the EUPL.
 *  Please see LICENSE file for your rights under this license. */
 
+require_once("func.php");
+
 $piholeFTLConfFile = "/etc/pihole/pihole-FTL.conf";
+$piholeFTLPidFile = "/run/pihole-FTL.pid";
+
+function piholeFTLVersion()
+{
+	static $piholeFTLVersion;
+
+	if( !isset( $piholeFTLVersion ))
+	{
+		$piholeFTLVersion = readPiholeFTLVersion();
+	}
+
+	return $piholeFTLVersion;
+}
+
+function readPiholeFTLVersion()
+{
+	$version = pihole_execute( 'version' );
+
+	if( isset( $version[0] ))
+	{
+		return $version[0];
+	}
+}
+
+function piholeFTLStatus()
+{
+	static $piholeFTLStatus;
+
+	if( !isset( $piholeFTLStatus ))
+	{
+		$piholeFTLStatus = readPiholeFTLStatus();
+	}
+
+	return $piholeFTLStatus;
+}
+
+function readPiholeFTLStatus()
+{
+	$status = pihole_execute( 'status web' );
+
+	if( isset( $status[0] ))
+	{
+		return (int)$status[0];
+	}
+}
+
+function piholeFTLPid()
+{
+	static $piholeFTLPid;
+
+	if( !isset( $piholeFTLPid ))
+	{
+		$piholeFTLPid = readPiholeFTLPid();
+	}
+
+	return $piholeFTLPid;
+}
+
+function readPiholeFTLPid()
+{
+	global $piholeFTLPidFile;
+
+	if( is_readable( $piholeFTLPidFile ))
+	{
+		$pid = (int)file_get_contents( $piholeFTLPidFile );
+
+		if( $pid > 0 )
+		{
+			return $pid;
+		}
+	}
+
+	// Not running
+	return -1;
+}
+
+function piholeFTLActive()
+{
+	return ( piholeFTLPid() > 0 );
+}
+
+function piholeFTLProcessInfo( $key = null )
+{
+	static $piholeFTLProcessInfo;
+
+	if( !isset( $piholeFTLProcessInfo ))
+	{
+		$piholeFTLProcessInfo = readPiholeFTLProcessInfo();
+	}
+
+	if( isset( $key ))
+	{
+		if( isset( $piholeFTLProcessInfo[ $key ] ))
+		{
+			return $piholeFTLProcessInfo[ $key ];
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	return $piholeFTLProcessInfo;
+}
+
+function readPiholeFTLProcessInfo()
+{
+	$pid = piholeFTLPid();
+
+	if( $pid < 0 )
+	{
+		return array();
+	}
+
+	// Output of ps is split by spaces!
+	// `ps` man page: "The following ... specifiers may contain spaces:
+	// args, cmd, comm, command, fname, ucmd, ucomm, lstart, bsdstart, start"
+	// `ltime` contains spaces and must therefore be at the end of the list.
+	$keys = array(
+		'user' => "euser",
+		'group' => "egroup",
+		'cpu' => "%cpu",
+		'mem' => "%mem",
+		'rss' => "rss",
+		'start' => "lstart",
+	);
+
+	$ps = preg_split(
+		'/\s+/',
+		exec( "ps -p " . $pid . " --no-headers -o " . implode( ",", $keys )),
+		count( $keys )
+	);
+
+	if( $ps === false )
+	{
+		return array();
+	}
+
+	$info = [];
+	foreach( array_keys( $keys ) as $idx => $key )
+	{
+		if( isset( $ps[ $idx ] ))
+		{
+			$info[ $key ] = $ps[ $idx ];
+		}
+	}
+
+	return $info;
+}
+
+function piholeFTLuser()
+{
+	return piholeFTLProcessInfo( 'user' );
+}
+
+function piholeFTLgroup()
+{
+	return piholeFTLProcessInfo( 'group' );
+}
+
+function piholeFTLCpu()
+{
+	return (float)piholeFTLProcessInfo( 'cpu' );
+}
+
+function piholeFTLMem()
+{
+	return (float)piholeFTLProcessInfo( 'mem' );
+}
+
+function piholeFTLRss()
+{
+	return (float)piholeFTLProcessInfo( 'rss' ) * 1000;
+}
+
+function piholeFTLStart()
+{
+	return strtotime( piholeFTLProcessInfo( 'start' ));
+}
+
+function piholeFTLTemperature()
+{
+	static $piholeFTLTemperature;
+
+	if( !isset( $piholeFTLTemperature ))
+	{
+		$piholeFTLTemperature = readPiholeFTLTemperature();
+	}
+
+	return $piholeFTLTemperature;
+}
+
+function readPiholeFTLTemperature()
+{
+	$sensors = array_merge( glob( '/sys/class/thermal/thermal_zone?/temp' ), glob( '/sys/class/hwmon/hwmon?/temp1_input' ));
+	$temperature = null;
+
+	foreach( $sensors as $sensor )
+	{
+		if( is_readable( $sensor ))
+		{
+			$temperature = (int)trim( file_get_contents( $sensor )) / 1000;
+			break;
+		}
+	}
+
+	return $temperature;
+}
+
+function piholeFTLLoad()
+{
+	$load = sys_getloadavg();
+
+	if( $load === false )
+	{
+		return array( null, null, null );
+	}
+
+	return $load;
+}
+
+function piholeFTLLoadLimit()
+{
+	static $piholeFTLLoadLimit;
+
+	if( !isset( $piholeFTLLoadLimit ))
+	{
+		$piholeFTLLoadLimit = readPiholeFTLLoadLimit();
+	}
+
+	return $piholeFTLLoadLimit;
+}
+
+function readPiholeFTLLoadLimit()
+{
+	$limit = (int)exec( 'nproc' );
+
+	if( $limit < 1 )
+	{
+			$cpuinfo = file_get_contents( "/proc/cpuinfo" );
+			$limit = preg_match_all( '/^processor/m', $cpuinfo );
+	}
+
+	if( $limit > 0 )
+	{
+		return $limit;
+	}
+}
+
+function piholeFTLMemoryUsage()
+{
+	static $piholeFTLMemoryUsage;
+
+	if( !isset( $piholeFTLMemoryUsage ))
+	{
+		$piholeFTLMemoryUsage = readPiholeFTLMemoryUsage();
+	}
+
+	return $piholeFTLMemoryUsage;
+}
+
+function readPiholeFTLMemoryUsage()
+{
+	$meminfo = file( "/proc/meminfo", FILE_IGNORE_NEW_LINES );
+
+	if( $meminfo === false )
+	{
+		return null;
+	}
+
+	$memTotal = null;
+	$memAvaliable = null;
+	$memFree = null;
+	$memBuffers = 0;
+	$memCached = 0;
+
+	foreach( $meminfo as $line )
+	{
+		if( preg_match( '/^MemTotal:\s+(\d+) kB/', $line, $matches ))
+		{
+			$memTotal = (int)$matches[1];
+
+			if( !( $memTotal > 0 ))
+			{
+				return null;
+			}
+
+			continue;
+		}
+
+		if( preg_match( '/^MemAvailable:\s+(\d+) kB/', $line, $matches ))
+		{
+			$memAvaliable = (int)$matches[1];
+
+			if( isset( $memTotal ))
+			{
+			}
+
+			continue;
+		}
+
+		if( preg_match( '/^MemFree:\s+(\d+) kB/', $line, $matches ))
+		{
+			$memFree = (int)$matches[1];
+			continue;
+		}
+
+		if( preg_match( '/^Buffers:\s+(\d+) kB/', $line, $matches ))
+		{
+			$memBuffers = (int)$matches[1];
+			continue;
+		}
+
+		if( preg_match( '/^Cached:\s+(\d+) kB/', $line, $matches ))
+		{
+			$memCached = (int)$matches[1];
+			continue;
+		}
+	}
+
+	if( isset( $memTotal ))
+	{
+		if( isset( $memAvaliable ))
+		{
+			return ( $memTotal - $memAvaliable ) / $memTotal;
+		}
+
+		if( isset( $memFree ))
+		{
+			return ( $memTotal - $memFree - $memBuffers - $memCached ) / $memTotal;
+		}
+	}
+}
+
+function piholeFTLMemoryUsageLimit()
+{
+	return 0.75;
+}
 
 function piholeFTLConfig()
 {

--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -118,10 +118,7 @@ function readPiholeFTLProcessInfo()
 {
 	$pid = piholeFTLPid();
 
-	if( $pid < 0 )
-	{
-		return array();
-	}
+	if( $pid < 0 ) return array();
 
 	// Output of ps is split by spaces!
 	// `ps` man page: "The following ... specifiers may contain spaces:
@@ -142,10 +139,7 @@ function readPiholeFTLProcessInfo()
 		count( $keys )
 	);
 
-	if( $ps === false )
-	{
-		return array();
-	}
+	if( $ps === false ) return array();
 
 	$info = [];
 	foreach( array_keys( $keys ) as $idx => $key )
@@ -221,12 +215,7 @@ function readPiholeFTLTemperature()
 function piholeFTLLoad()
 {
 	$load = sys_getloadavg();
-
-	if( $load === false )
-	{
-		return array( null, null, null );
-	}
-
+	if( $load === false ) return array( null, null, null );
 	return $load;
 }
 
@@ -274,10 +263,7 @@ function readPiholeFTLMemoryUsage()
 {
 	$meminfo = file( "/proc/meminfo", FILE_IGNORE_NEW_LINES );
 
-	if( $meminfo === false )
-	{
-		return null;
-	}
+	if( $meminfo === false ) return null;
 
 	$memTotal = null;
 	$memAvaliable = null;
@@ -290,23 +276,13 @@ function readPiholeFTLMemoryUsage()
 		if( preg_match( '/^MemTotal:\s+(\d+) kB/', $line, $matches ))
 		{
 			$memTotal = (int)$matches[1];
-
-			if( !( $memTotal > 0 ))
-			{
-				return null;
-			}
-
+			if( !( $memTotal > 0 )) return null;
 			continue;
 		}
 
 		if( preg_match( '/^MemAvailable:\s+(\d+) kB/', $line, $matches ))
 		{
 			$memAvaliable = (int)$matches[1];
-
-			if( isset( $memTotal ))
-			{
-			}
-
 			continue;
 		}
 

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -147,7 +147,7 @@
 
     function pidofFTL()
     {
-        return shell_exec("pidof pihole-FTL");
+        return shell_exec("pgrep pihole-FTL");
     }
     $FTLpid = intval(pidofFTL());
     $FTL = ($FTLpid !== 0 ? true : false);
@@ -347,7 +347,7 @@ if($auth) {
                         if($FTL)
                         {
                             if ($celsius >= -273.15) {
-                                echo "<span id=\"temperature\"><i class=\"fa fa-fire ";
+                                echo '<span id="temperature"><i class="fa fa-fire ';
                                 if ($celsius > $temperaturelimit) {
                                     echo "text-red";
                                 }
@@ -355,12 +355,12 @@ if($auth) {
                                 {
                                     echo "text-vivid-blue";
                                 }
-                                ?>"></i> Temp:&nbsp;<span id="rawtemp" hidden><?php echo $celsius;?></span><span id="tempdisplay"></span></span><?php
+                                echo '"></i> Temp:&nbsp;<span id="rawtemp" hidden>', $celsius, '</span><span id="tempdisplay"></span></span>';
                             }
                         }
                         else
                         {
-                            echo '<span id=\"temperature\"><i class="fa fa-circle text-red"></i> FTL offline</span>';
+                            echo '<span id="temperature"><i class="fa fa-circle text-red"></i> FTL offline</span>';
                         }
                     ?>
                     <br/>

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -722,4 +722,16 @@ function addStaticDHCPLease($mac, $ip, $hostname) {
 
 		return $bytes;
 	}
-?>
+function convertseconds($argument)
+{
+		$seconds = round($argument);
+		if ($seconds < 60) {
+				return sprintf('%ds', $seconds);
+		} elseif ($seconds < 3600) {
+				return sprintf('%dm %ds', ($seconds / 60), ($seconds % 60));
+		} elseif ($seconds < 86400) {
+				return sprintf('%dh %dm %ds', ($seconds / 3600 % 24), ($seconds / 60 % 60), ($seconds % 60));
+		} else {
+				return sprintf('%dd %dh %dm %ds', ($seconds / 86400), ($seconds / 3600 % 24), ($seconds / 60 % 60), ($seconds % 60));
+		}
+}

--- a/settings.php
+++ b/settings.php
@@ -239,72 +239,63 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                 <div class="box-body">
                                     <div class="row">
                                         <div class="col-lg-12">
-                                            <?php
-                                            if ($FTL) {
-                                                function get_FTL_data($arg)
-                                                {
-                                                    global $FTLpid;
-                                                    return trim(exec("ps -p " . $FTLpid . " -o " . $arg));
-                                                }
-
-                                                $FTLversion = exec("/usr/bin/pihole-FTL version");
-                                            ?>
-                                            <table class="table table-striped table-bordered nowrap">
-                                                <tbody>
-                                                    <tr>
-                                                        <th scope="row">FTL version:</th>
-                                                        <td><?php echo $FTLversion; ?></td>
-                                                    </tr>
-                                                    <tr>
-                                                        <th scope="row">Process identifier (PID):</th>
-                                                        <td><?php echo $FTLpid; ?></td>
-                                                    </tr>
-                                                    <tr>
-                                                        <th scope="row">Time FTL started:</th>
-                                                        <td><?php print_r(get_FTL_data("lstart")); ?></td>
-                                                    </tr>
-                                                    <tr>
-                                                        <th scope="row">User / Group:</th>
-                                                        <td><?php print_r(get_FTL_data("euser")); ?> / <?php print_r(get_FTL_data("egroup")); ?></td>
-                                                    </tr>
-                                                    <tr>
-                                                        <th scope="row">Total CPU utilization:</th>
-                                                        <td><?php print_r(get_FTL_data("%cpu")); ?>%</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <th scope="row">Memory utilization:</th>
-                                                        <td><?php print_r(get_FTL_data("%mem")); ?>%</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <th scope="row">
-                                                            <span title="Resident memory is the portion of memory occupied by a process that is held in main memory (RAM). The rest of the occupied memory exists in the swap space or file system.">Used memory:</span>
-                                                        </th>
-                                                        <td><?php echo formatSizeUnits(1e3 * floatval(get_FTL_data("rss"))); ?></td>
-                                                    </tr>
-                                                    <tr>
-                                                        <th scope="row">
-                                                            <span title="Size of the DNS domain cache">DNS cache size:</span>
-                                                        </th>
-                                                        <td id="cache-size">&nbsp;</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <th scope="row">
-                                                            <span title="Number of cache insertions">DNS cache insertions:</span>
-                                                        </th>
-                                                        <td id="cache-inserted">&nbsp;</td>
-                                                    </tr>
-                                                    <tr>
-                                                        <th scope="row">
-                                                            <span title="Number of cache entries that had to be removed although they are not expired (increase cache size to reduce this number)">DNS cache evictions:</span>
-                                                        </th>
-                                                        <td id="cache-live-freed">&nbsp;</td>
-                                                    </tr>
-                                                </tbody>
-                                            </table>
-                                            See also our <a href="https://docs.pi-hole.net/ftldns/dns-cache/" rel="noopener" target="_blank">DNS cache documentation</a>.
-                                            <?php } else { ?>
-                                            <div>The FTL service is offline!</div>
-                                            <?php } ?>
+                                            <?php if( piholeFTLActive() ): ?>
+                                                <table class="table table-striped table-bordered nowrap">
+                                                    <tbody>
+                                                        <tr>
+                                                            <th scope="row">FTL version:</th>
+                                                            <td><?php echo piholeFTLVersion(); ?></td>
+                                                        </tr>
+                                                        <tr>
+                                                            <th scope="row">Process identifier (PID):</th>
+                                                            <td><?php echo piholeFTLPid(); ?></td>
+                                                        </tr>
+                                                        <tr>
+                                                            <th scope="row">Time FTL started:</th>
+                                                            <td><?php echo strftime( "%c", piholeFTLStart()); ?></td>
+                                                        </tr>
+                                                        <tr>
+                                                            <th scope="row">User / Group:</th>
+                                                            <td><?php echo piholeFTLUser(); ?> / <?php echo piholeFTLGroup(); ?></td>
+                                                        </tr>
+                                                        <tr>
+                                                            <th scope="row">Total CPU utilization:</th>
+                                                            <td><?php echo number_format( piholeFTLCpu(), 1 ); ?>%</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <th scope="row">Memory utilization:</th>
+                                                            <td><?php echo number_format( piholeFTLMem(), 1 ); ?>%</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <th scope="row">
+                                                                <span title="Resident memory is the portion of memory occupied by a process that is held in main memory (RAM). The rest of the occupied memory exists in the swap space or file system.">Used memory:</span>
+                                                            </th>
+                                                            <td><?php echo formatSizeUnits( piholeFTLRss() ); ?></td>
+                                                        </tr>
+                                                        <tr>
+                                                            <th scope="row">
+                                                                <span title="Size of the DNS domain cache">DNS cache size:</span>
+                                                            </th>
+                                                            <td id="cache-size">&nbsp;</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <th scope="row">
+                                                                <span title="Number of cache insertions">DNS cache insertions:</span>
+                                                            </th>
+                                                            <td id="cache-inserted">&nbsp;</td>
+                                                        </tr>
+                                                        <tr>
+                                                            <th scope="row">
+                                                                <span title="Number of cache entries that had to be removed although they are not expired (increase cache size to reduce this number)">DNS cache evictions:</span>
+                                                            </th>
+                                                            <td id="cache-live-freed">&nbsp;</td>
+                                                        </tr>
+                                                    </tbody>
+                                                </table>
+                                                See also our <a href="https://docs.pi-hole.net/ftldns/dns-cache/" rel="noopener" target="_blank">DNS cache documentation</a>.
+                                            <?php else: ?>
+                                                <div>The FTL service is offline!</div>
+                                            <?php endif; ?>
                                         </div>
                                     </div>
                                 </div>

--- a/settings.php
+++ b/settings.php
@@ -572,20 +572,6 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "adlists", "
                                 if (!is_resource($dhcpleases))
                                     $leasesfile = false;
 
-                                function convertseconds($argument)
-                                {
-                                    $seconds = round($argument);
-                                    if ($seconds < 60) {
-                                        return sprintf('%ds', $seconds);
-                                    } elseif ($seconds < 3600) {
-                                        return sprintf('%dm %ds', ($seconds / 60), ($seconds % 60));
-                                    } elseif ($seconds < 86400) {
-                                        return sprintf('%dh %dm %ds', ($seconds / 3600 % 24), ($seconds / 60 % 60), ($seconds % 60));
-                                    } else {
-                                        return sprintf('%dd %dh %dm %ds', ($seconds / 86400), ($seconds / 3600 % 24), ($seconds / 60 % 60), ($seconds % 60));
-                                    }
-                                }
-
                                 while (!feof($dhcpleases) && $leasesfile) {
                                     $line = explode(" ", trim(fgets($dhcpleases)));
                                     if (count($line) == 5) {

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -271,14 +271,10 @@
   padding: 0 12px;
 }
 
-.user-panel > .info > span {
+.user-panel > .info span {
   padding-right: 5px;
   margin-top: 3px;
   font-size: 11px;
-}
-
-.user-panel > .info i {
-  margin-right: 3px;
 }
 
 .row-centered > div[class^="col-"] {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide], as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license]
- [X] I have squashed any insignificant commits. (`git rebase`)
- [X] I have Signed Off all commits. (`git commit --signoff`)
---

**What does this PR aim to accomplish?**
Use `pgrep` instead of `pidof` to detect the `pihole-FTL` process id. `pidof` is not necessarily available and/or in the PATH on certain systems, e.g. CentOS. 

Further down I fixed a small issue in the HTML rendering of the temperature indication.

**How does this PR accomplish the above?**
n/a

**What documentation changes (if any) are needed to support this PR?**
n/a