### PR TITLE
Fix dashboard icon animations in Safari

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -339,7 +339,7 @@
 /*** Icons grow on hover, but remain centered ***/
 .small-box:hover .icon {
   font-size: 90px; /* keep the same font-size, to avoid shifting the position */
-  transform: scale(106%);
+  transform: scale(1.06);
 }
 
 .list-status-0 {


### PR DESCRIPTION
Signed-off-by: Iksas <Iksas@users.noreply.github.com>

**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

The CSS transformation added in #1915 didn't work in Safari 15.0 and earlier, because those versions don't support percentages in the `scale()` function. This PR fixes it.

**How does this PR accomplish the above?:**

Instead of percentages, a decimal number is used in the `scale()` function.

**What documentation changes (if any) are needed to support this PR?:**

none