### PR TITLE
1119 Privacy - Query Page and Dom.storage

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -294,7 +294,7 @@ $(function () {
       }
 
       $(row).addClass(blocked === true ? "blocked-row" : "allowed-row");
-      if (localStorage.getItem("colorfulQueryLog_chkbox") === "true") {
+      if (localStorage && localStorage.getItem("colorfulQueryLog_chkbox") === "true") {
         $(row).addClass(blocked === true ? "text-red" : "text-green");
       }
 

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -58,7 +58,9 @@ function countDown() {
   } else {
     ena.text("Enable");
     piholeChanged("enabled");
-    localStorage.removeItem("countDownTarget");
+    if (localStorage) {
+      localStorage.removeItem("countDownTarget");
+    }
   }
 }
 
@@ -148,7 +150,7 @@ function initCheckboxRadioStyle() {
   }
 
   // Read from local storage, initialize if needed
-  var chkboxStyle = localStorage.getItem("theme_icheck");
+  var chkboxStyle = localStorage ? localStorage.getItem("theme_icheck") : null;
   if (chkboxStyle === null) {
     chkboxStyle = "primary";
   }
@@ -172,7 +174,10 @@ function initCheckboxRadioStyle() {
 
 function initCPUtemp() {
   function setCPUtemp(unit) {
-    localStorage.setItem("tempunit", tempunit);
+    if (localStorage) {
+      localStorage.setItem("tempunit", tempunit);
+    }
+
     var temperature = parseFloat($("#rawtemp").text());
     var displaytemp = $("#tempdisplay");
     if (!isNaN(temperature)) {
@@ -195,7 +200,7 @@ function initCPUtemp() {
   }
 
   // Read from local storage, initialize if needed
-  var tempunit = localStorage.getItem("tempunit");
+  var tempunit = localStorage ? localStorage.getItem("tempunit") : null;
   if (tempunit === null) {
     tempunit = "C";
   }

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -231,7 +231,7 @@ $(function () {
       fieldtext += '<input type="hidden" name="id" value="' + parseInt(data[4], 10) + '">';
 
       $(row).addClass(blocked === true ? "blocked-row" : "allowed-row");
-      if (localStorage.getItem("colorfulQueryLog_chkbox") === "true") {
+      if (localStorage && localStorage.getItem("colorfulQueryLog_chkbox") === "true") {
         $(row).addClass(blocked === true ? "text-red" : "text-green");
       }
 

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -334,7 +334,7 @@ $(".nav-tabs a").on("shown.bs.tab", function (e) {
 // Bar/Smooth chart toggle
 $(function () {
   var bargraphs = $("#bargraphs");
-  var chkboxData = localStorage.getItem("barchart_chkbox");
+  var chkboxData = localStorage ? localStorage.getItem("barchart_chkbox") : null;
 
   if (chkboxData !== null) {
     // Restore checkbox state
@@ -342,7 +342,9 @@ $(function () {
   } else {
     // Initialize checkbox
     bargraphs.prop("checked", true);
-    localStorage.setItem("barchart_chkbox", true);
+    if (localStorage) {
+      localStorage.setItem("barchart_chkbox", true);
+    }
   }
 
   bargraphs.click(function () {
@@ -352,7 +354,7 @@ $(function () {
 
 $(function () {
   var colorfulQueryLog = $("#colorfulQueryLog");
-  var chkboxData = localStorage.getItem("colorfulQueryLog_chkbox");
+  var chkboxData = localStorage ? localStorage.getItem("colorfulQueryLog_chkbox") : null;
 
   if (chkboxData !== null) {
     // Restore checkbox state
@@ -360,7 +362,9 @@ $(function () {
   } else {
     // Initialize checkbox
     colorfulQueryLog.prop("checked", false);
-    localStorage.setItem("colorfulQueryLog_chkbox", false);
+    if (localStorage) {
+      localStorage.setItem("colorfulQueryLog_chkbox", false);
+    }
   }
 
   colorfulQueryLog.click(function () {

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -235,7 +235,7 @@ function stateSaveCallback(itemName, data) {
 
 function stateLoadCallback(itemName) {
   // Receive previous state from client's local storage area
-  var data = localStorage.getItem(itemName);
+  var data = localStorage ? localStorage.getItem(itemName) : null;
   // Return if not available
   if (data === null) {
     return null;
@@ -259,7 +259,7 @@ function stateLoadCallback(itemName) {
 
 function getGraphType() {
   // Only return line if `barchart_chkbox` is explicitly set to false. Else return bar
-  return localStorage.getItem("barchart_chkbox") === "false" ? "line" : "bar";
+  return localStorage && localStorage.getItem("barchart_chkbox") === "false" ? "line" : "bar";
 }
 
 function addFromQueryLog(domain, list) {

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -239,9 +239,14 @@ function stateSaveCallback(itemName, data) {
 }
 
 function stateLoadCallback(itemName) {
+  var data;
   // Receive previous state from client's local storage area
-  var data =
-    localStorage === null ? backupStorage[itemName] || null : localStorage.getItem(itemName);
+  if (localStorage === null) {
+    var item = backupStorage[itemName];
+    data = typeof item === "undefined" ? null : item;
+  } else {
+    localStorage.getItem(itemName);
+  }
 
   // Return if not available
   if (data === null) {

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -245,7 +245,7 @@ function stateLoadCallback(itemName) {
     var item = backupStorage[itemName];
     data = typeof item === "undefined" ? null : item;
   } else {
-    localStorage.getItem(itemName);
+    data = localStorage.getItem(itemName);
   }
 
   // Return if not available

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -229,13 +229,20 @@ function setBsSelectDefaults() {
   };
 }
 
+var backupStorage = {};
 function stateSaveCallback(itemName, data) {
-  localStorage.setItem(itemName, JSON.stringify(data));
+  if (localStorage === null) {
+    backupStorage[itemName] = JSON.stringify(data);
+  } else {
+    localStorage.setItem(itemName, JSON.stringify(data));
+  }
 }
 
 function stateLoadCallback(itemName) {
   // Receive previous state from client's local storage area
-  var data = localStorage ? localStorage.getItem(itemName) : null;
+  var data =
+    localStorage === null ? backupStorage[itemName] || null : localStorage.getItem(itemName);
+
   // Return if not available
   if (data === null) {
     return null;


### PR DESCRIPTION
handle localStorage being null

Signed-off-by: Chris Miceli <chrismiceli@outlook.com>

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Addresses https://github.com/pi-hole/AdminLTE/issues/1119

**How does this PR accomplish the above?:**
This PR defaults all storage access to as if the item wasn't present to allow execution of scripts to continue. Note that I left some cases where a user interacts with a setting so that there is an indication the preference/setting wasn't persisted.

**What documentation changes (if any) are needed to support this PR?:**
None, unless we want to officially document when storage is disabled.
