### PR TITLE
Add link to Pi-hole docs when showing dnsmasq warnings

### DIFF
--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -89,7 +89,11 @@ function renderMessage(data, type, row) {
       );
 
     case "DNSMASQ_WARN":
-      return "Warning in <code>dnsmasq</code> core:<pre>" + row.message + "</pre>";
+      return (
+        "Warning in <code>dnsmasq</code> core:<pre>" +
+        row.message +
+        '</pre> Check out <a href="https://docs.pi-hole.net/ftldns/dnsmasq_warn/" target="_blank">our documentation</a> for further information.'
+      );
 
     case "LOAD":
       return (


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Point users to our docs when they see `dnsmasq` warnings in the Pi-hole diagnosis system.

**How does this PR accomplish the above?:**

See title

![Screenshot from 2021-12-23 11-29-43](https://user-images.githubusercontent.com/16748619/147227750-8970edd0-7a60-48d5-8359-0c3cef68061d.png)


**What documentation changes (if any) are needed to support this PR?:**

None