### PR TITLE
Queryads single DIV and responsive CSS

### DIFF
--- a/queryads.php
+++ b/queryads.php
@@ -15,26 +15,13 @@
   <div class="col-md-12">
     <div class="box">
       <div class="box-body">
-        <!-- Domain Input <992px -->
-        <div class="visible-xs-block visible-sm-block">
-          <div class="input-group-block">
-            <input id="domain_1" type="url" class="form-control" placeholder="Domain to look for (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off" style="margin-bottom: 5px">
-            <input id="quiet" type="hidden" value="no">
-            <div class="text-center" style="display: block; width: 100%">
-              <button type="button" id="btnSearch_1" class="btn btn-default">Search partial match</button>
-              <button type="button" id="btnSearchExact_1" class="btn btn-default">Search exact match</button>
-            </div>
-          </div>
-        </div>
-        <!-- Domain Input >=992px -->
-        <div class="visible-md-block visible-lg-block">
-          <div class="input-group">
-            <input id="domain_2" type="url" class="form-control" placeholder="Domain to look for (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
-            <span class="input-group-btn">
-              <button type="button" id="btnSearch_2" class="btn btn-default">Search partial match</button>
-              <button type="button" id="btnSearchExact_2" class="btn btn-default">Search exact match</button>
-            </span>
-          </div>
+        <!-- single div with responsive CSS -->
+        <div id="domain-search-block" class="input-group">
+          <input id="domain" type="url" class="form-control" placeholder="Domain to look for (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+          <span class="input-group-btn">
+            <button type="button" id="btnSearch" class="btn btn-default">Search partial match</button>
+            <button type="button" id="btnSearchExact" class="btn btn-default">Search exact match</button>
+          </span>
         </div>
       </div>
     </div>

--- a/queryads.php
+++ b/queryads.php
@@ -18,6 +18,7 @@
         <!-- single div with responsive CSS -->
         <div id="domain-search-block" class="input-group">
           <input id="domain" type="url" class="form-control" placeholder="Domain to look for (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+          <input id="quiet" type="hidden" value="no">
           <span class="input-group-btn">
             <button type="button" id="btnSearch" class="btn btn-default">Search partial match</button>
             <button type="button" id="btnSearchExact" class="btn btn-default">Search exact match</button>

--- a/scripts/pi-hole/js/queryads.js
+++ b/scripts/pi-hole/js/queryads.js
@@ -88,7 +88,7 @@ function eventsource() {
 }
 
 // Handle enter key
-$("#domain_1, #domain_2").keypress(function (e) {
+$("#domain").keypress(function (e) {
   if (e.which === 13) {
     // Enter was pressed, and the input has focus
     exact = "";

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -377,3 +377,20 @@ td.details-control {
 .allowed-row td {
   background-color: rgb(70, 149, 74, 0.1);
 }
+
+@media screen and (max-width: 991px) {
+  #domain-search-block {
+    display: block;
+  }
+  #domain {
+    margin: 5px 0;
+  }
+  #domain-search-block .input-group-btn {
+    margin: 5px 0;
+    text-align: center;
+  }
+  #domain-search-block .input-group-btn button {
+    margin: 0 2px;
+    border-radius: 3px;
+  }
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This PR Solves issue #1461 (and related [comment in #1284](https://github.com/pi-hole/AdminLTE/pull/1284#issuecomment-636289733))


**How does this PR accomplish the above?:**

This PR removes the double DIV solution introduced in #1284 and #1264 and replaces it with a different approach.
A single div + responsive CSS targeting the div and its inner elements.

**What documentation changes (if any) are needed to support this PR?:**

None