### PR TITLE
Multiple MACs alllowed for static DHCP leases

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
         days-before-stale: 30
         days-before-close: 5
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Please comment or update this issue or it will be closed in 5 days.'
-        stale-issue-label: 'Submitter Attention Required'
+        stale-issue-label: 'stale'
         exempt-issue-labels: 'internal, Fixed In Next Release, Bug'
         exempt-all-issue-assignees: true
         operations-per-run: 300

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -71,7 +71,9 @@ function validCIDRIP($address){
 function validMAC($mac_addr)
 {
   // Accepted input format: 00:01:02:1A:5F:FF (characters may be lower case)
-  return !filter_var($mac_addr, FILTER_VALIDATE_MAC) === false;
+  $parts = explode(",", $mac_addr);
+  foreach ($parts as &$value)
+	return !filter_var($value, FILTER_VALIDATE_MAC) === false;
 }
 
 function validEmail($email)

--- a/settings.php
+++ b/settings.php
@@ -698,11 +698,11 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                                         </tr>
                                                     </tfoot>
                                                 </table>
-                                                <p>Specifying the MAC address is mandatory and only one entry per MAC
-                                                   address is allowed. If the IP address is omitted and a host name is
-                                                   given, the IP address will still be generated dynamically and the
-                                                   specified host name will be used. If the host name is omitted, only
-                                                   a static lease will be added.</p>
+						<p>Specifying the MAC address(es) is mandatory and only one entry per
+						   (set of) MAC addresses is allowed. If the IP address is omitted and
+						   a host name is given, the IP address will still be generated
+						   dynamically and the specified host name will be used. If the host
+						   name is omitted, only a static lease will be added.</p>
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
dnsmasq allows for multiple hardware addresses per lease, which is handy for cases that a laptop gets the same IP for wired
and wireless connections, as well as when there are multiple SSIDs that a device can connect to, using randomized MAC address - such as 2.4GHz and 5GHz wireless networks.
The Pi-hole web interface doesn't allow for this to happen, and this is addressed.

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [ ] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ ] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

This patch allows entries with multiple mac addresses to be handled.
The patch also resolves the issue: https://github.com/pi-hole/AdminLTE/issues/1543

**How does this PR accomplish the above?:**

`{A detailed description (such as a changelog) and screenshots (if necessary) of the implemented fix}`

**What documentation changes (if any) are needed to support this PR?:**

`{A detailed list of any necessary changes}`

