### PR TITLE
footer.php: Improve Pi-Hole update instruction for Docker image

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -103,7 +103,11 @@
                     </li>
                 </ul>
                 <?php if($core_update || $web_update || $FTL_update) { ?>
+                <?php if($dockerTag) { ?>
+                    <p>To install updates, <a href="https://github.com/pi-hole/docker-pi-hole#upgrading--reconfiguring" rel="noopener" target="_blank">replace this old container with a fresh upgraded image</a>.</p>
+                <?php } else { ?>
                     <p>To install updates, run <code><a href="https://docs.pi-hole.net/main/update/" rel="noopener" target="_blank">pihole -up</a></code>.</p>
+                <?php } ?>
                 <?php } ?>
                 <?php } ?>
             </div>


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'devel' branch!}`

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

The old prompt message inside Docker is not a useful one.

Running `pihole -up` in the Docker image release is not allowed, and will receive this prompt msg: `Function not supported in Docker images`, should display a different prompt message for Docker image release.

**How does this PR accomplish the above?:**

Use the same mechanism in `footer.php` to determine if it's a Docker release, and display the prompt about how to use the Docker way to update Pi-Hole, instead of using `pihole -up`.

**What documentation changes (if any) are needed to support this PR?:**

Doesn't look like it need documentation ;)

Before:

![image](https://user-images.githubusercontent.com/3691490/153744395-724f35f9-8d8f-4f3c-8606-108d35b62e8f.png)

After:

![image](https://user-images.githubusercontent.com/3691490/153744382-db0edc73-f86c-4aa6-8966-4aac562404f4.png)

