### PR TITLE
Show ignored items when adding new adlists 

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -384,21 +384,12 @@ function addAdlist() {
     success: function (response) {
       utils.enableAll();
       if (response.success) {
-        if (response.message) {
-          // If there is a message, we have ignored adlists. Showing them in a warning.
-          utils.showAlert(
-            "warning",
-            "fas fa-plus",
-            "Warning - duplicated adlist(s) ignored:",
-            response.message + "<br><b>Adlists successfully processed.<b>"
-          );
+        if (response.warning) {
+          // Ignored items found! Showing ignored and added items in a warning.
+          utils.showAlert("warning", "fas fa-plus", "Warning", response.message);
         } else {
-          utils.showAlert(
-            "success",
-            "fas fa-plus",
-            "Successfully added adlist",
-            "<small>" + address.split(" ").filter(Boolean).join("<br>") + "</small>"
-          );
+          // All items added.
+          utils.showAlert("success", "fas fa-plus", "Successfully added adlist", response.message);
         }
 
         table.ajax.reload(null, false);

--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -384,7 +384,23 @@ function addAdlist() {
     success: function (response) {
       utils.enableAll();
       if (response.success) {
-        utils.showAlert("success", "fas fa-plus", "Successfully added adlist", address);
+        if (response.message) {
+          // If there is a message, we have ignored adlists. Showing them in a warning.
+          utils.showAlert(
+            "warning",
+            "fas fa-plus",
+            "Warning - duplicated adlist(s) ignored:",
+            response.message + "<br><b>Adlists successfully processed.<b>"
+          );
+        } else {
+          utils.showAlert(
+            "success",
+            "fas fa-plus",
+            "Successfully added adlist",
+            "<small>" + address.split(" ").filter(Boolean).join("<br>") + "</small>"
+          );
+        }
+
         table.ajax.reload(null, false);
         $("#new_address").val("");
         $("#new_comment").val("");

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -31,6 +31,16 @@ function JSON_success($message = null)
     echo json_encode(array('success' => true, 'message' => $message));
 }
 
+function JSON_warning($message = null)
+{
+    header('Content-type: application/json');
+    echo json_encode(array(
+        'success' => true,
+        'warning' => true,
+        'message' => $message,
+    ));
+}
+
 function JSON_error($message = null)
 {
     header('Content-type: application/json');
@@ -958,6 +968,7 @@ if ($_POST['action'] == 'get_groups') {
         $addresses = explode(' ', html_entity_decode(trim($_POST['address'])));
         $total = count($addresses);
         $added = 0;
+        $ignored = 0;
 
         $stmt = $db->prepare('INSERT INTO adlist (address,comment) VALUES (:address,:comment)');
         if (!$stmt) {
@@ -973,6 +984,7 @@ if ($_POST['action'] == 'get_groups') {
             throw new Exception('While binding comment: ' . $db->lastErrorMsg());
         }
 
+        $added_list = "";
         $ignored_list = "";
         foreach ($addresses as $address) {
             // Silently skip this entry when it is empty or not a string (e.g. NULL)
@@ -999,13 +1011,16 @@ if ($_POST['action'] == 'get_groups') {
                     // ErrorCode 19 is "Constraint violation", here the unique constraint of `address` 
                     //   is violated (https://www.sqlite.org/rescode.html#constraint).
                     // If the list is already in database, add to ignored list, but don't throw error
-                    $ignored_list .= "<small><i>" . $address . "</i></small><br>";
+                    $ignored++;
+                    $ignored_list .= "<small>" . $address . "</small><br>";
                 } else {
                     throw new Exception('While executing: <strong>' . $db->lastErrorMsg() . '</strong><br>'.
                     'Added ' . $added . " out of " . $total . " adlists");
                 }
+            } else {
+                $added++;
+                $added_list .= "<small>" . $address . "</small><br>";
             }
-            $added++;
         }
 
         if(!$db->query('COMMIT;')) {
@@ -1013,9 +1028,20 @@ if ($_POST['action'] == 'get_groups') {
         }
 
         $reload = true;
+        if ($ignored_list != "") {
+            // Send added and ignored lists
+            $msg = "<b>Ignored duplicated adlists: " . $ignored . "</b><br>" . $ignored_list;
+            if ($added_list != "") {
+              $msg .= "<br><b>Added adlists: " . $added . "</b><br>" . $added_list;
+            }
+            $msg .= "<br><b>Total: " . $total . " adlist(s) processed.</b>";
+            JSON_warning($msg);
+        } else {
+            // All adlists added
+            $msg = $added_list . "<br><b>Total: " . $total . " adlist(s) processed.</b>";
+            JSON_success($msg);
+        }
 
-        // Send Success or the ignored list as message
-        JSON_success($ignored_list);
     } catch (\Exception $ex) {
         JSON_error($ex->getMessage());
     }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

When a user is adding adlists, sometimes the adlist is already in the database.
The item is correctly ignored, but there's no feedback to the user. 

**How does this PR accomplish the above?:**

This PR adds a warning message (when an adlist is already in the database) and reports all added/ignored adlists.
![multiple_adlists_added_ignored](https://user-images.githubusercontent.com/1385443/146590903-a706b6c3-3d38-4d4f-90ed-7d992024050e.gif)

**What documentation changes (if any) are needed to support this PR?:**

none.