### PR TITLE
Add border to status indicators in the LCARS theme

### DIFF
--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -839,8 +839,9 @@ label {
   margin: 20px 0 0;
 }
 
-.user-panel .info span svg {
-  filter: drop-shadow(0 0 0.4px rgba(0, 68, 255, 0.4));
+.user-panel .fa-circle path {
+  stroke: rgba(0, 0, 0, 0.5);
+  stroke-width: 5%;
 }
 
 .user-panel svg.text-orange,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

The green status indicators in the LCARS theme are hard to see on the light background. This PR aims to fix that. 
Here's a before and after on a high DPI display:

<img width="201" alt="before-highdpi" src="https://user-images.githubusercontent.com/17005217/147364545-ddddf5d3-fec0-4b89-b484-f3fd1a3b4e52.png">
<img width="202" alt="with-border-hidpi" src="https://user-images.githubusercontent.com/17005217/147367442-37cee62b-5868-41a7-bc3a-4146c367344c.png">


And on a low DPI display:

![before-lowdpi](https://user-images.githubusercontent.com/17005217/147364569-7429467a-0ede-4cfc-a790-62cf2bfd745c.png)
![with-border-lowdpi](https://user-images.githubusercontent.com/17005217/147367437-a51e4011-9d75-4d83-a189-60ee45a6cea6.png)


Successfully tested in Firefox, Safari and mobile Safari.

**How does this PR accomplish the above?:**

A small border is added in the CSS.

**What documentation changes (if any) are needed to support this PR?:**

none