### PR TITLE
Suppress empty lines during teleporter import

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -517,6 +517,7 @@ if(isset($_POST["action"]))
 
 			if(isset($_POST["localdnsrecords"]) && $file->getFilename() === "custom.list")
 			{
+				ob_start();
 				if($flushtables) {
 					// Defined in func.php included via auth.php
 					deleteAllCustomDNSEntries();
@@ -528,7 +529,7 @@ if(isset($_POST["action"]))
 					if(addCustomDNSEntry($ip, $domain, false))
 						$num++;
 				}
-
+				ob_end_clean();
 				echo "Processed local DNS records (".$num.noun($num).")<br>\n";
 				if($num > 0) {
 					$importedsomething = true;
@@ -537,6 +538,7 @@ if(isset($_POST["action"]))
 
 			if(isset($_POST["localcnamerecords"]) && $file->getFilename() === "05-pihole-custom-cname.conf")
 			{
+				ob_start();
 				if($flushtables) {
 					// Defined in func.php included via auth.php
 					deleteAllCustomCNAMEEntries();
@@ -556,7 +558,7 @@ if(isset($_POST["action"]))
 					if(addCustomCNAMEEntry($domain, $target, false))
 						$num++;
 				}
-
+				ob_end_clean();
 				echo "Processed local CNAME records (".$num.noun($num).")<br>\n";
 				if($num > 0) {
 					$importedsomething = true;


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

During Teleporter import `deleteAllCustomDNSEntries`, `addCustomDNSEntry`, `deleteAllCustomCNAMEEntries` and `addCustomCNAMEEntry` are called. They all finish by calling 

https://github.com/pi-hole/AdminLTE/blob/5588be9c9086ec120cd3bd4dc36bc9d4ed0acd77/scripts/pi-hole/php/func.php#L432

which outputs `<br>` if `$json` is not `true` (which it never is during teleporter import)

https://github.com/pi-hole/AdminLTE/blob/5588be9c9086ec120cd3bd4dc36bc9d4ed0acd77/scripts/pi-hole/php/func.php#L459-L467

So for every entry in Local DNS records or CNAME Records an empty line is printed.

This PR does suppress the output by using output_buffer.

Before
![Bildschirmfoto zu 2021-10-10 22-02-01](https://user-images.githubusercontent.com/26622301/136711883-11fcdf36-19c1-4437-95db-299de1d6fcdd.png)

After
![Bildschirmfoto zu 2021-10-10 22-10-50](https://user-images.githubusercontent.com/26622301/136711898-461d07c0-a140-4fae-90ad-c438293336e4.png)

