### PR TITLE
Add httponly = true to persistent login cookie

### DIFF
--- a/scripts/pi-hole/php/password.php
+++ b/scripts/pi-hole/php/password.php
@@ -50,7 +50,8 @@
             {
                 $auth = true;
                 // Refresh cookie with new expiry
-                setcookie('persistentlogin', $pwhash, time()+60*60*24*7);
+                // setcookie( $name, $value, $expire, $path, $domain, $secure, $httponly )
+                setcookie('persistentlogin', $pwhash, time()+60*60*24*7, null, null, null, true );
             }
             else
             {
@@ -79,7 +80,8 @@
                     // Set persistent cookie if selected
                     if (isset($_POST['persistentlogin']))
                     {
-                        setcookie('persistentlogin', $pwhash, time()+60*60*24*7);
+                        // setcookie( $name, $value, $expire, $path, $domain, $secure, $httponly )
+                        setcookie('persistentlogin', $pwhash, time()+60*60*24*7, null, null, null, true );
                     }
                     header('Location: index.php');
                     exit();


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Sets the httponly property of the persistentlogin cookie to true, discussed : https://github.com/pi-hole/AdminLTE/issues/1447