### PR TITLE
Background colors on Query log + striped table

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -359,10 +359,10 @@ td.details-control {
   padding: 2px 5px;
 }
 
-.blocked-row {
-  background-color: rgb(229, 83, 75, 0.1) !important;
+.blocked-row td {
+  background-color: rgb(229, 83, 75, 0.1);
 }
 
-.allowed-row {
-  background-color: rgb(70, 149, 74, 0.1) !important;
+.allowed-row td {
+  background-color: rgb(70, 149, 74, 0.1);
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

On PR #1893  the CSS for the background of the query tables was created using "!important", to force the background colors for blocked/allowed on the table lines, but this introduced a visual problem: all lines have the same background. No more striped tables.

**How does this PR accomplish the above?:**

To solve this, I moved the background color effect from the `tr` tags to `td` tags. Now the rows (tr) have striped backgrounds and the cells adds a color layer.

![pi-hole_queryTable_background](https://user-images.githubusercontent.com/1385443/135929815-8af06453-bff3-4e1a-aae3-9a216497b638.gif)
- remove "!important" from CSS on ".blocked-row" and ".allowed-row";
- change ".blocked-row" to ".blocked-row td";
- change ".allowed-row" to ".allowed-row td".


**What documentation changes (if any) are needed to support this PR?:**
none
