### PR TITLE
Restore `api.php?summary` response format

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -39,12 +39,23 @@ else
 			$tmp = explode(" ",$line);
 
 			if($tmp[0] === "domains_being_blocked" && !is_numeric($tmp[1])) {
-				$stats[$tmp[0]] = $tmp[1]; // Expect string response
+				// Expect string response
+				$stats[$tmp[0]] = $tmp[1];
 			} elseif ($tmp[0] === "status") {
+				// Expect string response
 				$stats[$tmp[0]] = piholeStatusAPI();
+			} elseif (isset($_GET['summary'])) {
+				// "summary" expects a formmated string response
+				if($tmp[0] !== "ads_percentage_today") {
+					$stats[$tmp[0]] = number_format($tmp[1]);
+				} else {
+					$stats[$tmp[0]] = number_format($tmp[1], 1, '.', '');
+				}
 			} else {
-				$stats[$tmp[0]] = floatval($tmp[1]); // Expect float response
+				// Expect float response
+				$stats[$tmp[0]] = floatval($tmp[1]);
 			}
+
 		}
 		$stats['gravity_last_updated'] = gravity_last_update(true);
 		$data = array_merge($data,$stats);

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -723,7 +723,7 @@ function updateSummaryData(runOnce) {
     }
   };
 
-  $.getJSON("api.php?summary", function (data) {
+  $.getJSON("api.php?summaryRaw", function (data) {
     updateSessionTimer();
 
     if ("FTLnotrunning" in data) {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

A recent modification in API changed the response format of `api.php?summary`.
This PR restores the old format.

**How does this PR accomplish the above?:**

Restoring the old functions only in "summary" response.
**Note:** calling the API using `api.php?summaryRaw` or `api.php` (without parameters) will return the new format. 

**What documentation changes (if any) are needed to support this PR?:**

I don't know. 
Maybe the differences between `api.php?summary` and `api.php?summaryRaw` should be more explicit.