### PR TITLE
Changing the information source to "pi-hole status" in the API

### DIFF
--- a/api.php
+++ b/api.php
@@ -19,28 +19,7 @@ $data = array();
 
 // Common API functions
 if (isset($_GET['status'])) {
-    // Receive the return of "pihole status web"
-    $pistatus = pihole_execute('status web');
-
-    if (isset($pistatus[0])) {
-        $pistatus = intval($pistatus[0]);
-    } else {
-        // If no response, status="Unknown" (-2)
-        $pistatus = -2;
-    }
-
-    switch ($pistatus) {
-        case -2: // Unkown
-        case -1: // DNS service not running"
-        case 0: // Offline
-            $data = array_merge($data, array("status" => "disabled"));
-            break;
-
-        default:
-            // DNS service on port $returncode
-            $data = array_merge($data, array("status" => "enabled"));
-    }
-
+    $data = array_merge($data, array("status" => piholeStatusAPI()));
 } elseif (isset($_GET['enable']) && $auth) {
 	if(isset($_GET["auth"]))
 	{

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -29,21 +29,22 @@ else
 		$data["version"] = 3;
 	}
 
-	if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET))
-	{
+	if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET)) {
 		require_once("scripts/pi-hole/php/gravity.php");
 		sendRequestFTL("stats");
 		$return = getResponseFTL();
 
 		$stats = [];
-		foreach($return as $line)
-		{
+		foreach($return as $line) {
 			$tmp = explode(" ",$line);
 
-			if(($tmp[0] === "domains_being_blocked" && !is_numeric($tmp[1])) || $tmp[0] === "status")
+			if($tmp[0] === "domains_being_blocked" && !is_numeric($tmp[1])) {
 				$stats[$tmp[0]] = $tmp[1]; // Expect string response
-			else
+			} elseif ($tmp[0] === "status") {
+				$stats[$tmp[0]] = piholeStatusAPI();
+			} else {
 				$stats[$tmp[0]] = floatval($tmp[1]); // Expect float response
+			}
 		}
 		$stats['gravity_last_updated'] = gravity_last_update(true);
 		$data = array_merge($data,$stats);

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -483,4 +483,31 @@ function getQueryTypeStr($querytype)
         return "TYPE".($qtype - 100);
 }
 
+// Returns an integer representing pihole blocking status
+function piholeStatus()
+{
+    // Receive the return of "pihole status web"
+    $pistatus = pihole_execute('status web');
+    return isset($pistatus[0]) ? intval($pistatus[0]) : -2;
+}
+
+// Returns pihole status, using only valid API responses (enabled/disabled)
+function piholeStatusAPI()
+{
+    // Receive the return of "pihole status web"
+    $pistatus = piholeStatus();
+
+    switch ($pistatus) {
+        case -2: // Unkown
+        case -1: // DNS service not running"
+        case 0: // Offline
+            $response = "disabled";
+            break;
+
+        default:
+            // DNS service running on port $returncode
+            $response = "enabled";
+    }
+    return $response;
+}
 ?>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix an API intermittent error, where the status info received by `api.php` or `api.php?summary` is sometimes wrongly reported.
Cause: 
`api_FTL.php` uses FTL response to determine if pi-hole is _enabled_ or _disabled_. 
FTL only updates this value when is internally needed, but it doesn't update this value before answering the API call. 
  
**How does this PR accomplish the above?:**

Replacing the status received from FTL with the status currently stored in `setupVars.conf`.

**What documentation changes (if any) are needed to support this PR?:**

none