### PR TITLE
Limit MAXLOGAGE to 24h, just like FTL  

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,26 +1,24 @@
-<?php /*
+<?php
+/*
 *    Pi-hole: A black hole for Internet advertisements
 *    (c) 2017 Pi-hole, LLC (https://pi-hole.net)
 *    Network-wide ad blocking via your own hardware.
 *
 *    This file is copyright under the latest version of the EUPL.
 *    Please see LICENSE file for your rights under this license. */
-    $indexpage = true;
-    require "scripts/pi-hole/php/header.php";
-    require_once "scripts/pi-hole/php/gravity.php";
+$indexpage = true;
+require "scripts/pi-hole/php/header.php";
+require_once "scripts/pi-hole/php/gravity.php";
 
-    function getinterval()
-    {
-        global $piholeFTLConf;
-        if(isset($piholeFTLConf["MAXLOGAGE"]))
-        {
-             return round(floatval($piholeFTLConf["MAXLOGAGE"]), 1);
-        }
-        else
-        {
-             return "24";
-        }
+function getinterval()
+{
+    global $piholeFTLConf;
+    if (isset($piholeFTLConf["MAXLOGAGE"])) {
+        return min(round(floatval($piholeFTLConf["MAXLOGAGE"]), 1), 24);
+    } else {
+        return "24";
     }
+}
 ?>
 <!-- Sourceing CSS colors from stylesheet to be used in JS code -->
 <span class="queries-permitted"></span>

--- a/index.php
+++ b/index.php
@@ -1,6 +1,5 @@
 <?php
-/*
-*    Pi-hole: A black hole for Internet advertisements
+/*   Pi-hole: A black hole for Internet advertisements
 *    (c) 2017 Pi-hole, LLC (https://pi-hole.net)
 *    Network-wide ad blocking via your own hardware.
 *


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix #1825.

If `MAXLOGAGE` is set inside _pihole-FTL.conf_ to anything greater than 24, it is already limited by FTL (and the graphic is limited to 24 hours), but the graphic title shown on the dashboard is using the wrong (not limited) value.

**How does this PR accomplish the above?:**

Limiting the interval for the dashboard graphic title to a maximum of 24 hours, since FTL already limits this value.

**What documentation changes (if any) are needed to support this PR?:**

I think this was already changed in the docs.