### PR TITLE
Include FTL's DNS port in web status and give the temperature its own line

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -731,8 +731,6 @@ function updateSummaryData(runOnce) {
       data.ads_blocked_today = "connection";
       data.ads_percentage_today = "to";
       data.domains_being_blocked = "API";
-      // Adjust text
-      $("#temperature").html('<i class="fa fa-circle text-red"></i> FTL offline');
       // Show spinner
       $("#queries-over-time .overlay").show();
       $("#forward-destinations-pie .overlay").show();
@@ -745,7 +743,6 @@ function updateSummaryData(runOnce) {
     } else if (FTLoffline) {
       // FTL was previously offline
       FTLoffline = false;
-      $("#temperature").text(" ");
       updateQueriesOverTime();
       updateTopClientsChart();
       updateTopLists();

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -355,6 +355,10 @@ if($auth) {
                                 echo "text-vivid-blue";
                             }
                             ?>"></i> Temp:&nbsp;<span id="rawtemp" hidden><?php echo $celsius;?></span><span id="tempdisplay"></span></span><?php
+                        } else {
+                            echo "<span id=\"temperature\"><i class=\"fa fa-fire ";
+                            echo "text-vivid-blue";
+                            ?>"></i> No temp sensor found<span id="tempdisplay"></span><?php
                         }
                     ?>
                     <br/>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -151,7 +151,7 @@
     }
     $FTLpid = intval(pidofFTL());
     $FTL = ($FTLpid !== 0 ? true : false);
-    
+
     $piholeFTLConf = piholeFTLConfig();
 ?>
 <!doctype html>
@@ -350,24 +350,16 @@ if($auth) {
                         }
                         ?>
                       <br/>
-                    <?php
-                      // CPU Temp
-                        if ($celsius >= -273.15) {
-                            echo "<span id=\"temperature\"><i class=\"fa fa-fire ";
-                            if ($celsius > $temperaturelimit) {
-                                echo "text-red";
-                            }
-                            else
-                            {
-                                echo "text-vivid-blue";
-                            }
-                            ?>"></i> Temp:&nbsp;<span id="rawtemp" hidden><?php echo $celsius;?></span><span id="tempdisplay"></span></span><?php
-                        } else {
-                            echo "<span id=\"temperature\"><i class=\"fa fa-fire ";
-                            echo "text-vivid-blue";
-                            ?>"></i> No temp sensor found<span id="tempdisplay"></span><?php
-                        }
-                    ?>
+                      <?php $tempcolor = "text-vivid-blue";
+                      if ($celsius > $temperaturelimit) {
+                          $tempcolor = "text-red";}
+                      echo "<span id=\"temperature\"><i class=\"fa fa-fire ".$tempcolor."\"></i>";
+                      ?>
+                      <?php if ($celsius >= -273.15) {
+                        echo "Temp:&nbsp;<span id=\"rawtemp\" hidden>" .$celsius. "</span><span id=\"tempdisplay\"></span>";
+                      } else {
+                        echo "No temp sensor found<span id=\"tempdisplay\"></span>";}
+                      ?></span>
                     <br/>
                     <?php
                     echo "<span title=\"Detected $nproc cores\"><i class=\"fa fa-circle ";

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -336,10 +336,10 @@ if($auth) {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> Offline</span>';
                         } elseif ($pistatus === "-1") {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> DNS service not running</span>';
-                        } elseif ($pistatus === "-2") {
+                        } elseif ($pistatus === "-2" || is_null($pistatus)) {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> Unknown</span>';
                         } else {
-                            echo '<span id="status"><i class="fa fa-circle text-orange"></i> DNS service on port '; echo $pistatus; echo '</span>';
+                            echo '<span id="status"><i class="fa fa-circle text-orange"></i> DNS service on port '.$pistatus.'</span>';
                         }
                         ?>
                       <br/>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -319,7 +319,7 @@ if($auth) {
             <!-- Sidebar user panel -->
             <div class="user-panel">
                 <div class="pull-left image">
-                    <img src="img/logo.svg" alt="Pi-hole logo" width="45" height="67" style="height: 67px;">
+                    <img src="img/logo.svg" alt="Pi-hole logo" width="45" height="67" style="height: 90px;">
                 </div>
                 <div class="pull-left info">
                     <p>Status</p>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -145,6 +145,13 @@
         }
     }
 
+    function pidofFTL()
+    {
+        return shell_exec("pidof pihole-FTL");
+    }
+    $FTLpid = intval(pidofFTL());
+    $FTL = ($FTLpid !== 0 ? true : false);
+    
     $piholeFTLConf = piholeFTLConfig();
 ?>
 <!doctype html>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -326,24 +326,24 @@ if($auth) {
             <!-- Sidebar user panel -->
             <div class="user-panel">
                 <div class="pull-left image">
-                    <img src="img/logo.svg" alt="Pi-hole logo" width="45" height="67" style="height: 90px;">
+                    <img src="img/logo.svg" alt="Pi-hole logo" width="45" height="90" style="height: 90px;">
                 </div>
                 <div class="pull-left info">
                     <p>Status</p>
                         <?php
                         $pistatus = pihole_execute('status web');
                         if (isset($pistatus[0])) {
-                            $pistatus = $pistatus[0];
+                            $pistatus = intval($pistatus[0]);
                         } else {
                             $pistatus = null;
                         }
-                        if ($pistatus === "53") {
+                        if ($pistatus == "53") {
                             echo '<span id="status"><i class="fa fa-circle text-green-light"></i> Active</span>';
-                        } elseif ($pistatus === "0") {
+                        } elseif ($pistatus == "0") {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> Offline</span>';
-                        } elseif ($pistatus === "-1") {
+                        } elseif ($pistatus == "-1") {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> DNS service not running</span>';
-                        } elseif ($pistatus === "-2" || is_null($pistatus)) {
+                        } elseif ($pistatus == "-2" || is_null($pistatus)) {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> Unknown</span>';
                         } else {
                             echo '<span id="status"><i class="fa fa-circle text-orange"></i> DNS service on port '.$pistatus.'</span>';

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -346,28 +346,30 @@ if($auth) {
                         } elseif ($pistatus === "-2") {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> Unknown</span>';
                         } else {
-                            echo '<span id="status"><i class="fa fa-circle text-orange"></i> DNS service running on port </span>' <?php echo $pistatus;?>;
+                            echo '<span id="status"><i class="fa fa-circle text-orange"></i> DNS service running on port '; echo $pistatus; echo '</span>';
                         }
-
-                        // CPU Temp
-                        if($FTL)
-                        {
-                            if ($celsius >= -273.15) {
-                                echo "<span id=\"temperature\"><i class=\"fa fa-fire ";
-                                if ($celsius > $temperaturelimit) {
-                                    echo "text-red";
-                                }
-                                else
-                                {
-                                    echo "text-vivid-blue";
-                                }
-                                ?>"></i> Temp:&nbsp;<span id="rawtemp" hidden><?php echo $celsius;?></span><span id="tempdisplay"></span></span><?php
-                            }
-                        }
-                        else
-                        {
-                            echo '<span id=\"temperature\"><i class="fa fa-circle text-red"></i> FTL offline</span>';
-                        }
+                        ?>
+                      <br/>
+                    <?php
+                      // CPU Temp
+                      if($FTL)
+                      {
+                          if ($celsius >= -273.15) {
+                              echo "<span id=\"temperature\"><i class=\"fa fa-fire ";
+                              if ($celsius > $temperaturelimit) {
+                                  echo "text-red";
+                              }
+                              else
+                              {
+                                  echo "text-vivid-blue";
+                              }
+                              ?>"></i> Temp:&nbsp;<span id="rawtemp" hidden><?php echo $celsius;?></span><span id="tempdisplay"></span></span><?php
+                          }
+                      }
+                      else
+                      {
+                          echo '<span id=\"temperature\"><i class="fa fa-circle text-red"></i> FTL offline</span>';
+                      }
                     ?>
                     <br/>
                     <?php

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -337,14 +337,16 @@ if($auth) {
                         } else {
                             $pistatus = null;
                         }
-                        if ($pistatus === "1") {
+                        if ($pistatus === "53") {
                             echo '<span id="status"><i class="fa fa-circle text-green-light"></i> Active</span>';
                         } elseif ($pistatus === "0") {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> Offline</span>';
                         } elseif ($pistatus === "-1") {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> DNS service not running</span>';
+                        } elseif ($pistatus === "-2") {
+                            echo '<span id="status"><i class="fa fa-circle text-red"></i> Unknown</span>';
                         } else {
-                            echo '<span id="status"><i class="fa fa-circle text-orange"></i> Unknown</span>';
+                            echo '<span id="status"><i class="fa fa-circle text-orange"></i> DNS service running on port </span>' <?php echo $pistatus;?>;
                         }
 
                         // CPU Temp

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -145,13 +145,6 @@
         }
     }
 
-    function pidofFTL()
-    {
-        return shell_exec("pidof pihole-FTL");
-    }
-    $FTLpid = intval(pidofFTL());
-    $FTL = ($FTLpid !== 0 ? true : false);
-
     $piholeFTLConf = piholeFTLConfig();
 ?>
 <!doctype html>
@@ -346,30 +339,23 @@ if($auth) {
                         } elseif ($pistatus === "-2") {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> Unknown</span>';
                         } else {
-                            echo '<span id="status"><i class="fa fa-circle text-orange"></i> DNS service running on port '; echo $pistatus; echo '</span>';
+                            echo '<span id="status"><i class="fa fa-circle text-orange"></i> DNS service on port '; echo $pistatus; echo '</span>';
                         }
                         ?>
                       <br/>
                     <?php
                       // CPU Temp
-                      if($FTL)
-                      {
-                          if ($celsius >= -273.15) {
-                              echo "<span id=\"temperature\"><i class=\"fa fa-fire ";
-                              if ($celsius > $temperaturelimit) {
-                                  echo "text-red";
-                              }
-                              else
-                              {
-                                  echo "text-vivid-blue";
-                              }
-                              ?>"></i> Temp:&nbsp;<span id="rawtemp" hidden><?php echo $celsius;?></span><span id="tempdisplay"></span></span><?php
-                          }
-                      }
-                      else
-                      {
-                          echo '<span id=\"temperature\"><i class="fa fa-circle text-red"></i> FTL offline</span>';
-                      }
+                        if ($celsius >= -273.15) {
+                            echo "<span id=\"temperature\"><i class=\"fa fa-fire ";
+                            if ($celsius > $temperaturelimit) {
+                                echo "text-red";
+                            }
+                            else
+                            {
+                                echo "text-vivid-blue";
+                            }
+                            ?>"></i> Temp:&nbsp;<span id="rawtemp" hidden><?php echo $celsius;?></span><span id="tempdisplay"></span></span><?php
+                        }
                     ?>
                     <br/>
                     <?php
@@ -542,7 +528,7 @@ if($auth) {
                   </ul>
                     <!-- <a href="#" id="flip-status"><i class="fa fa-stop"></i> Disable</a> -->
                 </li>
-                <li id="pihole-enable" class="treeview"<?php if ($pistatus == "1") { ?> hidden<?php } ?>>
+                <li id="pihole-enable" class="treeview"<?php if (!in_array($pistatus,["0","-1","-2"])) { ?> hidden<?php } ?>>
                     <a href="#">
                       <i class="fa fa-fw menu-icon fa-play"></i>
                       <span id="enableLabel">Enable&nbsp;&nbsp;&nbsp;

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -337,13 +337,13 @@ if($auth) {
                         } else {
                             $pistatus = null;
                         }
-                        if ($pistatus == "53") {
+                        if ($pistatus == 53) {
                             echo '<span id="status"><i class="fa fa-circle text-green-light"></i> Active</span>';
-                        } elseif ($pistatus == "0") {
+                        } elseif ($pistatus == 0) {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> Offline</span>';
-                        } elseif ($pistatus == "-1") {
+                        } elseif ($pistatus == -1) {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> DNS service not running</span>';
-                        } elseif ($pistatus == "-2" || is_null($pistatus)) {
+                        } elseif ($pistatus == -2 || is_null($pistatus)) {
                             echo '<span id="status"><i class="fa fa-circle text-red"></i> Unknown</span>';
                         } else {
                             echo '<span id="status"><i class="fa fa-circle text-orange"></i> DNS service on port '.$pistatus.'</span>';


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Reports if FTL is running on another port than 53 in the user-panel in the web interface. Additionally, the temperature info got its own line in the user-panel

Fixes #2030

Needs: https://github.com/pi-hole/pi-hole/pull/4485

![Bildschirmfoto zu 2021-12-26 18-25-01](https://user-images.githubusercontent.com/26622301/147415586-6a65b573-3f55-467e-a5b1-6e7c5dd92e98.png)

