### PR TITLE
Remove traces of leftover API_PRIVACY_MODE

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -75,15 +75,6 @@ else
 	$showall = true;
 }
 
-if(isset($setupVars["API_PRIVACY_MODE"]))
-{
-	if($setupVars["API_PRIVACY_MODE"])
-	{
-		// Overwrite string from above
-		$showing .= ", privacy mode enabled";
-	}
-}
-
 if(strlen($showing) > 0)
 {
 	$showing = "(".$showing.")";

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -439,26 +439,12 @@ function addStaticDHCPLease($mac, $ip, $hostname) {
 				if(isset($_POST["querylog-permitted"]) && isset($_POST["querylog-blocked"]))
 				{
 					pihole_execute("-a setquerylog all");
-					if(!isset($_POST["privacyMode"]))
-					{
-						$success .= "All entries will be shown in Query Log";
-					}
-					else
-					{
-						$success .= "Only blocked entries will be shown in Query Log";
-					}
+					$success .= "All entries will be shown in Query Log";
 				}
 				elseif(isset($_POST["querylog-permitted"]))
 				{
 					pihole_execute("-a setquerylog permittedonly");
-					if(!isset($_POST["privacyMode"]))
-					{
-						$success .= "Only permitted will be shown in Query Log";
-					}
-					else
-					{
-						$success .= "No entries will be shown in Query Log";
-					}
+					$success .= "Only permitted will be shown in Query Log";
 				}
 				elseif(isset($_POST["querylog-blocked"]))
 				{
@@ -469,17 +455,6 @@ function addStaticDHCPLease($mac, $ip, $hostname) {
 				{
 					pihole_execute("-a setquerylog nothing");
 					$success .= "No entries will be shown in Query Log";
-				}
-
-
-				if(isset($_POST["privacyMode"]))
-				{
-					pihole_execute("-a privacymode true");
-					$success .= " (privacy mode enabled)";
-				}
-				else
-				{
-					pihole_execute("-a privacymode false");
 				}
 
 				break;

--- a/settings.php
+++ b/settings.php
@@ -185,13 +185,6 @@ if (isset($setupVars["API_QUERY_LOG_SHOW"])) {
     $queryLog = "all";
 }
 
-// Privacy Mode
-if (isset($setupVars["API_PRIVACY_MODE"])) {
-    $privacyMode = $setupVars["API_PRIVACY_MODE"];
-} else {
-    $privacyMode = false;
-}
-
 ?>
 
 <?php


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Removes traces of the leftover setting `API_PRIVACY_MODE`.
For details see: https://github.com/pi-hole/AdminLTE/issues/1941

The corresponding change in `/pihole` is: ~~https://github.com/pi-hole/pi-hole/pull/4413~~ as this PR is on hold due to internal discussion I cherry-picked the removal of the unused function in https://github.com/pi-hole/pi-hole/pull/4420

