### PR TITLE
Improves extension validation for `teleporter.php`

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -337,18 +337,15 @@ if(isset($_POST["action"]))
 		$source = $_FILES["zip_file"]["tmp_name"];
 		$type = mime_content_type($source);
 
-		$name = explode(".", $filename);
+		// verify the file mime type
 		$accepted_types = array('application/gzip', 'application/tar', 'application/x-compressed', 'application/x-gzip');
-		$okay = false;
-		foreach($accepted_types as $mime_type) {
-			if($mime_type == $type) {
-				$okay = true;
-				break;
-			}
-		}
+		$mime_valid = in_array($type, $accepted_types);
 
-		$continue = strtolower($name[1]) == 'tar' && strtolower($name[2]) == 'gz' ? true : false;
-		if(!$continue || !$okay) {
+		// verify the file extension (Looking for ".tar.gz" at the end of the file name)
+		$ext = array_slice(explode(".", $filename), -2, 2);
+		$ext_valid = strtolower($ext[0]) == "tar" && strtolower($ext[1]) == "gz" ? true : false;
+
+		if(!$ext_valid || !$mime_valid) {
 			die("The file you are trying to upload is not a .tar.gz file (filename: ".htmlentities($filename).", type: ".htmlentities($type)."). Please try again.");
 		}
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix #1455.

The original code assumed that the file extension ".tar.gz" was always after the first dot.

This way, it could accept invalid filenames like:
`filename.tar.gz.php`

or it could ignore valid filenames like:
`file.name.with.dots.tar.gz` 

**How does this PR accomplish the above?:**

Changing the code to look for the extension at the end of the filename.

**What documentation changes (if any) are needed to support this PR?:**

none.