### PR TITLE
Do not default true for unset variables `DNS_FQDN_REQUIRED` and `DNS_BOGUS_PRIV` 

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -106,7 +106,7 @@ if (isset($setupVars["DNS_FQDN_REQUIRED"])) {
         $DNSrequiresFQDN = false;
     }
 } else {
-    $DNSrequiresFQDN = true;
+    $DNSrequiresFQDN = false;
 }
 
 if (isset($setupVars["DNS_BOGUS_PRIV"])) {
@@ -116,7 +116,7 @@ if (isset($setupVars["DNS_BOGUS_PRIV"])) {
         $DNSbogusPriv = false;
     }
 } else {
-    $DNSbogusPriv = true;
+    $DNSbogusPriv = false;
 }
 
 if (isset($setupVars["DNSSEC"])) {


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Do not default true for unset variables. When `DNS_FQDN_REQUIRED` and `DNS_BOGUS_PRIV` have not been set in `setupVars.conf` at all, the relevant checkboxes in the web GUI were checked anyway. We don't do that for other variables (e.g. `DNSSEC`) and I think we shouldn't do this. If something is not set at all, we can not pretend it would be true.

**How does this PR accomplish the above?:**

Change the default to `false`

**What documentation changes (if any) are needed to support this PR?:**
None.
