### PR TITLE
Remove text transformation from update command

### DIFF
--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -101,6 +101,10 @@ code {
   font-family: "Ubuntu Mono", Consolas, "Courier New", monospace;
 }
 
+footer code {
+  text-transform: none;
+}
+
 pre {
   padding: 10px 3px;
   border: none;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This PR removes the upper case text transformation from the update command. The resulting change can be seen below:

<img width="389" alt="before" src="https://user-images.githubusercontent.com/17005217/147662549-3421ef85-3111-41d6-b30c-6f845dfc3578.png">
<img width="407" alt="after" src="https://user-images.githubusercontent.com/17005217/147662557-190cbd13-6d8b-4c6b-8faa-a16841f46019.png">

Only the LCARS theme is affected, because other themes don't use text transformations. 

**How does this PR accomplish the above?:**

The `text-transform` property is set to `none` for `code` elements in the footer.

**What documentation changes (if any) are needed to support this PR?:**

none