### PR TITLE
Fix the wrong escaping on settings datatable

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -268,8 +268,25 @@ $(function () {
       columnDefs: [
         { bSortable: false, orderable: false, targets: -1 },
         {
-          targets: [0, 1, 2],
+          targets: [0, 1],
           render: $.fn.dataTable.render.text(),
+        },
+        {
+          targets: 2,
+          render: function (data) {
+            // Show "unknown", when host is "*"
+            var str;
+            if (data === "*") {
+              str = "<i>unknown</i>";
+            } else {
+              str =
+                typeof data === "string"
+                  ? data.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
+                  : data;
+            }
+
+            return str;
+          },
         },
       ],
       paging: true,

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -279,10 +279,7 @@ $(function () {
             if (data === "*") {
               str = "<i>unknown</i>";
             } else {
-              str =
-                typeof data === "string"
-                  ? utils.escapeHtml(data)
-                  : data;
+              str = typeof data === "string" ? utils.escapeHtml(data) : data;
             }
 
             return str;

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -281,7 +281,7 @@ $(function () {
             } else {
               str =
                 typeof data === "string"
-                  ? data.replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;")
+                  ? utils.escapeHtml(data)
                   : data;
             }
 

--- a/settings.php
+++ b/settings.php
@@ -595,9 +595,6 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                         }
 
                                         $host = htmlentities($line[3]);
-                                        if ($host == "*") {
-                                            $host = "<i>unknown</i>";
-                                        }
 
                                         $clid = $line[4];
                                         if ($clid == "*") {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix #1513 

**How does this PR accomplish the above?:**

The datatable formarter `render: $.fn.dataTable.render.text()` escapes every HTML tag inside the cell, transforming `<i>unknown</i>` into `&lt;i&gt;unknown&lt;/i&gt;`.

**What documentation changes (if any) are needed to support this PR?:**

none