### PR TITLE
Make entire Forgot Password box header clickable

### DIFF
--- a/scripts/pi-hole/php/loginpage.php
+++ b/scripts/pi-hole/php/loginpage.php
@@ -54,17 +54,19 @@
         <div class="row">
           <div class="col-xs-12">
             <div class="box box-<?php if (!$wrongpassword) { ?>info collapsed-box<?php } else { ?>danger<?php }?>">
-              <div class="box-header with-border">
+              <div class="box-header with-border pointer no-user-select" data-widget="collapse">
                 <h3 class="box-title">Forgot password?</h3>
                 <div class="box-tools pull-right">
-                  <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa <?php if ($wrongpassword) { ?>fa-minus<?php } else { ?>fa-plus<?php } ?>"></i>
+                  <button type="button" class="btn btn-box-tool"><i class="fa <?php if ($wrongpassword) { ?>fa-minus<?php } else { ?>fa-plus<?php } ?>"></i>
                   </button>
                 </div>
               </div>
               <div class="box-body">
-                After installing Pi-hole for the first time, a password is generated and displayed to the user. The
-                password cannot be retrieved later on, but it is possible to set a new password (or explicitly disable
-                the password by setting an empty password) using the command
+                <p>
+                  After installing Pi-hole for the first time, a password is generated and displayed to the user. The
+                  password cannot be retrieved later on, but it is possible to set a new password (or explicitly disable
+                  the password by setting an empty password) using the command
+                </p>
                 <pre>sudo pihole -a -p</pre>
               </div>
             </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

To improve the usability & readability of the login screen's Forgot Password box. 

Currently, a user must specifically click on the `+` (plus) icon to reveal the hidden instructions, which can be confusing as it is common that a collapsed box's header and header text is interactive (for example, [Bootstrap's Accordion component](https://getbootstrap.com/docs/5.0/components/accordion/)).  

**How does this PR accomplish the above?:**

This adjusts the markup for the Forgot Password box to make the entire box header interactive (the text, whitespace and plus/minus icon).  The previous behaviour of clicking the icon remains the same as does the icon changing between plus and minus depending on the collapsed status.

This also improves the readability of the forgotten password box's content with a small change in markup.

**What documentation changes (if any) are needed to support this PR?:**

None that I'm aware of.
