### PR TITLE
fix: row background colors in query log

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -202,7 +202,7 @@ $(function () {
     rowCallback: function (row, data) {
       var fieldtext,
         buttontext = "",
-        blocked = true;
+        blocked = false;
       switch (data[4]) {
         case 1:
           fieldtext = "<span class='text-red'>Blocked (gravity)</span>";
@@ -265,7 +265,6 @@ $(function () {
         case 11:
           fieldtext =
             "<span class='text-red'>Blocked <br class='hidden-lg'>(exact blacklist, CNAME)</span>";
-          blocked = true;
           buttontext =
             '<button type="button" class="btn btn-default btn-sm text-green"><i class="fas fa-check"></i> Whitelist</button>';
           blocked = true;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one ~major~ minor change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes. (on my own, local Pi-hole instance)
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixes #1905 as also reported here: https://discourse.pi-hole.net/t/graphical-glitch-pi-hole-ftl-v5-10-1-web-v5-7-and-core-v5-5-released/50042

This bug was probably introduced in #1893.

**How does this PR accomplish the above?:**

The `blocked` boolean was initialized as `true`, which should have been `false`. In certain cases (in the switch statement below) `blocked` is set to `true`, so it only makes sense to initialize `blocked` to `false`.

Also, in line 268 and 271, `blocked` is set to `true` twice, I removed one of them.

**What documentation changes (if any) are needed to support this PR?:**

none
