### PR TITLE
Remove obsolete code from network.php

### DIFF
--- a/network.php
+++ b/network.php
@@ -8,12 +8,6 @@
     require "scripts/pi-hole/php/header.php";
 ?>
 
-<!-- Sourceing CSS colors from stylesheet to be used in JS code -->
-<span class="queries-permitted"></span>
-<span class="queries-blocked"></span>
-<span class="graphs-grid"></span>
-<span class="graphs-ticks"></span>
-
 <div class="row">
     <div class="col-md-12">
       <div class="box" id="network-details">


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Removes code that has been part of `network.php` probably due to copy&pasting. The four classes removed here are not used in the network table at all.

The code was introduced by https://github.com/pi-hole/AdminLTE/commit/6b47a937fb2e047f25d6526a561a12584f0bfa8e and the classes not even used back then.