### PR TITLE
Prevent misleading warning being printed to the lighttpd error log when importing from teleporter backup

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -84,11 +84,15 @@ function archive_restore_table($file, $table, $flush=false)
 	if(is_null($contents))
 		return 0;
 
-	// Flush table if requested, only flush each table once
+	// Flush table if requested. Only flush each table once, and only if it exists
 	if($flush && !in_array($table, $flushed_tables))
 	{
-		$db->exec("DELETE FROM \"".$table."\"");
-		array_push($flushed_tables, $table);
+		$tableExists = $db->querySingle("SELECT name FROM sqlite_master WHERE type='table' AND name='".$table."';");
+		if ($tableExists)
+		{			
+			$db->exec("DELETE FROM \"".$table."\"");
+			array_push($flushed_tables, $table);
+		}
 	}
 
 	// Prepare fields depending on the table we restore to


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes, and have included unit tests where possible.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Fixes #2117 by adding a check for table name before attempting to flush it