### PR TITLE
Set terminal type inside PHP

### DIFF
--- a/scripts/pi-hole/php/debug.php
+++ b/scripts/pi-hole/php/debug.php
@@ -50,9 +50,9 @@ function echoEvent($datatext) {
 }
 
 if (isset($_GET["upload"])) {
-    $proc = popen("sudo pihole -d -a -w", "r");
+    $proc = popen("export TERM=dumb && sudo pihole -d -a -w", "r");
 } else {
-    $proc = popen("sudo pihole -d -w", "r");
+    $proc = popen("export TERM=dumb && sudo pihole -d -w", "r");
 }
 
 while (!feof($proc)) {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix https://github.com/pi-hole/docker-pi-hole/issues/1015

When generating a Debug log from web interface, a message error `'unknown': unknown terminal type` appears in the docker log.
This happens because environment var `$TERM` has a value of `unknown` and the terminal type isn't recognized.

**How does this PR accomplish the above?:**

Setting `TERM=dumb` fixes the output.

**What documentation changes (if any) are needed to support this PR?:**
none