### PR TITLE
Fixing the escaping for settings datatable

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -238,8 +238,22 @@ $(function () {
       columnDefs: [
         { bSortable: false, orderable: false, targets: -1 },
         {
-          targets: [0, 1, 2],
+          targets: [0, 1],
           render: $.fn.dataTable.render.text(),
+        },
+        {
+          targets: 2,
+          render: function (data) {
+            // Show "unknown", when host is "*"
+            var str;
+            if (data === "*") {
+              str = "<i>unknown</i>";
+            } else {
+              str = typeof data === "string" ? utils.escapeHtml(data) : data;
+            }
+
+            return str;
+          },
         },
       ],
       paging: true,
@@ -268,22 +282,8 @@ $(function () {
       columnDefs: [
         { bSortable: false, orderable: false, targets: -1 },
         {
-          targets: [0, 1],
+          targets: [0, 1, 2],
           render: $.fn.dataTable.render.text(),
-        },
-        {
-          targets: 2,
-          render: function (data) {
-            // Show "unknown", when host is "*"
-            var str;
-            if (data === "*") {
-              str = "<i>unknown</i>";
-            } else {
-              str = typeof data === "string" ? utils.escapeHtml(data) : data;
-            }
-
-            return str;
-          },
         },
       ],
       paging: true,


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixes PR #2100.
This time, the code fixes the right spot.

**How does this PR accomplish the above?:**

Please refer to #2100 description.

**What documentation changes (if any) are needed to support this PR?:**

none