### PR TITLE
Fixing double `json_encode` output

### DIFF
--- a/api.php
+++ b/api.php
@@ -154,17 +154,20 @@ elseif(isset($_GET['customdns']) && $auth)
 
 	switch ($_GET["action"]) {
 		case 'get':
-			$_POST['action'] = 'get';
+			$data = echoCustomDNSEntries();
 			break;
-		case 'add':
-			$_POST['action'] = 'add';
-			break;
-		case 'delete':
-			$_POST['action'] = 'delete';
-			break;
-		}
 
-	require("scripts/pi-hole/php/customdns.php");
+		case 'add':
+			$data = addCustomDNSEntry();
+			break;
+
+		case 'delete':
+			$data = deleteCustomDNSEntry();
+			break;
+
+		default:
+			die("Wrong action");
+	}
 }
 elseif(isset($_GET['customcname']) && $auth)
 {
@@ -179,17 +182,20 @@ elseif(isset($_GET['customcname']) && $auth)
 
 	switch ($_GET["action"]) {
 		case 'get':
-			$_POST['action'] = 'get';
+			$data = echoCustomCNAMEEntries();
 			break;
-		case 'add':
-			$_POST['action'] = 'add';
-			break;
-		case 'delete':
-			$_POST['action'] = 'delete';
-			break;
-		}
 
-	require("scripts/pi-hole/php/customcname.php");
+		case 'add':
+			$data = addCustomCNAMEEntry();
+			break;
+
+		case 'delete':
+			$data = deleteCustomCNAMEEntry();
+			break;
+
+		default:
+			die("Wrong action");
+	}
 }
 
 // Other API functions


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

fix #2123, caused by 2 `echo json_encode()` outputs. 

**How does this PR accomplish the above?:**

Changing how the API receives and formats the output.

**What documentation changes (if any) are needed to support this PR?:**

none