### PR TITLE
Use theme gridColor and ticksColor in long time graph

### DIFF
--- a/db_graph.php
+++ b/db_graph.php
@@ -7,6 +7,9 @@
 *    Please see LICENSE file for your rights under this license. */
     require "scripts/pi-hole/php/header.php";
 ?>
+<!-- Sourceing CSS colors from stylesheet to be used in JS code -->
+<span class="graphs-grid"></span>
+<span class="graphs-ticks"></span>
 
 <div class="page-header">
     <h1>Compute graphical statistics from the Pi-hole query database</h1>

--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -160,6 +160,9 @@ $(function () {
   var ctx = document.getElementById("queryOverTimeChart").getContext("2d");
   var blockedColor = "#999";
   var permittedColor = "#00a65a";
+  var gridColor = $(".graphs-grid").css("background-color");
+  var ticksColor = $(".graphs-ticks").css("color");
+
   timeLineChart = new Chart(ctx, {
     type: utils.getGraphType(),
     data: {
@@ -298,6 +301,12 @@ $(function () {
                 year: "YYYY",
               },
             },
+            gridLines: {
+              color: gridColor,
+            },
+            ticks: {
+              fontColor: ticksColor,
+            },
           },
         ],
         yAxes: [
@@ -305,6 +314,10 @@ $(function () {
             stacked: true,
             ticks: {
               beginAtZero: true,
+              fontColor: ticksColor,
+            },
+            gridLines: {
+              color: gridColor,
             },
           },
         ],

--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -303,6 +303,7 @@ $(function () {
             },
             gridLines: {
               color: gridColor,
+              zeroLineColor: gridColor,
             },
             ticks: {
               fontColor: ticksColor,

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -888,6 +888,7 @@ $(function () {
             },
             gridLines: {
               color: gridColor,
+              zeroLineColor: gridColor,
             },
             ticks: {
               fontColor: ticksColor,
@@ -966,6 +967,7 @@ $(function () {
               },
               gridLines: {
                 color: gridColor,
+                zeroLineColor: gridColor,
               },
               ticks: {
                 fontColor: ticksColor,


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Use the gridColor and ticksColor defined in the theme css files for the long term data graph. The properties are already used for the graph on the dashboard (last 24h graph). Using the same code here to have the same style.
