### PR TITLE
footer.php: Add the Docker Hub tags filter link to "Docker Tag"

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -53,10 +53,12 @@
 
     $githubBaseUrl = "https://github.com/pi-hole";
     $coreUrl = $githubBaseUrl . "/pi-hole";
+    $dockerUrl = $githubBaseUrl . "/docker-pi-hole";
     $ftlUrl = $githubBaseUrl . "/FTL";
     $webUrl = $githubBaseUrl . "/AdminLTE";
 
     $coreReleasesUrl = $coreUrl . "/releases";
+    $dockerReleasesUrl = $dockerUrl . "/releases";
     $ftlReleasesUrl = $ftlUrl . "/releases";
     $webReleasesUrl = $webUrl . "/releases";
 ?>
@@ -78,7 +80,12 @@
                 </ul>
                 <?php } else { ?>
                 <ul class="list-inline">
-                    <?php if($dockerTag) { ?> <li><strong>Docker Tag</strong> <?php echo $dockerTag; ?></li> <?php } ?>
+                    <?php if($dockerTag) { ?>
+                    <li>
+                        <strong>Docker Tag</strong>
+                        <a href="<?php echo $dockerReleasesUrl . "/" . $dockerTag; ?>" rel="noopener" target="_blank"><?php echo $dockerTag; ?></a>
+                    </li>
+                    <?php } ?>
                     <li>
                         <strong>Pi-hole</strong>
                         <a href="<?php echo $coreReleasesUrl . "/" . $core_current; ?>" rel="noopener" target="_blank"><?php echo $core_current; ?></a>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

There're some links to the releases pages at the footer, which is very useful, but only the Docker Tag doesn't have it:
![image](https://user-images.githubusercontent.com/3691490/150525578-6bb73c86-cc17-41ff-ac18-15a4d5161fef.png)

**How does this PR accomplish the above?:**

Just add the Docker Hub link to filter the Docker image tags in the `pihole/pihole` repository, result:

**Docker Tag** [2022.01.1](https://hub.docker.com/r/pihole/pihole/tags?page=1&name=2022.01.1)
![image](https://user-images.githubusercontent.com/3691490/150525769-0e229fac-e3cf-4039-abcf-767e7976102a.png)


**What documentation changes (if any) are needed to support this PR?:**

Doesn't look like it need documentation ;)