### PR TITLE
Add background colors on Query log + switchable text coloring (as before)

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -202,14 +202,13 @@ $(function () {
     rowCallback: function (row, data) {
       var fieldtext,
         buttontext = "",
-        rowClass = "allowed-row",
-        color;
+        blocked = true;
       switch (data[4]) {
         case 1:
           fieldtext = "<span class='text-red'>Blocked (gravity)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case 2:
           fieldtext =
@@ -228,48 +227,48 @@ $(function () {
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case 5:
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case 6:
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(external, IP)";
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case 7:
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NULL)</span>";
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case 8:
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NXRA)</span>";
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case 9:
           fieldtext = "<span class='text-red'>Blocked (gravity, CNAME)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case 10:
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist, CNAME)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case 11:
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist, CNAME)</span>";
-          rowClass = "blocked-row";
+          blocked = true;
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case 12:
           fieldtext = "<span class='text-green'>Retried</span>";
@@ -285,15 +284,18 @@ $(function () {
           break;
         case 15:
           fieldtext =
-            "<span class='text-red'>Blocked <br class='hidden-lg'>(database is busy)</span>";
-          rowClass = "blocked-row";
+            "<span class='text-orange'>Blocked <br class='hidden-lg'>(database is busy)</span>";
+          blocked = true;
           break;
         default:
-          color = "black";
           fieldtext = "Unknown";
       }
 
-      $(row).addClass(rowClass);
+      $(row).addClass(blocked === true ? "blocked-row" : "allowed-row");
+      if (localStorage.getItem("colorfulQueryLog_chkbox") === "true") {
+        $(row).addClass(blocked === true ? "text-red" : "text-green");
+      }
+
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(5)", row).html(buttontext);
 

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -212,15 +212,15 @@ $(function () {
           rowClass = "blocked-row";
           break;
         case 2:
-          fieldtext = "<span class='text-green'>OK</span> (forwarded to <br class='hidden-lg'>" +
+          fieldtext =
+            "<span class='text-green'>OK</span> (forwarded to <br class='hidden-lg'>" +
             (data.length > 5 && data[5] !== "N/A" ? data[5] : "") +
             ")";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         case 3:
-          fieldtext =
-            "<span class='text-green'>OK</span> <br class='hidden-lg'>(cache)";
+          fieldtext = "<span class='text-green'>OK</span> <br class='hidden-lg'>(cache)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -202,96 +202,98 @@ $(function () {
     rowCallback: function (row, data) {
       var fieldtext,
         buttontext = "",
+        rowClass = "allowed-row",
         color;
       switch (data[4]) {
         case 1:
-          color = "red";
-          fieldtext = "Blocked (gravity)";
+          fieldtext = "<span class='text-red'>Blocked (gravity)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          rowClass = "blocked-row";
           break;
         case 2:
-          color = "green";
-          fieldtext =
-            "OK <br class='hidden-lg'>(forwarded to " +
+          fieldtext = "<span class='text-green'>OK</span> (forwarded to <br class='hidden-lg'>" +
             (data.length > 5 && data[5] !== "N/A" ? data[5] : "") +
             ")";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         case 3:
-          color = "green";
-          fieldtext = "OK <br class='hidden-lg'>(cached)";
+          fieldtext =
+            "<span class='text-green'>OK</span> <br class='hidden-lg'>(cache)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         case 4:
-          color = "red";
-          fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist)";
+          fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          rowClass = "blocked-row";
           break;
         case 5:
-          color = "red";
-          fieldtext = "Blocked <br class='hidden-lg'>(exact blacklist)";
+          fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          rowClass = "blocked-row";
           break;
         case 6:
-          color = "red";
-          fieldtext = "Blocked <br class='hidden-lg'>(external, IP)";
+          fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(external, IP)";
+          rowClass = "blocked-row";
           break;
         case 7:
-          color = "red";
-          fieldtext = "Blocked <br class='hidden-lg'>(external, NULL)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NULL)</span>";
+          rowClass = "blocked-row";
           break;
         case 8:
-          color = "red";
-          fieldtext = "Blocked <br class='hidden-lg'>(external, NXRA)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NXRA)</span>";
+          rowClass = "blocked-row";
           break;
         case 9:
-          color = "red";
-          fieldtext = "Blocked (gravity, CNAME)";
+          fieldtext = "<span class='text-red'>Blocked (gravity, CNAME)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          rowClass = "blocked-row";
           break;
         case 10:
-          color = "red";
-          fieldtext = "Blocked <br class='hidden-lg'>(regex blacklist, CNAME)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist, CNAME)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          rowClass = "blocked-row";
           break;
         case 11:
-          color = "red";
-          fieldtext = "Blocked <br class='hidden-lg'>(exact blacklist, CNAME)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist, CNAME)</span>";
+          rowClass = "blocked-row";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          rowClass = "blocked-row";
           break;
         case 12:
-          color = "green";
-          fieldtext = "Retried";
+          fieldtext = "<span class='text-green'>Retried</span>";
           break;
         case 13:
-          color = "green";
-          fieldtext = "Retried <br class='hidden-lg'>(ignored)";
-          buttontext = "";
+          fieldtext = "<span class='text-green'>Retried</span> <br class='hidden-lg'>(ignored)";
           break;
         case 14:
-          color = "green";
-          fieldtext = "OK <br class='hidden-lg'>(already forwarded)";
+          fieldtext =
+            "<span class='text-green'>OK</span> <br class='hidden-lg'>(already forwarded)";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         case 15:
-          color = "text-orange";
-          fieldtext = "Blocked <br class='hidden-lg'>(database is busy)";
+          fieldtext =
+            "<span class='text-red'>Blocked <br class='hidden-lg'>(database is busy)</span>";
+          rowClass = "blocked-row";
           break;
         default:
           color = "black";
           fieldtext = "Unknown";
       }
 
-      $(row).css("color", color);
+      $(row).addClass(rowClass);
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(5)", row).html(buttontext);
 

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -111,6 +111,7 @@ $(function () {
       // Query status
       var fieldtext,
         buttontext = "",
+        rowClass = "allowed-row",
         isCNAME = false,
         regexLink = false;
 
@@ -119,6 +120,7 @@ $(function () {
           fieldtext = "<span class='text-red'>Blocked (gravity)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
+          rowClass = "blocked-row";
           break;
         case "2":
           fieldtext =
@@ -140,7 +142,7 @@ $(function () {
           break;
         case "4":
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist)";
-
+          rowClass = "blocked-row";
           if (data.length > 9 && data[9] > 0) {
             regexLink = true;
           }
@@ -150,25 +152,30 @@ $(function () {
           break;
         case "5":
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist)";
+          rowClass = "blocked-row";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         case "6":
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(external, IP)";
+          rowClass = "blocked-row";
           buttontext = "";
           break;
         case "7":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NULL)</span>";
+          rowClass = "blocked-row";
           buttontext = "";
           break;
         case "8":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NXRA)</span>";
+          rowClass = "blocked-row";
           buttontext = "";
           break;
         case "9":
           fieldtext = "<span class='text-red'>Blocked (gravity, CNAME)</span>";
+          rowClass = "blocked-row";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;
@@ -188,6 +195,7 @@ $(function () {
         case "11":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist, CNAME)</span>";
+          rowClass = "blocked-row";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;
@@ -208,6 +216,7 @@ $(function () {
         case "15":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(database is busy)</span>";
+          rowClass = "blocked-row";
           break;
         default:
           fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";
@@ -220,6 +229,8 @@ $(function () {
       if ((data[1] === "DNSKEY" || data[1] === "DS") && data[3] === "pi.hole") buttontext = "";
 
       fieldtext += '<input type="hidden" name="id" value="' + parseInt(data[4], 10) + '">';
+
+      $(row).addClass(rowClass);
 
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(6)", row).html(buttontext);

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -111,7 +111,7 @@ $(function () {
       // Query status
       var fieldtext,
         buttontext = "",
-        rowClass = "allowed-row",
+        blocked = false,
         isCNAME = false,
         regexLink = false;
 
@@ -120,7 +120,7 @@ $(function () {
           fieldtext = "<span class='text-red'>Blocked (gravity)</span>";
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
-          rowClass = "blocked-row";
+          blocked = true;
           break;
         case "2":
           fieldtext =
@@ -142,7 +142,7 @@ $(function () {
           break;
         case "4":
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(regex blacklist)";
-          rowClass = "blocked-row";
+          blocked = true;
           if (data.length > 9 && data[9] > 0) {
             regexLink = true;
           }
@@ -152,30 +152,30 @@ $(function () {
           break;
         case "5":
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist)";
-          rowClass = "blocked-row";
+          blocked = true;
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           break;
         case "6":
           fieldtext = "<span class='text-red'>Blocked <br class='hidden-lg'>(external, IP)";
-          rowClass = "blocked-row";
+          blocked = true;
           buttontext = "";
           break;
         case "7":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NULL)</span>";
-          rowClass = "blocked-row";
+          blocked = true;
           buttontext = "";
           break;
         case "8":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(external, NXRA)</span>";
-          rowClass = "blocked-row";
+          blocked = true;
           buttontext = "";
           break;
         case "9":
           fieldtext = "<span class='text-red'>Blocked (gravity, CNAME)</span>";
-          rowClass = "blocked-row";
+          blocked = true;
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;
@@ -195,7 +195,7 @@ $(function () {
         case "11":
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist, CNAME)</span>";
-          rowClass = "blocked-row";
+          blocked = true;
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           isCNAME = true;
@@ -215,8 +215,8 @@ $(function () {
           break;
         case "15":
           fieldtext =
-            "<span class='text-red'>Blocked <br class='hidden-lg'>(database is busy)</span>";
-          rowClass = "blocked-row";
+            "<span class='text-orange'>Blocked <br class='hidden-lg'>(database is busy)</span>";
+          blocked = true;
           break;
         default:
           fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";
@@ -230,7 +230,10 @@ $(function () {
 
       fieldtext += '<input type="hidden" name="id" value="' + parseInt(data[4], 10) + '">';
 
-      $(row).addClass(rowClass);
+      $(row).addClass(blocked === true ? "blocked-row" : "allowed-row");
+      if (localStorage.getItem("colorfulQueryLog_chkbox") === "true") {
+        $(row).addClass(blocked === true ? "text-red" : "text-green");
+      }
 
       $("td:eq(4)", row).html(fieldtext);
       $("td:eq(6)", row).html(buttontext);

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -284,6 +284,24 @@ $(function () {
   });
 });
 
+$(function () {
+  var colorfulQueryLog = $("#colorfulQueryLog");
+  var chkboxData = localStorage.getItem("colorfulQueryLog_chkbox");
+
+  if (chkboxData !== null) {
+    // Restore checkbox state
+    colorfulQueryLog.prop("checked", chkboxData === "true");
+  } else {
+    // Initialize checkbox
+    colorfulQueryLog.prop("checked", false);
+    localStorage.setItem("colorfulQueryLog_chkbox", false);
+  }
+
+  colorfulQueryLog.click(function () {
+    localStorage.setItem("colorfulQueryLog_chkbox", colorfulQueryLog.prop("checked"));
+  });
+});
+
 // Delete dynamic DHCP lease
 $('button[id="removedynamic"]').on("click", function () {
   var tr = $(this).closest("tr");

--- a/settings.php
+++ b/settings.php
@@ -1171,6 +1171,14 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                                 <label for="bargraphs"><strong>Use new Bar charts on dashboard</strong></label>
                                             </div>
                                         </div>
+                                      </div>
+                                      <div class="row">
+                                        <div class="col-md-12">
+                                            <div>
+                                                <input type="checkbox" name="colorfulQueryLog" id="colorfulQueryLog" value="no">
+                                                <label for="colorfulQueryLog"><strong>Colorful Query Log</strong></label>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -358,3 +358,11 @@ td.details-control {
 .dataTables-child td {
   padding: 2px 5px;
 }
+
+.blocked-row {
+  background-color: rgb(229,83,75,0.1)!important;
+}
+
+.allowed-row {
+  background-color: rgb(70,149,74,0.1)!important;
+}

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -360,9 +360,9 @@ td.details-control {
 }
 
 .blocked-row {
-  background-color: rgb(229,83,75,0.1)!important;
+  background-color: rgb(229, 83, 75, 0.1) !important;
 }
 
 .allowed-row {
-  background-color: rgb(70,149,74,0.1)!important;
+  background-color: rgb(70, 149, 74, 0.1) !important;
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

I'm going to throw a spanner in the works here, been playing about with this as a middle ground using `background-color: rgb(229,83,75,0.1)!important;` for blocked and `background-color: rgb(70,149,74,0.1)!important;` for allowed

![image](https://user-images.githubusercontent.com/1998970/133492694-2c571f82-f956-4799-baac-f171c3b70931.png)

![image](https://user-images.githubusercontent.com/1998970/133492705-f8348780-0c1e-4c5f-881d-3465698cc900.png)

![image](https://user-images.githubusercontent.com/1998970/133492724-cc69f279-ddb3-46b3-b987-943b3c315b84.png)
