### PR TITLE
Fix layout resizing on login screen in LCARS theme

### DIFF
--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -1657,13 +1657,11 @@ table.dataTable {
   }
 }
 
-@media (min-width: 1920px) {
+@media (min-width: 1960px) {
   .layout-boxed .form-group.has-error.login-box-msg::before {
     font-size: calc((1920px - var(--sidebar-width) - 60px) / 12);
   }
-}
 
-@media (min-width: 1960px) {
   .layout-boxed .wrapper {
     box-shadow: none;
     max-width: 1920px;


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

If the screen width is between 1920px and 1960px, and a wrong password is entered while using the LCARS theme, there was overlapping text.
This is because the text was resized at widths > 1920px, but the surrounding elements were only resized at widths > 1960px:

<img width="350" alt="overlap" src="https://user-images.githubusercontent.com/17005217/150658789-08fe1001-fefa-477b-adee-ca692638d0f8.png">

**How does this PR accomplish the above?:**

The layout is now only resized once at a width of 1960px, so the text and the surrounding elements are resized at the same time.
Confirmed to work in Chromium, Firefox and Safari.

**What documentation changes (if any) are needed to support this PR?:**

none