### PR TITLE
Fix the icon position (login password field)

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -406,3 +406,8 @@ td.details-control {
     border-radius: 3px;
   }
 }
+
+/* Fix the icon position (login password field) */
+.form-control-feedback {
+  right: 12px;
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

The Login password icon is mispositioned.
This PR fixes the _key_ icon position on the login page.

![login-icon-position](https://user-images.githubusercontent.com/1385443/141696087-145fafe0-e2ab-4768-bb53-09a647b5a5eb.gif)

**How does this PR accomplish the above?:**

Using CSS to fix the position.
 
**What documentation changes (if any) are needed to support this PR?:**

None.

**Note:** Maybe update the README.md image, section **[Password protection](https://github.com/pi-hole/AdminLTE#password-protection)**.
