### PR TITLE
Include timezone info in time/date FTL has been started

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -20,7 +20,7 @@ if(isset($last_error) && ($last_error["type"] === E_WARNING || $last_error["type
 }
 
 # Timezone is set in docker via ENV otherwise get it from commandline
-$timezone=getenv("TZ");
+$timezone=htmlspecialchars(getenv("TZ"));
 if (empty($timezone)) {
 	$timezone=shell_exec("date +'%Z'");
 }

--- a/settings.php
+++ b/settings.php
@@ -240,7 +240,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                                 }
 
                                                 $FTLversion = exec("/usr/bin/pihole-FTL version");
-																								$FTLstart = exec("date -r /proc/" . $FTLpid . " '+%a %d %b %Y %R %Z'");
+                                                $FTLstart = exec("date -r /proc/" . $FTLpid . " '+%a %d %b %Y %R %Z'");
                                             ?>
                                             <table class="table table-striped table-bordered nowrap">
                                                 <tbody>

--- a/settings.php
+++ b/settings.php
@@ -240,6 +240,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                                 }
 
                                                 $FTLversion = exec("/usr/bin/pihole-FTL version");
+																								$FTLstart = exec("date -r /proc/" . $FTLpid . " '+%a %d %b %Y %R %Z'");
                                             ?>
                                             <table class="table table-striped table-bordered nowrap">
                                                 <tbody>
@@ -253,7 +254,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">Time FTL started:</th>
-                                                        <td><?php print_r(get_FTL_data("lstart")); ?></td>
+                                                        <td><?php echo $FTLstart; ?></td>
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">User / Group:</th>

--- a/settings.php
+++ b/settings.php
@@ -19,6 +19,12 @@ if(isset($last_error) && ($last_error["type"] === E_WARNING || $last_error["type
 	$error .= "There was a problem applying your settings.<br>Debugging information:<br>PHP error (".htmlspecialchars($last_error["type"])."): ".htmlspecialchars($last_error["message"])." in ".htmlspecialchars($last_error["file"]).":".htmlspecialchars($last_error["line"]);
 }
 
+# Timezone is set in docker via ENV otherwise get it from commandline
+$timezone=getenv("TZ");
+if (empty($timezone)) {
+	$timezone=shell_exec("date +'%Z'");
+}
+
 ?>
 <style>
 	.tooltip-inner {
@@ -240,7 +246,6 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                                 }
 
                                                 $FTLversion = exec("/usr/bin/pihole-FTL version");
-                                                $FTLstart = exec("date -r /proc/" . $FTLpid . " '+%a %d %b %Y %R %Z'");
                                             ?>
                                             <table class="table table-striped table-bordered nowrap">
                                                 <tbody>
@@ -254,7 +259,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">Time FTL started:</th>
-                                                        <td><?php echo $FTLstart; ?></td>
+                                                        <td><?php print_r(get_FTL_data("lstart")); echo " ".$timezone; ?></td>
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">User / Group:</th>


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Include the local timezone in the "FTL started" date/time output
![Bildschirmfoto zu 2022-02-05 17-10-26](https://user-images.githubusercontent.com/26622301/152649451-a04cd314-2a1a-4139-b838-cc2e91c100f5.png)


**How does this PR accomplish the above?:**

Included a check for the ENV "TZ" which can be used by docker installations. If not present, I use the time zone output of date.
