### PR TITLE
Fix invisible buttons in password fields (desktop Safari)

### DIFF
--- a/style/themes/default-dark.css
+++ b/style/themes/default-dark.css
@@ -485,6 +485,12 @@ fieldset[disabled] .form-control {
   background-color: #367fa9 !important;
   border: 1px solid #367fa9;
 }
+input[type="password"]::-webkit-credentials-auto-fill-button {
+  background: #bfc5ca;
+}
+input[type="password"]::-webkit-caps-lock-indicator {
+  filter: invert(100%);
+}
 
 .network-never {
   background-color: #661b02;

--- a/style/themes/default-darker.css
+++ b/style/themes/default-darker.css
@@ -3644,6 +3644,12 @@ a:focus {
 .register-box-body .form-control-feedback {
   color: rgb(157, 148, 136);
 }
+input[type="password"]::-webkit-credentials-auto-fill-button {
+  background: #b1aca3;
+}
+input[type="password"]::-webkit-caps-lock-indicator {
+  filter: invert(100%);
+}
 .invoice {
   background-color: rgb(24, 26, 27);
   background-image: none;

--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -1709,6 +1709,14 @@ input[type="number"]::-webkit-outer-spin-button {
   margin: 0;
 }
 
+input[type="password"]::-webkit-credentials-auto-fill-button {
+  background: white;
+}
+
+input[type="password"]::-webkit-caps-lock-indicator {
+  filter: invert(100%);
+}
+
 /*** ----------------------------------------------------- ***/
 .not-used {
   background-color: #222;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

When using dark themes in desktop Safari, the autofill button cannot be seen because it's colored black on a black background. For the same reason, the caps lock indicator cannot be seen. This PR fixes both issues.

**How does this PR accomplish the above?:**

The issues are fixed by using the text color for the autofill button, and by inverting the caps lock indicator:

<img width="473" alt="dark" src="https://user-images.githubusercontent.com/17005217/147355714-ae845e04-f7fd-4068-8075-d5845a49a4c8.png">
<img width="474" alt="darker" src="https://user-images.githubusercontent.com/17005217/147355719-59edcae4-fb62-44a7-b482-cc01c897018c.png">
<img width="501" alt="lcars" src="https://user-images.githubusercontent.com/17005217/147355725-e108e781-1605-42ca-86d1-2fd62aaa905b.png">


**What documentation changes (if any) are needed to support this PR?:**

none