### PR TITLE
Update ecmaVersion to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "plugin:compat/recommended"
     ],
     "parserOptions": {
-      "ecmaVersion": 5,
+      "ecmaVersion": "latest",
       "sourceType": "script"
     },
     "prettier": true,


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

We use `xo` as linter in our workflows. It uses `eslint` internally. We did not change the default of the ecmaVersion to use, so it defaults to version `5`. This was released 2009 (https://www.wikiwand.com/en/ECMAScript) and is missing a lot of modern js stuff. Therefore we have seen errors like `Error - Parsing error: The keyword 'const' is reserved`

Setting the ecmaVersion to `latest` guarantees we are supporting up-to-date syntax  https://eslint.org/docs/user-guide/configuring/language-options#specifying-parser-options
