### PR TITLE
Convert IDNs to punycode before searching the lists

### DIFF
--- a/scripts/pi-hole/php/queryads.php
+++ b/scripts/pi-hole/php/queryads.php
@@ -26,10 +26,10 @@ function echoEvent($datatext) {
 if(isset($_GET["domain"]))
 {
     // Is this a valid domain?
-    $url = $_GET["domain"];
+    $url = idn_to_ascii($_GET["domain"]);
     if(!validDomain($url))
     {
-        echoEvent("Invalid domain!");
+        echoEvent("$url is an invalid domain!");
         die();
     }
 }


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Fixes https://github.com/pi-hole/AdminLTE/issues/1462
When using the web interface for searching the adlists for a particular domain, this should be converted to punycode if it's an IDN. 
So far, we do not convert the domain but report invalid. However, using `pihole -q` we to the conversion

https://github.com/pi-hole/pi-hole/blob/326cd6a1f845b3f2654e0bde9591d08d0f87e010/advanced/Scripts/query.sh#L92

This PR brings the web interface in par with cli.
The domain validation check is preserved.

![Bildschirmfoto zu 2022-04-04 13-37-47](https://user-images.githubusercontent.com/26622301/161536941-f3a65fc5-ee4c-4d55-9b9a-d5321c6ae3f0.png)
![Bildschirmfoto zu 2022-04-04 13-37-56](https://user-images.githubusercontent.com/26622301/161536943-ab3e1269-974d-4328-af7b-46155b1d635b.png)

