### PR TITLE
Fix extra spaces in queryads

### DIFF
--- a/scripts/pi-hole/php/queryads.php
+++ b/scripts/pi-hole/php/queryads.php
@@ -17,7 +17,7 @@ header('Cache-Control: no-cache');
 
 function echoEvent($datatext) {
     if(!isset($_GET["IE"]))
-      echo "data: ".implode("\ndata: ", explode("\n", $datatext))."\n\n";
+      echo "data:".implode("\ndata:", explode("\n", $datatext))."\n\n";
     else
       echo $datatext;
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix #1259. 

**How does this PR accomplish the above?:**

Removes the extra spaces on PHP function.

**What documentation changes (if any) are needed to support this PR?:**

none.