### PR TITLE
Add date and time to status section.

### DIFF
--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -334,6 +334,10 @@ if($auth) {
                 <div class="pull-left info">
                     <p>Status</p>
                     <?php
+                        echo "<span>Stardate: " . date("Y-m-d H:i") . "</span>"
+                    ?>
+                    <br/>
+                    <?php
                     $pistatus = piholeStatus();
                     if ($pistatus == 53) {
                         echo '<span id="status"><i class="fa fa-w fa-circle text-green-light"></i> Active</span>';


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [ ] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ ] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
I have Pi-hole running on OrangePi Zero. Once in a while all DNS requests become blocked. The culprit turned out to be systemd service that tries to rotate logs and gets killed by watchdog. The system time is reset to somewhen in 1981 in the process, and causes the DNS requests' failures. All system services that require system logging e.g. ssh login, /sbin/reboot and even '/sbin/init 6' get stuck on logging step. The existing services keep running, and some times Pi-hole UI still responds. Currently to detect that situation I must open the pihole.log tail section, which may not be immediately available. Having the system date and time in status section at a glance would help to detect the problem.
Currently the only work-around I found is to disconnect the power and restart the SBC, just FYI if anybody encounters that.

**How does this PR accomplish the above?:**
A date is presented in status section.

**What documentation changes (if any) are needed to support this PR?:**
I don't think there is a need to change any documentation.


> - `{Please delete this quoted section when opening your pull request}`
> - You must follow the template instructions. Failure to do so will result in your issue being closed.
> - Please respect that Pi-hole is developed by volunteers, who can only reply in their spare time.
> - Detail helps us understand an issue quicker, but please ensure it's relevant.
