### PR TITLE
Prevent ad blockers from blocking query log UI elements

### DIFF
--- a/db_queries.php
+++ b/db_queries.php
@@ -79,7 +79,7 @@
         <!-- small box -->
         <div class="small-box bg-aqua no-user-select">
             <div class="inner">
-                <h3 class="statistic" id="ads_blocked_exact">---</h3>
+                <h3 class="statistic" id="queries_blocked_exact">---</h3>
                 <p>Queries Blocked</p>
             </div>
             <div class="icon">
@@ -92,7 +92,7 @@
         <!-- small box -->
         <div class="small-box bg-aqua no-user-select">
             <div class="inner">
-                <h3 class="statistic" id="ads_wildcard_blocked">---</h3>
+                <h3 class="statistic" id="queries_wildcard_blocked">---</h3>
                 <p>Queries Blocked (Wildcards)</p>
             </div>
             <div class="icon">
@@ -118,7 +118,7 @@
         <!-- small box -->
         <div class="small-box bg-yellow no-user-select">
             <div class="inner">
-                <h3 class="statistic" id="ads_percentage_today">---</h3>
+                <h3 class="statistic" id="queries_percentage_today">---</h3>
                 <p>Queries Blocked</p>
             </div>
             <div class="icon">

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -165,8 +165,8 @@ var reloadCallback = function () {
 
   var formatter = new Intl.NumberFormat();
   $("h3#dns_queries").text(formatter.format(statistics[0]));
-  $("h3#ads_blocked_exact").text(formatter.format(statistics[2]));
-  $("h3#ads_wildcard_blocked").text(formatter.format(statistics[3]));
+  $("h3#queries_blocked_exact").text(formatter.format(statistics[2]));
+  $("h3#queries_wildcard_blocked").text(formatter.format(statistics[3]));
 
   var percent = 0;
   if (statistics[2] + statistics[3] > 0) {
@@ -174,7 +174,7 @@ var reloadCallback = function () {
   }
 
   var percentage = formatter.format(Math.round(percent * 10) / 10);
-  $("h3#ads_percentage_today").text(percentage + " %");
+  $("h3#queries_percentage_today").text(percentage + " %");
 };
 
 function refreshTableData() {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This PR fixes an issue where certain ad blockers block elements with an ID starting with `ads_`.
In the past, a similar issue has been discussed in #850. 

Before:
<img width="1007" alt="before" src="https://user-images.githubusercontent.com/17005217/147698559-762d3b0d-b189-47a0-9d33-0e04b557456f.png">

After:
<img width="1011" alt="after" src="https://user-images.githubusercontent.com/17005217/147698595-1193c2bb-6832-499e-abb7-be91e342d1a9.png">

**How does this PR accomplish the above?:**

In the IDs of the affected elements, `ads_` is replaced with `queries_`. 
An identical solution has already been implemented for the elements mentioned in #850.

**What documentation changes (if any) are needed to support this PR?:**

none