### PR TITLE
Add per-browser setting for Query Log colorization

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -111,12 +111,14 @@ $(function () {
       // Query status
       var fieldtext,
         buttontext = "",
+        colorClass = "text-green",
         isCNAME = false,
         regexLink = false;
 
       switch (data[4]) {
         case "1":
           fieldtext = "<span class='text-red'>Blocked (gravity)</span>";
+          colorClass = "text-red";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
@@ -140,6 +142,7 @@ $(function () {
           break;
         case "4":
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist)";
+          colorClass = "text-red";
 
           if (data.length > 9 && data[9] > 0) {
             regexLink = true;
@@ -150,25 +153,30 @@ $(function () {
           break;
         case "5":
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist)";
+          colorClass = "text-red";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         case "6":
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(external, IP)";
+          colorClass = "text-red";
           buttontext = "";
           break;
         case "7":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NULL)</span>";
+          colorClass = "text-red";
           buttontext = "";
           break;
         case "8":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NXRA)</span>";
+          colorClass = "text-red";
           buttontext = "";
           break;
         case "9":
           fieldtext = "<span class='text-red'>Blocked (gravity, CNAME)</span>";
+          colorClass = "text-red";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;
@@ -176,6 +184,7 @@ $(function () {
         case "10":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist, CNAME)</span>";
+          colorClass = "text-red";
 
           if (data.length > 9 && data[9] > 0) {
             regexLink = true;
@@ -188,6 +197,7 @@ $(function () {
         case "11":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist, CNAME)</span>";
+          colorClass = "text-red";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;
@@ -202,15 +212,18 @@ $(function () {
           fieldtext =
             "<span class='text-green'>OK</span> <br class='hidden-lg'>(already forwarded)" +
             dnssecStatus;
+          colorClass = "text-red";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         case "15":
           fieldtext =
-            "<span class='text-red'>Blocked <br class='hidden-lg'>(database is busy)</span>";
+            "<span class='text-orange'>Blocked <br class='hidden-lg'>(database is busy)</span>";
+          colorClass = "text-orange";
           break;
         default:
           fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";
+          colorClass = false;
       }
 
       // Add EDE here if available and not included in dnssecStatus
@@ -220,6 +233,10 @@ $(function () {
       if ((data[1] === "DNSKEY" || data[1] === "DS") && data[3] === "pi.hole") buttontext = "";
 
       fieldtext += '<input type="hidden" name="id" value="' + parseInt(data[4], 10) + '">';
+
+      if (colorClass !== false && localStorage.getItem("colorfulQueryLog_chkbox") === "true") {
+        $(row).addClass(colorClass);
+      }
 
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(6)", row).html(buttontext);

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -284,6 +284,25 @@ $(function () {
   });
 });
 
+// Colorful domains on the Query Log toggle
+$(function () {
+  var colorfulQueryLog = $("#colorfulQueryLog");
+  var chkboxData = localStorage.getItem("colorfulQueryLog_chkbox");
+
+  if (chkboxData !== null) {
+    // Restore checkbox state
+    colorfulQueryLog.prop("checked", chkboxData === "true");
+  } else {
+    // Initialize checkbox
+    colorfulQueryLog.prop("checked", false);
+    localStorage.setItem("colorfulQueryLog_chkbox", false);
+  }
+
+  colorfulQueryLog.click(function () {
+    localStorage.setItem("colorfulQueryLog_chkbox", colorfulQueryLog.prop("checked"));
+  });
+});
+
 // Delete dynamic DHCP lease
 $('button[id="removedynamic"]').on("click", function () {
   var tr = $(this).closest("tr");

--- a/settings.php
+++ b/settings.php
@@ -1172,6 +1172,14 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                             </div>
                                         </div>
                                     </div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div>
+                                                <input type="checkbox" name="colorfulQueryLog" id="colorfulQueryLog" value="no">
+                                                <label for="colorfulQueryLog"><strong>Colorful Query Log</strong></label>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fix the issue discussed on https://github.com/pi-hole/AdminLTE/pull/1872 that less color leads to issues with seeing if a domain was blocked or not on small screens.

**How does this PR accomplish the above?:**

Add a checkbox on the settings page (default: off) that re-enables the pre-v5.4 behavior (color entire row).

![Screenshot from 2021-09-13 17-02-56](https://user-images.githubusercontent.com/16748619/133130499-8b396221-b217-48a8-965e-b7bc20f892a6.png)

**What documentation changes (if any) are needed to support this PR?:**

None