### PR TITLE
Fix DHCP tables button column

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -219,7 +219,7 @@ $(function () {
       columnDefs: [
         { bSortable: false, orderable: false, targets: -1 },
         {
-          targets: "_all",
+          targets: [0,1,2],
           render: $.fn.dataTable.render.text(),
         },
       ],
@@ -245,7 +245,7 @@ $(function () {
       columnDefs: [
         { bSortable: false, orderable: false, targets: -1 },
         {
-          targets: "_all",
+          targets: [0,1,2],
           render: $.fn.dataTable.render.text(),
         },
       ],

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -219,7 +219,7 @@ $(function () {
       columnDefs: [
         { bSortable: false, orderable: false, targets: -1 },
         {
-          targets: [0,1,2],
+          targets: [0, 1, 2],
           render: $.fn.dataTable.render.text(),
         },
       ],
@@ -245,7 +245,7 @@ $(function () {
       columnDefs: [
         { bSortable: false, orderable: false, targets: -1 },
         {
-          targets: [0,1,2],
+          targets: [0, 1, 2],
           render: $.fn.dataTable.render.text(),
         },
       ],


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

https://github.com/pi-hole/AdminLTE/pull/1948 introduced text rendering to all table's column rendering. This fails in case of the DHCP tables, as the last column (Action) with the delete buttons should not be rendered as text.

https://github.com/pi-hole/AdminLTE/blob/21cba361e03bfbc6f241497066c2558a57c13c8e/scripts/pi-hole/js/settings.js#L245-L251

**How does this PR accomplish the above?:**

Limit the rendering to the first three columns

