### PR TITLE
fix: exclude status checkboxes from being treated as iCheck elements

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -139,7 +139,10 @@ function initCheckboxRadioStyle() {
     boxsheet.attr("href", getCheckboxURL(style));
     // Get all radio/checkboxes for theming, with the exception of the two radio buttons on the custom disable timer,
     // as well as every element with an id that starts with "status_"
-    var sel = $("input[type='radio'],input[type='checkbox']").not("#selSec").not("#selMin").not('[id^=status_]');
+    var sel = $("input[type='radio'],input[type='checkbox']")
+      .not("#selSec")
+      .not("#selMin")
+      .not("[id^=status_]");
     sel.parent().removeClass();
     sel.parent().addClass("icheck-" + style);
   }

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -137,8 +137,9 @@ function initCheckboxRadioStyle() {
 
   function applyCheckboxRadioStyle(style) {
     boxsheet.attr("href", getCheckboxURL(style));
-    // Get all radio/checkboxes for theming, with the exception of the two radio buttons on the custom disable timer
-    var sel = $("input[type='radio'],input[type='checkbox']").not("#selSec").not("#selMin");
+    // Get all radio/checkboxes for theming, with the exception of the two radio buttons on the custom disable timer,
+    // as well as every element with an id that starts with "status_"
+    var sel = $("input[type='radio'],input[type='checkbox']").not("#selSec").not("#selMin").not('[id^=status_]');
     sel.parent().removeClass();
     sel.parent().addClass("icheck-" + style);
   }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixes #1849.
In Safari, the toggle buttons under Group Management > Groups are broken. 
This is due to the following phenomenon: The data table is rendered *before* these lines in footer.js:
https://github.com/pi-hole/AdminLTE/blob/50f43bde73d25211ac2c81e9092be67512611d2a/scripts/pi-hole/js/footer.js#L140-L143

This obviously leads to all classes being removed, along with their styling.
The more interesting question is: why does every other browser render the data table *after* these lines in footer.js? I honestly don't have a good answer.

Other pages don't cause this issue in Safari due to how the data fetching is implemented (an explicit `initTable` callback function which gets pushed onto the call stack). I considered using the same implementation here, but 
in my opinion this wouldn't avoid the issue from occurring, because it is still somewhat of a race condition.

**How does this PR accomplish the above?:**

To avoid race conditions in general, I added an exception to the initialization of iCheck elements by using a `:not` selector for all elements that have an `id` attribute starting with "status_".

**What documentation changes (if any) are needed to support this PR?:**

none
