### PR TITLE
Use existing noun function to ensure correct grammar in teleporter import output

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -455,21 +455,21 @@ if(isset($_POST["action"]))
 			if(isset($_POST["group"]) && $file->getFilename() === "group.json")
 			{
 				$num = archive_restore_table($file, "group", $flushtables);
-				echo "Processed group (".$num." entries)<br>\n";
+				echo "Processed group (".$num.noun($num).")<br>\n";
 				$importedsomething = true;
 			}
 
 			if(isset($_POST["client"]) && $file->getFilename() === "client.json")
 			{
 				$num = archive_restore_table($file, "client", $flushtables);
-				echo "Processed client (".$num." entries)<br>\n";
+				echo "Processed client (".$num.noun($num).")<br>\n";
 				$importedsomething = true;
 			}
 
 			if(isset($_POST["client"]) && $file->getFilename() === "client_by_group.json")
 			{
 				$num = archive_restore_table($file, "client_by_group", $flushtables);
-				echo "Processed client group assignments (".$num." entries)<br>\n";
+				echo "Processed client group assignments (".$num.noun($num).")<br>\n";
 				$importedsomething = true;
 			}
 
@@ -478,14 +478,14 @@ if(isset($_POST["action"]))
 				$file->getFilename() === "domainlist_by_group.json")
 			{
 				$num = archive_restore_table($file, "domainlist_by_group", $flushtables);
-				echo "Processed black-/whitelist group assignments (".$num." entries)<br>\n";
+				echo "Processed black-/whitelist group assignments (".$num.noun($num).")<br>\n";
 				$importedsomething = true;
 			}
 
 			if(isset($_POST["adlist"]) && $file->getFilename() === "adlist_by_group.json")
 			{
 				$num = archive_restore_table($file, "adlist_by_group", $flushtables);
-				echo "Processed adlist group assignments (".$num." entries)<br>\n";
+				echo "Processed adlist group assignments (".$num.noun($num).")<br>\n";
 				$importedsomething = true;
 			}
 
@@ -529,7 +529,7 @@ if(isset($_POST["action"]))
 						$num++;
 				}
 
-				echo "Processed local DNS records (".$num." entries)<br>\n";
+				echo "Processed local DNS records (".$num.noun($num).")<br>\n";
 				if($num > 0) {
 					$importedsomething = true;
 				}
@@ -557,7 +557,7 @@ if(isset($_POST["action"]))
 						$num++;
 				}
 
-				echo "Processed local CNAME records (".$num." entries)<br>\n";
+				echo "Processed local CNAME records (".$num.noun($num).")<br>\n";
 				if($num > 0) {
 					$importedsomething = true;
 				}


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Use singular/plural for all item during teleporter import. 

**How does this PR accomplish the above?:**

Use the existing function `noun` for all items
https://github.com/pi-hole/AdminLTE/blob/5588be9c9086ec120cd3bd4dc36bc9d4ed0acd77/scripts/pi-hole/php/teleporter.php#L323

____
See `client` and  `client group assignment`

![Bildschirmfoto zu 2021-10-10 22-10-50](https://user-images.githubusercontent.com/26622301/136712182-52bf74ce-5fe4-4ebb-a92a-accb33d16c2a.png)

![Bildschirmfoto zu 2021-10-10 22-26-35](https://user-images.githubusercontent.com/26622301/136712178-f4ed0eca-7035-4f83-a617-407be8f6c92a.png)


