### PR TITLE
Set stateDuration to 0 for all saved datatables to store the state indefinitely

### DIFF
--- a/scripts/pi-hole/js/customcname.js
+++ b/scripts/pi-hole/js/customcname.js
@@ -71,7 +71,6 @@ $(function () {
     ],
     order: [[0, "asc"]],
     stateSave: true,
-    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("LocalCNAMETable", data);
     },

--- a/scripts/pi-hole/js/customcname.js
+++ b/scripts/pi-hole/js/customcname.js
@@ -71,6 +71,7 @@ $(function () {
     ],
     order: [[0, "asc"]],
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("LocalCNAMETable", data);
     },

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -71,6 +71,7 @@ $(function () {
     ],
     order: [[0, "asc"]],
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("LocalDNSTable", data);
     },

--- a/scripts/pi-hole/js/customdns.js
+++ b/scripts/pi-hole/js/customdns.js
@@ -71,7 +71,6 @@ $(function () {
     ],
     order: [[0, "asc"]],
     stateSave: true,
-    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("LocalDNSTable", data);
     },

--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -289,7 +289,6 @@ function initTable() {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
-    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("groups-adlists-table", data);
     },

--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -295,11 +295,6 @@ function initTable() {
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("groups-adlists-table");
 
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Apply loaded state to table

--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -289,6 +289,7 @@ function initTable() {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("groups-adlists-table", data);
     },

--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -223,11 +223,6 @@ function initTable() {
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("groups-clients-table");
 
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Apply loaded state to table

--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -217,7 +217,6 @@ function initTable() {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
-    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("groups-clients-table", data);
     },

--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -217,6 +217,7 @@ function initTable() {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("groups-clients-table", data);
     },

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -252,11 +252,6 @@ function initTable() {
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("groups-domains-table");
 
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Show group assignment column only on full page

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -246,7 +246,6 @@ function initTable() {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
-    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("groups-domains-table", data);
     },

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -246,6 +246,7 @@ function initTable() {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("groups-domains-table", data);
     },

--- a/scripts/pi-hole/js/groups.js
+++ b/scripts/pi-hole/js/groups.js
@@ -92,11 +92,6 @@ $(function () {
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("groups-table");
 
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
-
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Apply loaded state to table

--- a/scripts/pi-hole/js/groups.js
+++ b/scripts/pi-hole/js/groups.js
@@ -86,7 +86,6 @@ $(function () {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
-    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("groups-table", data);
     },

--- a/scripts/pi-hole/js/groups.js
+++ b/scripts/pi-hole/js/groups.js
@@ -86,6 +86,7 @@ $(function () {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("groups-table", data);
     },

--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -141,6 +141,7 @@ $(function () {
       emptyTable: "No issues found.",
     },
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("messages-table", data);
     },

--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -141,7 +141,6 @@ $(function () {
       emptyTable: "No issues found.",
     },
     stateSave: true,
-    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("messages-table", data);
     },

--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -146,10 +146,6 @@ $(function () {
     },
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("messages-table");
-      // Return if not available
-      if (data === null) {
-        return null;
-      }
 
       // Reset visibility of ID and blob columns
       var hiddenCols = [0, 4, 5, 6, 7, 8];

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -276,6 +276,7 @@ $(function () {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("network_table", data);
     },

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -276,7 +276,6 @@ $(function () {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
-    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("network_table", data);
     },

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -334,7 +334,6 @@ $(function () {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
-    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("query_log_table", data);
     },

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -334,6 +334,7 @@ $(function () {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("query_log_table", data);
     },

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -223,7 +223,6 @@ $(function () {
       scrollX: true,
       order: [[2, "asc"]],
       stateSave: true,
-      stateDuration: 0,
       stateSaveCallback: function (settings, data) {
         utils.stateSaveCallback("activeDhcpLeaseTable", data);
       },

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -223,6 +223,7 @@ $(function () {
       scrollX: true,
       order: [[2, "asc"]],
       stateSave: true,
+      stateDuration: 0,
       stateSaveCallback: function (settings, data) {
         utils.stateSaveCallback("activeDhcpLeaseTable", data);
       },

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -234,6 +234,8 @@ function stateSaveCallback(itemName, data) {
 }
 
 function stateLoadCallback(itemName) {
+  // local storage data should be valid indefinitely 
+  stateDuration: 0,
   // Receive previous state from client's local storage area
   var data = localStorage.getItem(itemName);
   // Return if not available

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -234,8 +234,8 @@ function stateSaveCallback(itemName, data) {
 }
 
 function stateLoadCallback(itemName) {
-  // local storage data should be valid indefinitely 
-  stateDuration: 0,
+  // local storage data should be valid indefinitely
+  stateDuration: 0;
   // Receive previous state from client's local storage area
   var data = localStorage.getItem(itemName);
   // Return if not available

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -234,8 +234,6 @@ function stateSaveCallback(itemName, data) {
 }
 
 function stateLoadCallback(itemName) {
-  // local storage data should be valid indefinitely 
-  stateDuration: 0,
   // Receive previous state from client's local storage area
   var data = localStorage.getItem(itemName);
   // Return if not available

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -234,8 +234,8 @@ function stateSaveCallback(itemName, data) {
 }
 
 function stateLoadCallback(itemName) {
-  // local storage data should be valid indefinitely
-  stateDuration: 0;
+  // local storage data should be valid indefinitely 
+  stateDuration: 0,
   // Receive previous state from client's local storage area
   var data = localStorage.getItem(itemName);
   // Return if not available


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

We already save the state of the datatables in the local storage. However, we didn't set `stateDuration` explicitly, which make the option default to 7200 seconds (2h).
https://datatables.net/reference/option/stateDuration

Afterwards, datatables will consider the state invalid. This means, that despite having chosen non-default options for the datatables (which is still present in the local storage), on load they will fall-back to their default values and overwrite all previously chosen settings.

This has been reported here: https://github.com/pi-hole/AdminLTE/pull/764#issuecomment-952357401

___

Additionally, this PR removes some duplicated code that has been moved to the `utils.stateLoadCallback` function before.