### PR TITLE
Select PHP version for phpstan

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,6 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Change PHP version
+      run: |
+        sudo update-alternatives --set php /usr/bin/php8.0
+        sudo update-alternatives --set phar /usr/bin/phar8.0
+        sudo update-alternatives --set phpdbg /usr/bin/phpdbg8.0
+        sudo update-alternatives --set php-cgi /usr/bin/php-cgi8.0
+        sudo update-alternatives --set phar.phar /usr/bin/phar.phar8.0
+        php -version
     - name: Validate composer.json and composer.lock
       run: composer validate
     - name: Cache Composer packages


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This PR fixes the errors in phpstan tests, introduced by the new Virtual Environments forcing PHP8.1 (after 2021-12-08).

**How does this PR accomplish the above?:**

Creating a new step for phpstan to select the correct PHP version for the tests.

**What documentation changes (if any) are needed to support this PR?:**

none