### PR TITLE
Lift prefix limitaion for --rev-server

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -55,14 +55,14 @@ function validCIDRIP($address){
 		// One IPv6 element is 16bit: 0000 - FFFF
 		$v6elem = "[0-9A-Fa-f]{1,4}";
 		// dnsmasq allows arbitrary prefix-length since https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=35f93081dc9a52e64ac3b7196ad1f5c1106f8932
-		$v6cidr = "([1-128])";
+		$v6cidr = "([1-9]|[1-9][0-9]|1[01][0-9]|12[0-8])";
 		$validator = "/^(((?:$v6elem))((?::$v6elem))*::((?:$v6elem))((?::$v6elem))*|((?:$v6elem))((?::$v6elem)){7})\/$v6cidr$/";
 		return preg_match($validator, $address);
 	} else {
 		// One IPv4 element is 8bit: 0 - 256
 		$v4elem = "(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]?|0)";
 		// dnsmasq allows arbitrary prefix-length
-		$allowedv4cidr = "([1-32])";
+		$allowedv4cidr = "(([1-9]|[12][0-9]|3[0-2]))";
 		$validator = "/^$v4elem\.$v4elem\.$v4elem\.$v4elem\/$allowedv4cidr$/";
 		return preg_match($validator, $address);
 	}

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -54,19 +54,15 @@ function validCIDRIP($address){
 	if($isIPv6) {
 		// One IPv6 element is 16bit: 0000 - FFFF
 		$v6elem = "[0-9A-Fa-f]{1,4}";
-		// CIDR for IPv6 is any multiple of 4 from 4 up to 128 bit
-		$v6cidr = "(4";
-		for ($i=8; $i <= 128; $i+=4) {
-			$v6cidr .= "|$i";
-		}
-		$v6cidr .= ")";
+		// dnsmasq allows arbitrary prefix-length since https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=35f93081dc9a52e64ac3b7196ad1f5c1106f8932
+		$v6cidr = "([1-128])";
 		$validator = "/^(((?:$v6elem))((?::$v6elem))*::((?:$v6elem))((?::$v6elem))*|((?:$v6elem))((?::$v6elem)){7})\/$v6cidr$/";
 		return preg_match($validator, $address);
 	} else {
 		// One IPv4 element is 8bit: 0 - 256
 		$v4elem = "(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9][0-9]?|0)";
-		// Note that rev-server accepts only /8, /16, /24, and /32
-		$allowedv4cidr = "(8|16|24|32)";
+		// dnsmasq allows arbitrary prefix-length
+		$allowedv4cidr = "([1-32])";
 		$validator = "/^$v4elem\.$v4elem\.$v4elem\.$v4elem\/$allowedv4cidr$/";
 		return preg_match($validator, $address);
 	}

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -293,8 +293,7 @@ function addStaticDHCPLease($mac, $ip, $hostname) {
 					if (!validCIDRIP($cidr))
 					{
 						$error .= "Conditional forwarding subnet (\"".htmlspecialchars($cidr)."\") is invalid!<br>".
-						          "This field requires CIDR notation for local subnets (e.g., 192.168.0.0/16).<br>".
-						          "Please use only subnets /8, /16, /24, and /32.<br>";
+						          "This field requires CIDR notation for local subnets (e.g., 192.168.0.0/16).<br>";
 					}
 
 					// Validate target IP


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

`Dnsmasq` now allows arbitrary prefix lengths in `--rev-server` since 
https://thekelleys.org.uk/gitweb/?p=dnsmasq.git;a=commit;h=35f93081dc9a52e64ac3b7196ad1f5c1106f8932.

This has been merged into FTL [here](https://github.com/pi-hole/FTL/commit/d3c89167561d81e7d5a7206939abda9f6a918c58).

This are the accompanying  changes to the web interface to lift the restrictions to specific subnets

