### PR TITLE
Fix mislabeled privacy setting

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -1241,7 +1241,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                                 <div>
                                                     <input type="radio" name="privacylevel" id="privacylevel_1" value="1" <?php if ($privacylevel === 1){ ?>checked<?php } ?>>
                                                     <label for="privacylevel_1"><strong>Hide domains: Display and store all domains as "hidden"</strong></label>
-                                                    <p>This disables the Top Domains and Top Ads tables on the dashboard</p>
+                                                    <p>This disables the Top Domains and Top Blocked Domains tables on the dashboard</p>
                                                 </div>
                                                 <div>
                                                     <input type="radio" name="privacylevel" id="privacylevel_2" value="2" <?php if ($privacylevel === 2){ ?>checked<?php } ?>>

--- a/settings.php
+++ b/settings.php
@@ -1241,7 +1241,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                                 <div>
                                                     <input type="radio" name="privacylevel" id="privacylevel_1" value="1" <?php if ($privacylevel === 1){ ?>checked<?php } ?>>
                                                     <label for="privacylevel_1"><strong>Hide domains: Display and store all domains as "hidden"</strong></label>
-                                                    <p>This disables the Top Domains and Top Blocked Domains tables on the dashboard</p>
+                                                    <p>This disables the Top Permitted Domains and Top Blocked Domains tables on the dashboard</p>
                                                 </div>
                                                 <div>
                                                     <input type="radio" name="privacylevel" id="privacylevel_2" value="2" <?php if ($privacylevel === 2){ ?>checked<?php } ?>>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixed a mislabeled option in settings where it references a non-existent "Top Ads" section. It should instead reference "Top Blocked Domains"

**How does this PR accomplish the above?:**

Fixed a mislabeled option in settings 

**What documentation changes (if any) are needed to support this PR?:**

None

> - You must follow the template instructions. Failure to do so will result in your issue being closed.
> - Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
> - Detail helps us understand an issue quicker, but please ensure it's relevant.
