### PR TITLE
Fix PHP "Headers already sent" warning.

### DIFF
--- a/scripts/pi-hole/php/message.php
+++ b/scripts/pi-hole/php/message.php
@@ -1,4 +1,3 @@
-
 <?php
 /* Pi-hole: A black hole for Internet advertisements
 *  (c) 2021 Pi-hole, LLC (https://pi-hole.net)
@@ -8,6 +7,8 @@
 *  Please see LICENSE file for your rights under this license. */
 
 require_once('auth.php');
+require_once('func.php');
+require_once('database.php');
 
 // Authentication checks
 if (!isset($api)) {
@@ -21,8 +22,6 @@ if (!isset($api)) {
 
 $reload = false;
 
-require_once('func.php');
-require_once('database.php');
 $QueriesDB = getQueriesDBFilename();
 $db = SQLite3_connect($QueriesDB, SQLITE3_OPEN_READWRITE);
 


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix PHP warnings received inside `auth.php`:

```log
2022-03-21 10:58:57: (mod_fastcgi.c.421) FastCGI-stderr: PHP Warning:  Cannot modify header information - headers already sent by (output started at /var/www/html/admin/scripts/pi-hole/php/message.php:1) in /var/www/html/admin/scripts/pi-hole/php/auth.php on line 93
2022-03-21 10:58:57: (mod_fastcgi.c.421) FastCGI-stderr: PHP Warning:  ini_set(): Headers already sent. You cannot change the session module's ini settings at this time in /var/www/html/admin/scripts/pi-hole/php/auth.php on line 107
2022-03-21 10:58:57: (mod_fastcgi.c.421) FastCGI-stderr: PHP Warning:  ini_set(): Headers already sent. You cannot change the session module's ini settings at this time in /var/www/html/admin/scripts/pi-hole/php/auth.php on line 109
2022-03-21 10:58:57: (mod_fastcgi.c.421) FastCGI-stderr: PHP Warning:  session_start(): Cannot start session when headers already sent in /var/www/html/admin/scripts/pi-hole/php/auth.php on line 110
```

**How does this PR accomplish the above?:**

Removing the wrong output before `require "auth.php"` statement.

**What documentation changes (if any) are needed to support this PR?:**

None