### PR TITLE
Fixing PHP warnings in "qrcode.php"

### DIFF
--- a/scripts/pi-hole/php/api_token.php
+++ b/scripts/pi-hole/php/api_token.php
@@ -3,6 +3,7 @@
 <style>
 body {
   background: #fff;
+  margin: 10px 0;
 }
 
 .qrcode {
@@ -32,7 +33,8 @@ if($auth) {
     echo '<div class="qrcode">';
     require_once("../../vendor/qrcode.php");
     $qr = QRCode::getMinimumQRCode($pwhash, QR_ERROR_CORRECT_LEVEL_Q);
-    $qr->printSVG("10px");
+    // The size of each block (in pixels) should be an integer
+    $qr->printSVG(10);
     echo "</div>";
     echo 'Raw API Token: <code class="token">' . $pwhash . "</code></div>";
   } else {

--- a/scripts/vendor/qrcode.php
+++ b/scripts/vendor/qrcode.php
@@ -64,24 +64,27 @@ class QRCode {
         }
 
         switch($mode) {
-
-        case QR_MODE_NUMBER :
-            $this->addDataImpl(new QRNumber($data) );
+          case QR_MODE_NUMBER:
+            $d = new QRNumber($data);
+            $this->addDataImpl($d);
             break;
 
-        case QR_MODE_ALPHA_NUM :
-            $this->addDataImpl(new QRAlphaNum($data) );
+          case QR_MODE_ALPHA_NUM:
+            $d = new QRAlphaNum($data);
+            $this->addDataImpl($d);
             break;
 
-        case QR_MODE_8BIT_BYTE :
-            $this->addDataImpl(new QR8BitByte($data) );
+          case QR_MODE_8BIT_BYTE:
+            $d = new QR8BitByte($data);
+            $this->addDataImpl($d);
             break;
 
-        case QR_MODE_KANJI :
-            $this->addDataImpl(new QRKanji($data) );
+          case QR_MODE_KANJI:
+            $d = new QRKanji($data);
+            $this->addDataImpl($d);
             break;
 
-        default :
+          default:
             trigger_error("mode:$mode", E_USER_ERROR);
         }
     }
@@ -554,6 +557,7 @@ class QRCode {
 
     public function printSVG($size = 2)
     {
+        $size = (int) $size;
         $width = $this->getModuleCount() * $size;
         $height = $width;
         print('<svg width="' . $width . '" height="' . $height . '" viewBox="0 0 ' . $width . ' ' . $height . '" xmlns="http://www.w3.org/2000/svg">');


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This PR complements PR #2022, fixing a few warnings/notices generated by the qrcode library.

**How does this PR accomplish the above?:**

Fixes:
- the warning received when the code (between lines 66 and 89) calls `new` inside  `addDataImpl()`. 
- also fixes the `PHP Notice:  A non well formed numeric value encountered...` received when the code for `printSVG()` encounters a string where a numeric type is expected.

**What documentation changes (if any) are needed to support this PR?:**

none.