### PR TITLE
Better interval computation for Long-term data -> Graphics page

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -319,7 +319,7 @@ if (isset($_GET['getGraphData']) && $auth)
 	if(isset($_GET["interval"]))
 	{
 		$q = intval($_GET["interval"]);
-		if($q > 10)
+		if($q >= 10)
 			$interval = $q;
 	}
 

--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -8,9 +8,9 @@
 /* global utils:false, Chart:false, moment:false */
 
 var start__ = moment().subtract(7, "days");
-var from = moment(start__).utc().valueOf() / 1000;
+var from = Math.round(moment(start__).utc().valueOf() / 1000);
 var end__ = moment();
-var until = moment(end__).utc().valueOf() / 1000;
+var until = Math.round(moment(end__).utc().valueOf() / 1000);
 var interval = 0;
 
 var dateformat = "MMMM Do YYYY, HH:mm";
@@ -51,8 +51,8 @@ $(function () {
       autoUpdateInput: false,
     },
     function (startt, endt) {
-      from = moment(startt).utc().valueOf() / 1000;
-      until = moment(endt).utc().valueOf() / 1000;
+      from = Math.round(moment(startt).utc().valueOf() / 1000);
+      until = Math.round(moment(endt).utc().valueOf() / 1000);
     }
   );
 });
@@ -63,32 +63,80 @@ function compareNumbers(a, b) {
   return a - b;
 }
 
+function computeInterval(from, until) {
+  // Compute interval to obtain about 200 values
+  var num = 200;
+  // humanly understandable intervals (in seconds)
+  var intervals = [
+    10,
+    20,
+    30,
+    60,
+    120,
+    180,
+    300,
+    600,
+    900,
+    1200,
+    1800,
+    3600,
+    3600 * 2,
+    3600 * 3,
+    3600 * 4,
+    3600 * 6,
+    3600 * 8,
+    3600 * 12,
+    3600 * 24,
+    3600 * 24 * 7,
+    3600 * 24 * 30,
+  ];
+
+  var duration = until - from;
+  if (duration / (num * intervals[0]) < 1) {
+    return intervals[0];
+  }
+
+  var preverr = Number.MAX_VALUE,
+    err;
+  for (var i = 0; i < intervals.length; i++) {
+    err = Math.abs(1 - duration / (num * intervals[i]));
+    // pick the interval with least deviation
+    // from selected duration
+    if (preverr < err) {
+      return intervals[i - 1];
+    }
+
+    preverr = err;
+  }
+
+  return intervals[intervals.length - 1];
+}
+
 function updateQueriesOverTime() {
   var timeoutWarning = $("#timeoutWarning");
 
   $("#queries-over-time .overlay").show();
   timeoutWarning.show();
 
-  // Compute interval to obtain about 200 values
-  var num = 200;
-  interval = (until - from) / num;
+  interval = computeInterval(from, until);
   // Default displaying axis scaling
   timeLineChart.options.scales.xAxes[0].time.unit = "hour";
 
+  var duration = until - from;
   // Xaxis scaling based on selected daterange
-  if (num * interval > 4 * 365 * 24 * 60 * 60) {
+  if (duration > 4 * 365 * 24 * 60 * 60) {
     // If the requested data is more than 4 years, set ticks interval to year
     timeLineChart.options.scales.xAxes[0].time.unit = "year";
-  } else if (num * interval >= 366 * 24 * 60 * 60) {
+  } else if (duration >= 366 * 24 * 60 * 60) {
     // If the requested data is more than 1 year, set ticks interval to quarter
     timeLineChart.options.scales.xAxes[0].time.unit = "quarter";
-  } else if (num * interval >= 92 * 24 * 60 * 60) {
+  } else if (duration >= 92 * 24 * 60 * 60) {
     // If the requested data is more than 3 months, set ticks interval to months
     timeLineChart.options.scales.xAxes[0].time.unit = "month";
-  } else if (num * interval >= 31 * 24 * 60 * 60) {
+  } else if (duration >= 31 * 24 * 60 * 60) {
     // If the requested data is 1 month or more, set ticks interval to weeks
     timeLineChart.options.scales.xAxes[0].time.unit = "week";
-  } else if (num * interval > 3 * 24 * 60 * 60) {
+  } else if (duration > 3 * 24 * 60 * 60) {
     // If the requested data is more than 3 days (72 hours), set ticks interval to days
     timeLineChart.options.scales.xAxes[0].time.unit = "day";
   }


### PR DESCRIPTION
Signed-off-by: rubpa <rubpa@users.noreply.github.com>

**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

The Long-term data -> Graphics page showed graphs with very "unrounded" intervals as in the screenshots below. 

![image](https://user-images.githubusercontent.com/3681180/154848025-99dd8f3f-d5af-4898-b16e-5df2c7bc8d71.png)
API call for above was: admin/api_db.php?getGraphData&from=1645209000&until=**1645276215.962**&interval=**336.07980999946597**

![image](https://user-images.githubusercontent.com/3681180/154848059-e1df2ec7-6183-442b-a46b-c46f5e923e0c.png)
API call for above was: admin/api_db.php?getGraphData&from=1644671415.963&until=**1645276215.963**&interval=**3024**

**How does this PR accomplish the above?:**

This PR tries to still keep approx 200 intervals but by choosing more "rounded" values like 10 mins, 20 mins, 30 mins, 1 hr, etc. based on the selected duration.

**What documentation changes (if any) are needed to support this PR?:**

Documentation changes are not required.
