### PR TITLE
add link to swap between blocked and all client queries

### DIFF
--- a/queries.php
+++ b/queries.php
@@ -46,7 +46,19 @@ if(isset($_GET["all"]))
 }
 else if(isset($_GET["client"]))
 {
-	$showing .= " queries for client ".htmlentities($_GET["client"]);
+	// Add switch between showing all queries and blocked only
+	if (isset($_GET["type"]) && $_GET["type"] === "blocked")
+	{
+		// Show blocked queries for this client + link to all
+		$showing .= " blocked queries for client ".htmlentities($_GET["client"]);
+		$showing .= ", <a href=\"?client=".htmlentities($_GET["client"])."\">show all</a>";
+	}
+	else
+	{
+		// Show All queries for this client + link to show only blocked
+		$showing .= " all queries for client ".htmlentities($_GET["client"]);
+		$showing .= ", <a href=\"?client=".htmlentities($_GET["client"])."&type=blocked\">show blocked only</a>";
+	}
 }
 else if(isset($_GET["forwarddest"]))
 {


### PR DESCRIPTION
Signed-off-by: stuXORstu <stuxorstu@gmail.com>

**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

`Inserts a quick handy link to swap between blocked and all queries for clients.  Seemed like a handy thing to have since when troubleshooting potential blocks I end up first looking at blocked queries, and then if I can't spot anything want to look at all queries to confirm if recent activity is not being blocked - so having a quick link to jump between those two states seemed useful to me, particularly when using a mobile device and not wanting to mess about with multiple tabs`

**How does this PR accomplish the above?:**

`Modification of the existing code that shows queries types and provides context to the user on the queries.php page`

**What documentation changes (if any) are needed to support this PR?:**

`None - it is fairly straightforward (hopefully!!)`
