### PR TITLE
Add note to query log that `pi.hole` queries are not logged

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -158,7 +158,7 @@ if(strlen($showing) > 0)
                     </tr>
                 </tfoot>
             </table>
-            <p>Note: Queries for <code>pi.hole</code> are never logged.</p>
+            <p>Note: Queries for <code>pi.hole</code> and the hostename are never logged.</p>
             <p><strong>Filtering options:</strong></p>
             <ul>
                 <li>Click a value in a column to add/remove that value to/from the filter</li>

--- a/queries.php
+++ b/queries.php
@@ -158,7 +158,7 @@ if(strlen($showing) > 0)
                     </tr>
                 </tfoot>
             </table>
-            <p>Note: Queries for <code>pi.hole</code> and the hostename are never logged.</p>
+            <p>Note: Queries for <code>pi.hole</code> and the hostname are never logged.</p>
             <p><strong>Filtering options:</strong></p>
             <ul>
                 <li>Click a value in a column to add/remove that value to/from the filter</li>

--- a/queries.php
+++ b/queries.php
@@ -158,6 +158,7 @@ if(strlen($showing) > 0)
                     </tr>
                 </tfoot>
             </table>
+            <p>Note: Queries for <code>pi.hole</code> are never logged.</p>
             <p><strong>Filtering options:</strong></p>
             <ul>
                 <li>Click a value in a column to add/remove that value to/from the filter</li>


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Adds a note to the query log that queries for `pi.hole` and the hostname are never logged.

![Bildschirmfoto zu 2021-10-04 09-27-59](https://user-images.githubusercontent.com/26622301/135810546-7174a9c0-dce3-492f-a992-62ebb75d8dd3.png)

