### PR TITLE
Add bounce animation to Pi-hole diagnosis warning triangle

### DIFF
--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -263,7 +263,7 @@ if($auth) {
                 <ul class="nav navbar-nav">
                     <li id="pihole-diagnosis" class="hidden">
                         <a href="messages.php">
-                            <i class="fa fa-exclamation-triangle"></i>
+                            <i class="fa fa-exclamation-triangle fa-2x icon-bounce"></i>
                             <span class="label label-warning" id="pihole-diagnosis-count"></span>
                         </a>
                     </li>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -411,3 +411,33 @@ td.details-control {
 .form-control-feedback {
   right: 12px;
 }
+
+.icon-bounce {
+  display: inline-block;
+  position: relative;
+  animation: icon-bounce 1.5s infinite linear;
+}
+
+@keyframes icon-bounce {
+  0%,
+  20%,
+  50%,
+  70%,
+  90%,
+  100% {
+    transform: translateY(0);
+  }
+  40% {
+    transform: translateY(-15px);
+  }
+  60% {
+    transform: translateY(-8px);
+  }
+  80% {
+    transform: translateY(-4px);
+  }
+}
+
+.navbar-nav {
+  height: 50px;
+}


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

This PR aims to make the Pi-hole diagnosis system, containing many helpful messages to aid users helping themselves.

**How does this PR accomplish the above?:**

Add an animation to the warning icon. Furthermore, making the icon twice as large on all screens.
![ezgif-3-ddf519f74cc4](https://user-images.githubusercontent.com/16748619/143895585-f31b249d-30d0-42e3-963a-6ba5d2f9467b.gif)


Full screen preview:

![ezgif-2-31021110ffa5](https://user-images.githubusercontent.com/16748619/143895342-b18ee497-135f-4646-b78c-41e3671afed5.gif)


**What documentation changes (if any) are needed to support this PR?:**

None