### PR TITLE
Add delete button to the network table to allow deleting individual entries

### DIFF
--- a/network.php
+++ b/network.php
@@ -25,6 +25,7 @@
             <table id="network-entries" class="table table-striped table-bordered" width="100%">
                 <thead>
                     <tr>
+                        <th>ID</th>
                         <th>IP address</th>
                         <th>Hardware address</th>
                         <th>Interface</th>
@@ -33,10 +34,12 @@
                         <th>Last Query</th>
                         <th>Number of queries</th>
                         <th>Uses Pi-hole</th>
+                        <th>Action</th>
                     </tr>
                 </thead>
                 <tfoot>
                     <tr>
+                        <th>ID</th>
                         <th>IP address</th>
                         <th>Hardware address</th>
                         <th>Interface</th>
@@ -45,6 +48,7 @@
                         <th>Last Query</th>
                         <th>Number of queries</th>
                         <th>Uses Pi-hole</th>
+                        <th>Action</th>
                     </tr>
                 </tfoot>
             </table>

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -59,6 +59,8 @@ function parseColor(input) {
   }
 }
 
+function deleteNetworkEntry() {}
+
 $(function () {
   tableApi = $("#network-entries").DataTable({
     rowCallback: function (row, data) {
@@ -170,6 +172,16 @@ $(function () {
       if (data.hwaddr.startsWith("ip-")) {
         $("td:eq(1)", row).text("N/A");
       }
+
+      // Add delete button
+      $(row).attr("data-id", data.id);
+      var button =
+        '<button type="button" class="btn btn-danger btn-xs" id="deleteNetworkEntry_' +
+        data.id +
+        '">' +
+        '<span class="far fa-trash-alt"></span>' +
+        "</button>";
+      $("td:eq(8)", row).html(button);
     },
     dom:
       "<'row'<'col-sm-12'f>>" +
@@ -179,8 +191,9 @@ $(function () {
     ajax: { url: API_STRING, error: handleAjaxError, dataSrc: "network" },
     autoWidth: false,
     processing: true,
-    order: [[5, "desc"]],
+    order: [[6, "desc"]],
     columns: [
+      { data: "id", visible: false },
       { data: "ip", type: "ip-address", width: "10%", render: $.fn.dataTable.render.text() },
       { data: "hwaddr", width: "10%", render: $.fn.dataTable.render.text() },
       { data: "interface", width: "4%", render: $.fn.dataTable.render.text() },
@@ -209,7 +222,13 @@ $(function () {
       },
       { data: "numQueries", width: "9%", render: $.fn.dataTable.render.text() },
       { data: "", width: "6%", orderable: false },
+      { data: "", width: "6%", orderable: false },
     ],
+    drawCallback: function () {
+      $('button[id^="deleteNetworkEntry_"]').on("click", deleteNetworkEntry);
+      // Remove visible dropdown to prevent orphaning
+      $("body > .bootstrap-select.dropdown").remove();
+    },
     lengthMenu: [
       [10, 25, 50, 100, -1],
       [10, 25, 50, 100, "All"],
@@ -223,7 +242,7 @@ $(function () {
     },
     columnDefs: [
       {
-        targets: -1,
+        targets: [-1, -2],
         data: null,
         defaultContent: "",
       },

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -8,6 +8,7 @@
 /* global utils:false */
 
 var tableApi;
+var token = $("#token").text();
 
 var API_STRING = "api_db.php?network";
 
@@ -59,7 +60,48 @@ function parseColor(input) {
   }
 }
 
-function deleteNetworkEntry() {}
+function deleteNetworkEntry() {
+  var tr = $(this).closest("tr");
+  var id = tr.attr("data-id");
+
+  utils.disableAll();
+  utils.showAlert("info", "", "Deleting network table entry with ID " + parseInt(id, 10), "...");
+  $.ajax({
+    url: "scripts/pi-hole/php/network.php",
+    method: "post",
+    dataType: "json",
+    data: { action: "delete_network_entry", id: id, token: token },
+    success: function (response) {
+      utils.enableAll();
+      if (response.success) {
+        utils.showAlert(
+          "success",
+          "far fa-trash-alt",
+          "Successfully deleted network table entry # ",
+          id
+        );
+        tableApi.row(tr).remove().draw(false).ajax.reload(null, false);
+      } else {
+        utils.showAlert(
+          "error",
+          "",
+          "Error while network table entry with ID " + id,
+          response.message
+        );
+      }
+    },
+    error: function (jqXHR, exception) {
+      utils.enableAll();
+      utils.showAlert(
+        "error",
+        "",
+        "Error while deleting network table entry with ID " + id,
+        jqXHR.responseText
+      );
+      console.log(exception); // eslint-disable-line no-console
+    },
+  });
+}
 
 $(function () {
   tableApi = $("#network-entries").DataTable({

--- a/scripts/pi-hole/php/network.php
+++ b/scripts/pi-hole/php/network.php
@@ -1,0 +1,82 @@
+
+<?php
+/* Pi-hole: A black hole for Internet advertisements
+*  (c) 2021 Pi-hole, LLC (https://pi-hole.net)
+*  Network-wide ad blocking via your own hardware.
+*
+*  This file is copyright under the latest version of the EUPL.
+*  Please see LICENSE file for your rights under this license. */
+
+require_once('auth.php');
+
+// Authentication checks
+if (!isset($api)) {
+    if (isset($_POST['token'])) {
+        check_cors();
+        check_csrf($_POST['token']);
+    } else {
+        log_and_die('Not allowed (login session invalid or expired, please relogin on the Pi-hole dashboard)!');
+    }
+}
+
+$reload = false;
+
+require_once('func.php');
+require_once('database.php');
+$QueriesDB = getQueriesDBFilename();
+$db = SQLite3_connect($QueriesDB, SQLITE3_OPEN_READWRITE);
+
+function JSON_success($message = null)
+{
+    header('Content-type: application/json');
+    echo json_encode(array('success' => true, 'message' => $message));
+}
+
+function JSON_error($message = null)
+{
+    header('Content-type: application/json');
+    $response = array('success' => false, 'message' => $message);
+    if (isset($_POST['action'])) {
+        array_push($response, array('action' => $_POST['action']));
+    }
+    echo json_encode($response);
+}
+
+if ($_POST['action'] == 'delete_network_entry' && isset($_POST['id'])) {
+// Delete netwwork and network_addresses table entry identified by ID
+    try {
+
+        $stmt = $db->prepare('DELETE FROM network_addresses WHERE network_id=:id');
+        if (!$stmt) {
+            throw new Exception('While preparing message statement: ' . $db->lastErrorMsg());
+        }
+
+        if (!$stmt->bindValue(':id', intval($_POST['id']), SQLITE3_INTEGER)) {
+            throw new Exception('While binding id to message statement: ' . $db->lastErrorMsg());
+        }
+
+        if (!$stmt->execute()) {
+            throw new Exception('While executing message statement: ' . $db->lastErrorMsg());
+        }
+
+        $stmt = $db->prepare('DELETE FROM network WHERE id=:id');
+        if (!$stmt) {
+            throw new Exception('While preparing message statement: ' . $db->lastErrorMsg());
+        }
+
+        if (!$stmt->bindValue(':id', intval($_POST['id']), SQLITE3_INTEGER)) {
+            throw new Exception('While binding id to message statement: ' . $db->lastErrorMsg());
+        }
+
+        if (!$stmt->execute()) {
+            throw new Exception('While executing message statement: ' . $db->lastErrorMsg());
+        }
+
+        $reload = true;
+        JSON_success();
+    } catch (\Exception $ex) {
+        JSON_error($ex->getMessage());
+    }
+} else {
+    log_and_die('Requested action not supported!');
+}


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Adds a delete button to the network table. Users can now delete individual entries from the table (e.g. a device has left the network) without the need to flush the whole network table. 

![Bildschirmfoto zu 2021-10-11 14-24-21](https://user-images.githubusercontent.com/26622301/136789520-590350ea-1a4d-4054-85dd-697a9d5fbacd.png)

**How does this PR accomplish the above?:**

Re-use the function to delete entries from the message table.

