### PR TITLE
Fix gradient transparency issues in Safari

### DIFF
--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -824,7 +824,7 @@ label {
   left: 0;
   width: 88px;
   z-index: -1;
-  background-image: linear-gradient(to right, #cce6ff 70%, transparent 100%);
+  background-image: linear-gradient(to right, rgb(204, 230, 255) 70%, rgba(204, 230, 255, 0) 100%);
 }
 
 .user-panel > .info,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

There is a gradient in the `user-panel` of the Star Trek LCARS theme that leads to display errors in Safari (both mobile and desktop):

<img width="347" alt="Before (Safari)" src="https://user-images.githubusercontent.com/17005217/147300694-a48c9de4-eaa4-4bab-a963-2f72c20e0515.png">

To fix this, the gradient from the `user-panel` has been edited as suggested by @rdwebdesign. The site now looks exactly the same in all browsers:

<img width="367" alt="After (Firefox)" src="https://user-images.githubusercontent.com/17005217/147300771-e31af098-db65-4f43-aee7-76382eb6dce3.png">

**How does this PR accomplish the above?:**

The erroneous gradient has been replaced as suggested by @rdwebdesign.

**What documentation changes (if any) are needed to support this PR?:**

none