### PR TITLE
Reduce eye size

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -443,7 +443,7 @@ td.details-control {
 }
 
 .eyeConWrapper {
-  font-size: 17px;
+  font-size: 14px;
 }
 
 #apiTokenIframe {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Reduce eye size to make it less obtrusive. This also removes the extra vertical padding between the legend items.

Comparison:
![ezgif-5-b89f5c4a73](https://user-images.githubusercontent.com/16748619/147048956-38fa21b0-a23a-448d-9bf6-5a6026761693.gif)
(larger icons and more spacing is before, smaller icon and reduced padding is with this PR)

**How does this PR accomplish the above?:**

Reduce `font-size` of the eye from 17px to 14px to make the eye smaller

**What documentation changes (if any) are needed to support this PR?:**

None