### PR TITLE
Revert "Remove duplicated code as it is already part of utils.stateLoadCallback"

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -306,6 +306,11 @@ function initTable() {
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("groups-adlists-table");
 
+      // Return if not available
+      if (data === null) {
+        return null;
+      }
+
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Apply loaded state to table

--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -230,6 +230,11 @@ function initTable() {
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("groups-clients-table");
 
+      // Return if not available
+      if (data === null) {
+        return null;
+      }
+
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Apply loaded state to table

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -259,6 +259,11 @@ function initTable() {
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("groups-domains-table");
 
+      // Return if not available
+      if (data === null) {
+        return null;
+      }
+
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Show group assignment column only on full page

--- a/scripts/pi-hole/js/groups.js
+++ b/scripts/pi-hole/js/groups.js
@@ -99,6 +99,11 @@ $(function () {
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("groups-table");
 
+      // Return if not available
+      if (data === null) {
+        return null;
+      }
+
       // Reset visibility of ID column
       data.columns[0].visible = false;
       // Apply loaded state to table

--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -156,6 +156,10 @@ $(function () {
     },
     stateLoadCallback: function () {
       var data = utils.stateLoadCallback("messages-table");
+      // Return if not available
+      if (data === null) {
+        return null;
+      }
 
       // Reset visibility of ID and blob columns
       var hiddenCols = [0, 4, 5, 6, 7, 8];


### PR DESCRIPTION
This reverts commit 395b1b6c1f656a4a77e4f50e408c5d352229e713.

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Commit https://github.com/pi-hole/AdminLTE/pull/1944/commits/395b1b6c1f656a4a77e4f50e408c5d352229e713 (part of https://github.com/pi-hole/AdminLTE/pull/1944) removed an important `if` clause that returned `null` if the specific data was not found in the LocalStorage of the browser. 
E.g. this is the case when Pi-hole web GUI is opened the first time. 

Without the revert, the tables wont load properly. Reason is that non-existing data can not be modified.

![Bildschirmfoto zu 2021-11-13 12-51-02](https://user-images.githubusercontent.com/26622301/141699787-47efac27-feea-423a-ba84-37fca8140428.png)




**How does this PR accomplish the above?:**

Revert the commit.