### PR TITLE
Add the ability to specity the number of recentlyBlocked items returned in the web API

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -317,20 +317,12 @@ else
 		$data = array_merge($data, $result);
 	}
 
-    if(isset($_GET["recentBlocked"]) && $auth)
-    {
-        if(is_numeric($_GET['recentBlocked']))
-        {
-            sendRequestFTL("recentBlocked (".$_GET['recentBlocked'].")");
-            $data = getResponseFTL();
-        }
-        else
-        {
-            sendRequestFTL("recentBlocked");
-            die(utf8_encode(getResponseFTL()[0]));
-            unset($data);
-        }
-    }
+	if(isset($_GET["recentBlocked"]) && $auth)
+	{
+		sendRequestFTL("recentBlocked");
+		die(utf8_encode(getResponseFTL()[0]));
+		unset($data);
+	}
 
 	if (isset($_GET['getForwardDestinationNames']) && $auth)
 	{

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -317,12 +317,20 @@ else
 		$data = array_merge($data, $result);
 	}
 
-	if(isset($_GET["recentBlocked"]) && $auth)
-	{
-		sendRequestFTL("recentBlocked");
-		die(utf8_encode(getResponseFTL()[0]));
-		unset($data);
-	}
+    if(isset($_GET["recentBlocked"]) && $auth)
+    {
+        if(is_numeric($_GET['recentBlocked']))
+        {
+            sendRequestFTL("recentBlocked (".$_GET['recentBlocked'].")");
+            $data = getResponseFTL();
+        }
+        else
+        {
+            sendRequestFTL("recentBlocked");
+            die(utf8_encode(getResponseFTL()[0]));
+            unset($data);
+        }
+    }
 
 	if (isset($_GET['getForwardDestinationNames']) && $auth)
 	{


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [X ] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [ X] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ X] I have tested my proposed changes.
- [ X] I am willing to help maintain this change if there are issues with it later.
- [ X] I give this submission freely and claim no ownership.
- [ X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Added the ability to specify the number of recentlyBlocked items to return.

**How does this PR accomplish the above?:**

Added a simple if/then, similar to the other options that have the ability to specify an int

**What documentation changes (if any) are needed to support this PR?:**

I couldn't find much documentation on the web API so I don't think any documentation needs to be updated.

