### PR TITLE
Display Docker Tag in footer if the PIHOLE_DOCKER_TAG environment variable is detected

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -49,7 +49,7 @@
     $coreVersionStr = $core_current . (isset($core_commit) ? " (" . $core_branch . ", " . $core_commit . ")" : "");
     $ftlVersionStr = $FTL_current . (isset($FTL_commit) ? " (" . $FTL_branch . ", " . $FTL_commit . ")" : "");
     $webVersionStr = $web_current . (isset($web_commit) ? " (" . $web_branch . ", " . $web_commit . ")" : "");
-    $dockerTag = getenv('PIHOLE_DOCKER_TAG') == true ? getenv('PIHOLE_DOCKER_TAG') : "";
+    $dockerTag = getenv('PIHOLE_DOCKER_TAG');
 
     $githubBaseUrl = "https://github.com/pi-hole";
     $coreUrl = $githubBaseUrl . "/pi-hole";

--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -49,6 +49,7 @@
     $coreVersionStr = $core_current . (isset($core_commit) ? " (" . $core_branch . ", " . $core_commit . ")" : "");
     $ftlVersionStr = $FTL_current . (isset($FTL_commit) ? " (" . $FTL_branch . ", " . $FTL_commit . ")" : "");
     $webVersionStr = $web_current . (isset($web_commit) ? " (" . $web_branch . ", " . $web_commit . ")" : "");
+    $dockerTag = getenv('PIHOLE_DOCKER_TAG') == true ? getenv('PIHOLE_DOCKER_TAG') : "";
 
     $githubBaseUrl = "https://github.com/pi-hole";
     $coreUrl = $githubBaseUrl . "/pi-hole";
@@ -70,12 +71,14 @@
             <div class="col-xs-12 col-sm-8 col-md-6">
                 <?php if (isset($core_commit) || isset($web_commit) || isset($FTL_commit)) { ?>
                 <ul class="list-unstyled">
+                    <?php if($dockerTag) { ?> <li><strong>Docker Tag</strong> <?php echo $dockerTag; ?></li> <?php } ?>
                     <li><strong>Pi-hole</strong> <?php echo $coreVersionStr; ?></li>
                     <li><strong>FTL</strong> <?php echo $ftlVersionStr; ?></li>
                     <li><strong>Web Interface</strong> <?php echo $webVersionStr; ?></li>
                 </ul>
                 <?php } else { ?>
                 <ul class="list-inline">
+                    <?php if($dockerTag) { ?> <li><strong>Docker Tag</strong> <?php echo $dockerTag; ?></li> <?php } ?>
                     <li>
                         <strong>Pi-hole</strong>
                         <a href="<?php echo $coreReleasesUrl . "/" . $core_current; ?>" rel="noopener" target="_blank"><?php echo $core_current; ?></a>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

This is currently hacked into the docker container, which `sed`s it into footer.php. This is a cleaner way of doing it as it keeps the internal repo on the docker side of things in line with what is actually released.

`PIHOLE_DOCKER_TAG=dev`:

![image](https://user-images.githubusercontent.com/1998970/138557227-8dc6e1e8-42e9-46dd-a5eb-a52073a4bb15.png)

`PIHOLE_DOCKER_TAG` not set:

![image](https://user-images.githubusercontent.com/1998970/138557277-9aa9a82b-30c9-4d87-a3f6-d2feef58cf02.png)

Companion to: pi-hole/docker-pi-hole/pull/930