### PR TITLE
Remove obsolet list_verify function

### DIFF
--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -133,28 +133,4 @@ function check_domain(&$domains) {
     }
 }
 
-function list_verify($type) {
-    global $pwhash, $wrongpassword, $auth;
-    if(!isset($_POST['domain']) || !isset($_POST['list']) || !(isset($_POST['pw']) || isset($_POST['token']))) {
-        log_and_die("Missing POST variables");
-    }
-
-    if(isset($_POST['token']))
-    {
-        check_cors();
-        check_csrf($_POST['token']);
-    }
-    elseif(isset($_POST['pw']))
-    {
-        require("password.php");
-        if($wrongpassword || !$auth)
-        {
-            log_and_die("Wrong password - ".htmlspecialchars($type)."listing of ".htmlspecialchars($_POST['domain'])." not permitted");
-        }
-    }
-    else
-    {
-        log_and_die("Not allowed!");
-    }
-}
 ?>


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Removes the unused function `list_verify`.

This was introduced 5 years ago by https://github.com/pi-hole/AdminLTE/pull/311 and used in `add.php` and `sub.php` Those files were later removed https://github.com/pi-hole/AdminLTE/pull/1387 and https://github.com/pi-hole/AdminLTE/pull/1154.
Therefore the function is unused now.

The only reminiscence of `add.php` is in the blocking page
https://github.com/pi-hole/pi-hole/blob/4c39edbeb91c04b83d4d78e4eaf669c3a8c04fc6/advanced/index.php#L362

