### PR TITLE
Fix list add for already forwarded queries

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -450,7 +450,7 @@ $(function () {
 
   $("#all-queries tbody").on("click", "button", function () {
     var data = tableApi.row($(this).parents("tr")).data();
-    if (data[4] === "2" || data[4] === "3") {
+    if (data[4] === "2" || data[4] === "3" || data[4] === "14") {
       utils.addFromQueryLog(data[2], "black");
     } else {
       utils.addFromQueryLog(data[2], "white");


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

PR https://github.com/pi-hole/AdminLTE/pull/1720 added a new reply type `14 = "already forwarded"`. The Query log action column got "blacklist domain" icon, however, it was forgotten to add this case to the actual action. It therefore it defaulted to whitelist. This PR adds the case to the blacklist action

Fixes https://github.com/pi-hole/AdminLTE/issues/1755

(P.S. The long-term database is not affected, as the logic is revered: everything is blacklisted except cases explicite defined as whitelist types)

https://github.com/pi-hole/AdminLTE/blob/b57ff6aeec72e99f0226e339fcaf55b3567ee6ae/scripts/pi-hole/js/db_queries.js#L371-L376
