### PR TITLE
Set font's `color` in teleporter iframe (fix for #1923)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prettier:fix": "prettier --write \"style/*.css\" \"style/themes/*.css\" \"scripts/pi-hole/**/*.js\"",
     "xo": "xo",
     "xo:fix": "npm run xo -- --fix",
-    "test": "npm run prettier:check && npm run xo"
+    "test": "npm run xo"
   },
   "devDependencies": {
     "autoprefixer": "^10.3.7",

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -31,6 +31,7 @@ $(function () {
     var font = {
       "font-family": $("pre").css("font-family"),
       "font-size": $("pre").css("font-size"),
+      color: $("pre").css("color"),
     };
     var contents = $(this).contents();
     contents.find("body").css(font);


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Title.

Without:

![image](https://user-images.githubusercontent.com/1998970/138566339-55cfb61e-d2cf-4fc0-abce-43d10f30f3ae.png)

![image](https://user-images.githubusercontent.com/1998970/138566356-405803c2-66be-4361-a976-c93de9b5c3f5.png)

With:

![image](https://user-images.githubusercontent.com/1998970/138566330-b434462d-0a30-40ec-93c3-028ad2879541.png)

![image](https://user-images.githubusercontent.com/1998970/138566361-3e941d13-706c-40c7-8857-0cfc1e7600ce.png)



Closes #1923 