### PR TITLE
Do not restart for every item during Teleporter import of Local DNS record or CNAME

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -195,7 +195,7 @@ function getCustomDNSEntries()
     return $entries;
 }
 
-function addCustomDNSEntry($ip="", $domain="", $json=true)
+function addCustomDNSEntry($ip="", $domain="", $reload="", $json=true)
 {
     try
     {
@@ -204,6 +204,9 @@ function addCustomDNSEntry($ip="", $domain="", $json=true)
 
         if(isset($_REQUEST['domain']))
             $domain = trim($_REQUEST['domain']);
+
+				if(isset($_REQUEST['reload']))
+		            $reload = $_REQUEST['reload'];
 
         if (empty($ip))
             return returnError("IP must be set", $json);
@@ -229,7 +232,7 @@ function addCustomDNSEntry($ip="", $domain="", $json=true)
         }
 
         // Add record
-        pihole_execute("-a addcustomdns ".$ip." ".$domain);
+        pihole_execute("-a addcustomdns ".$ip." ".$domain." ".$reload);
 
         return returnSuccess("", $json);
     }
@@ -280,9 +283,9 @@ function deleteAllCustomDNSEntries()
 	try
 	{
 			$existingEntries = getCustomDNSEntries();
-
+			// passing false to pihole_execute stops pihole from reloading after each enty has been deleted
 			foreach ($existingEntries as $entry) {
-					pihole_execute("-a removecustomdns ".$entry->ip." ".$entry->domain);
+					pihole_execute("-a removecustomdns ".$entry->ip." ".$entry->domain." false");
 				}
 
 	}
@@ -341,7 +344,7 @@ function getCustomCNAMEEntries()
     return $entries;
 }
 
-function addCustomCNAMEEntry($domain="", $target="", $json=true)
+function addCustomCNAMEEntry($domain="", $target="", $reload="", $json=true)
 {
     try
     {
@@ -350,6 +353,9 @@ function addCustomCNAMEEntry($domain="", $target="", $json=true)
 
         if(isset($_REQUEST['target']))
             $target = trim($_REQUEST['target']);
+
+				if(isset($_REQUEST['reload']))
+						$reload = $_REQUEST['reload'];
 
         if (empty($domain))
             return returnError("Domain must be set", $json);
@@ -375,7 +381,7 @@ function addCustomCNAMEEntry($domain="", $target="", $json=true)
                 if (in_array($d, $entry->domains))
                     return returnError("There is already a CNAME record for '$d'", $json);
 
-        pihole_execute("-a addcustomcname ".$domain." ".$target);
+        pihole_execute("-a addcustomcname ".$domain." ".$target." ".$reload);
 
         return returnSuccess("", $json);
     }
@@ -426,9 +432,9 @@ function deleteAllCustomCNAMEEntries()
     try
     {
         $existingEntries = getCustomCNAMEEntries();
-
+				// passing false to pihole_execute stops pihole from reloading after each enty has been deleted
         foreach ($existingEntries as $entry) {
-            pihole_execute("-a removecustomcname ".$entry->domain." ".$entry->target);
+            pihole_execute("-a removecustomcname ".$entry->domain." ".$entry->target." false");
         }
 
     }

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -278,14 +278,17 @@ function deleteCustomDNSEntry()
     }
 }
 
-function deleteAllCustomDNSEntries()
+function deleteAllCustomDNSEntries($reload="")
 {
 	try
 	{
+		if(isset($_REQUEST['reload']))
+				$reload = $_REQUEST['reload'];
+
 			$existingEntries = getCustomDNSEntries();
 			// passing false to pihole_execute stops pihole from reloading after each enty has been deleted
 			foreach ($existingEntries as $entry) {
-					pihole_execute("-a removecustomdns ".$entry->ip." ".$entry->domain." false");
+					pihole_execute("-a removecustomdns ".$entry->ip." ".$entry->domain." ".$reload);
 				}
 
 	}
@@ -427,14 +430,17 @@ function deleteCustomCNAMEEntry()
     }
 }
 
-function deleteAllCustomCNAMEEntries()
+function deleteAllCustomCNAMEEntries($reload="")
 {
     try
     {
+			if(isset($_REQUEST['reload']))
+					$reload = $_REQUEST['reload'];
+					
         $existingEntries = getCustomCNAMEEntries();
 				// passing false to pihole_execute stops pihole from reloading after each enty has been deleted
         foreach ($existingEntries as $entry) {
-            pihole_execute("-a removecustomcname ".$entry->domain." ".$entry->target." false");
+            pihole_execute("-a removecustomcname ".$entry->domain." ".$entry->target." ".$reload);
         }
 
     }

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -205,8 +205,8 @@ function addCustomDNSEntry($ip="", $domain="", $reload="", $json=true)
         if(isset($_REQUEST['domain']))
             $domain = trim($_REQUEST['domain']);
 
-				if(isset($_REQUEST['reload']))
-		            $reload = $_REQUEST['reload'];
+        if(isset($_REQUEST['reload']))
+            $reload = $_REQUEST['reload'];
 
         if (empty($ip))
             return returnError("IP must be set", $json);
@@ -280,24 +280,24 @@ function deleteCustomDNSEntry()
 
 function deleteAllCustomDNSEntries($reload="")
 {
-	try
-	{
-		if(isset($_REQUEST['reload']))
-				$reload = $_REQUEST['reload'];
+    try
+		{
+        if(isset($_REQUEST['reload']))
+            $reload = $_REQUEST['reload'];
 
-			$existingEntries = getCustomDNSEntries();
-			// passing false to pihole_execute stops pihole from reloading after each enty has been deleted
-			foreach ($existingEntries as $entry) {
-					pihole_execute("-a removecustomdns ".$entry->ip." ".$entry->domain." ".$reload);
-				}
+        $existingEntries = getCustomDNSEntries();
+        // passing false to pihole_execute stops pihole from reloading after each enty has been deleted
+        foreach ($existingEntries as $entry) {
+            pihole_execute("-a removecustomdns ".$entry->ip." ".$entry->domain." ".$reload);
+        }
 
-	}
-	catch (\Exception $ex)
-	{
-			return returnError($ex->getMessage());
-	}
+    }
+    catch (\Exception $ex)
+    {
+        return returnError($ex->getMessage());
+    }
 
-	return returnSuccess();
+    return returnSuccess();
 }
 
 // CNAME
@@ -357,8 +357,8 @@ function addCustomCNAMEEntry($domain="", $target="", $reload="", $json=true)
         if(isset($_REQUEST['target']))
             $target = trim($_REQUEST['target']);
 
-				if(isset($_REQUEST['reload']))
-						$reload = $_REQUEST['reload'];
+        if(isset($_REQUEST['reload']))
+            $reload = $_REQUEST['reload'];
 
         if (empty($domain))
             return returnError("Domain must be set", $json);
@@ -434,11 +434,11 @@ function deleteAllCustomCNAMEEntries($reload="")
 {
     try
     {
-			if(isset($_REQUEST['reload']))
-					$reload = $_REQUEST['reload'];
-					
+        if(isset($_REQUEST['reload']))
+            $reload = $_REQUEST['reload'];
+
         $existingEntries = getCustomCNAMEEntries();
-				// passing false to pihole_execute stops pihole from reloading after each enty has been deleted
+        // passing false to pihole_execute stops pihole from reloading after each enty has been deleted
         foreach ($existingEntries as $entry) {
             pihole_execute("-a removecustomcname ".$entry->domain." ".$entry->target." ".$reload);
         }

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -277,37 +277,21 @@ function deleteCustomDNSEntry()
 
 function deleteAllCustomDNSEntries()
 {
-    if (isset($customDNSFile))
-    {
-        $handle = fopen($customDNSFile, "r");
-        if ($handle)
-        {
-            try
-            {
-                while (($line = fgets($handle)) !== false) {
-                    $line = str_replace("\r","", $line);
-                    $line = str_replace("\n","", $line);
-                    $explodedLine = explode (" ", $line);
+	try
+	{
+			$existingEntries = getCustomDNSEntries();
 
-                    if (count($explodedLine) != 2)
-                        continue;
+			foreach ($existingEntries as $entry) {
+					pihole_execute("-a removecustomdns ".$entry->ip." ".$entry->domain);
+				}
 
-                    $ip = $explodedLine[0];
-                    $domain = $explodedLine[1];
+	}
+	catch (\Exception $ex)
+	{
+			return returnError($ex->getMessage());
+	}
 
-                    pihole_execute("-a removecustomdns ".$ip." ".$domain);
-                }
-            }
-            catch (\Exception $ex)
-            {
-                return returnError($ex->getMessage());
-            }
-
-            fclose($handle);
-        }
-    }
-
-    return returnSuccess();
+	return returnSuccess();
 }
 
 // CNAME

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -519,14 +519,14 @@ if(isset($_POST["action"]))
 			if(isset($_POST["localdnsrecords"]) && $file->getFilename() === "custom.list")
 			{
 				ob_start();
+				$reload="false";
 				if($flushtables) {
 					// Defined in func.php included via auth.php
-					// will not restart Pi-hole
-					deleteAllCustomDNSEntries();
+					// passing reload="false" will not restart Pi-hole
+					deleteAllCustomDNSEntries($reload);
 				}
 				$num = 0;
 				$localdnsrecords = process_file(file_get_contents($file));
-				$reload="false";
 				foreach($localdnsrecords as $record) {
 					list($ip,$domain) = explode(" ",$record);
 					if(addCustomDNSEntry($ip, $domain, $reload, false))
@@ -543,15 +543,15 @@ if(isset($_POST["action"]))
 			if(isset($_POST["localcnamerecords"]) && $file->getFilename() === "05-pihole-custom-cname.conf")
 			{
 				ob_start();
+				$reload="false";
 				if($flushtables) {
 					// Defined in func.php included via auth.php
-					// will not restart Pi-hole
-					deleteAllCustomCNAMEEntries();
+					//passing reload="false" will not restart Pi-hole
+					deleteAllCustomCNAMEEntries($reload);
 				}
 
 				$num = 0;
 				$localcnamerecords = process_file(file_get_contents($file));
-				$reload="false";
 				foreach($localcnamerecords as $record) {
 					$line = str_replace("cname=","", $record);
 					$line = str_replace("\r","", $line);


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Do not restart Pi-hole for every entry in local DNS records or CNAME during Teleporter import. 
So far, Pi-hole did a full restart while deleting each individual entry (if clear data was selected) and on each entry import.
Fixes: https://github.com/pi-hole/pi-hole/issues/4077

Needs:  https://github.com/pi-hole/pi-hole/pull/4384

How?
Adds a flag "reload" which is passed down to the `webpage.sh`. For each step it is set to `false`. After all removal/importing is done, it sets the new variable `fullpiholerestart` to `true` which will finally do the full restart