### PR TITLE
Improve loop for getAllQueries from FTL's memory

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -310,7 +310,6 @@ if (isset($_GET['getAllQueries']) && $auth) {
       echo '{"data":[';
       $first = true;
 
-      #foreach ($return as $line)
       foreach($return as $line) {
 
         // Insert a comma before the next record (except on the first one)

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -303,9 +303,13 @@ if (isset($_GET['getAllQueries']) && $auth) {
         $return = callFTLAPI("getallqueries");
     }
 
+<<<<<<< HEAD
     if (array_key_exists("FTLnotrunning", $return)) {
       $data = array("FTLnotrunning" => true);
     } else {
+=======
+    if (!in_array("FTLnotrunning", $return )) {
+>>>>>>> Add proper guarding
       // Start the JSON string
       echo '{"data":[';
       $first = true;

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -303,13 +303,9 @@ if (isset($_GET['getAllQueries']) && $auth) {
         $return = callFTLAPI("getallqueries");
     }
 
-<<<<<<< HEAD
     if (array_key_exists("FTLnotrunning", $return)) {
       $data = array("FTLnotrunning" => true);
     } else {
-=======
-    if (!in_array("FTLnotrunning", $return )) {
->>>>>>> Add proper guarding
       // Start the JSON string
       echo '{"data":[';
       $first = true;

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -332,9 +332,9 @@ if (isset($_GET['getAllQueries']) && $auth) {
       }
       // Finish the JSON string
       echo ']}';
+      // exit at the end
+      exit();
     }
-    // exit at the end
-    exit();
 }
 
 if (isset($_GET["recentBlocked"]) && $auth) {

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -306,19 +306,35 @@ if (isset($_GET['getAllQueries']) && $auth) {
     if (array_key_exists("FTLnotrunning", $return)) {
       $data = array("FTLnotrunning" => true);
     } else {
-      $allQueries = array();
-      foreach ($return as $line) {
-          $tmp = str_getcsv($line," ");
-          // UTF-8 encode domain
-          $tmp[2] = utf8_encode(str_replace("~"," ",$tmp[2]));
-          // UTF-8 encode client host name
-          $tmp[3] = utf8_encode($tmp[3]);
-          array_push($allQueries,$tmp);
-      }
+      // Start the JSON string
+      echo '{"data":[';
+      $first = true;
 
-      $result = array('data' => $allQueries);
-      $data = array_merge($data, $result);
-  }
+      #foreach ($return as $line)
+      foreach($return as $line) {
+
+        // Insert a comma before the next record (except on the first one)
+       if (!$first) {
+              echo ",";
+       } else {
+              $first = false;
+       }
+
+        $row = str_getcsv($line," ");
+        // UTF-8 encode domain
+        $domain = utf8_encode(str_replace("~"," ",$row[2]));
+        // UTF-8 encode client host name
+        $client = utf8_encode($row[3]);
+
+        // Insert into array and output it in JSON format
+        // array:         time      type     domain  client   status  dnssecStatus    reply    response_time   CNAMEDomain regexID  upstream destination    EDE
+        echo json_encode([$row[0], $row[1], $domain, $client, $row[4],  $row[5],     $row[6],     $row[7],      $row[8],   $row[9],     $row[10],         $row[11]]);
+      }
+      // Finish the JSON string
+      echo ']}';
+    }
+    // exit at the end
+    exit();
 }
 
 if (isset($_GET["recentBlocked"]) && $auth) {


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
This PR reduces the memory needed by `api.php?getAllQueries` to process every requested record.
It's basically a copy of https://github.com/pi-hole/AdminLTE/pull/2114 but for the current in-memory data served by FTL.

Usually we have seen the out-of-memory error when requesting large amounts of data from the long-term database, but currently there is an issue on discourse where the in-memory data is also too huge to process `getAllQueries`

https://discourse.pi-hole.net/t/all-queries-are-not-working/54711


**How does this PR accomplish the above?:**
The old code used to generate and return the request adds all records into a single array. This array grows for each record (and there are many many records).
Only at the end (and if memory holds up), it transforms the entire array into JSON and sends all at once as a string.

The new code outputs each record as a string immediately.
This way, there is no array and the memory for each iteration is always the same.
The web server is responsible for sending the "text stream", nothing else needs to change.
