### PR TITLE
Fix PHP 8 incompatibility on settings page

### DIFF
--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -209,10 +209,19 @@ function addStaticDHCPLease($mac, $ip, $hostname) {
 				{
 					foreach(["v4_1", "v4_2", "v6_1", "v6_2"] as $type)
 					{
-						if(@array_key_exists("DNSserver".str_replace(".","_",$value[$type]),$_POST))
-						{
-							array_push($DNSservers,$value[$type]);
-						}
+						// Skip if this IP type does not
+						// exist (e.g. IPv4-only or only
+						// one IPv6 address upstream
+						// server)
+						if(!array_key_exists($type, $value))
+							continue;
+
+						// If server exists and is set
+						// (POST), we add it to the
+						// array of DNS servers
+						$server = str_replace(".", "_", $value[$type]);
+						if(array_key_exists("DNSserver".$server, $_POST))
+							array_push($DNSservers, $value[$type]);
 					}
 				}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

See title - Fix PHP 8 incompatibility on settings page

**How does this PR accomplish the above?:**

Skip DNS server processing if the requested type is not available for this server.

**What documentation changes (if any) are needed to support this PR?:**

None