### PR TITLE
Dashboard icons - send to back and fixing position when scaled up

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -329,6 +329,17 @@
 .box,
 .small-box {
   border-radius: 10px;
+  z-index: 0; /* fix the small-box z-index (related to '.small-box .icon') */
+}
+
+.small-box .icon {
+  z-index: -1; /* sends the icon behind the text */
+}
+
+/*** Icons grow on hover, but remain centered ***/
+.small-box:hover .icon {
+    font-size: 90px; /* keep the same font-size, to avoid shifting the position */
+    transform: scale(106%);
 }
 
 .list-status-0 {

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -339,7 +339,7 @@
 /*** Icons grow on hover, but remain centered ***/
 .small-box:hover .icon {
     font-size: 90px; /* keep the same font-size, to avoid shifting the position */
-    transform: scale(106%);
+  transform: scale(106%);
 }
 
 .list-status-0 {

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -338,7 +338,7 @@
 
 /*** Icons grow on hover, but remain centered ***/
 .small-box:hover .icon {
-    font-size: 90px; /* keep the same font-size, to avoid shifting the position */
+  font-size: 90px; /* keep the same font-size, to avoid shifting the position */
   transform: scale(106%);
 }
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix for #1732 - Now the dashboard icons are behind the white text. 
Fix for #1747 - override the AdminLTE behavior when hovering: now the dashboard icons will grow, remaining centered. 


**How does this PR accomplish the above?:**

This PR:
- changes the z-index of `.small-box` and `.small-box .icon`. Now the text is in front of the icon (#1732).
- changes `.small-box:hover .icon`. Changing the font-size caused a undesired shift in the icon's position (#1747 ) because other properties using "em" unit changed too. Using CSS "transform" only the scale will change.


**What documentation changes (if any) are needed to support this PR?:**
none
