### PR TITLE
Guard socket and FTL response

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -20,7 +20,9 @@ if (isset($_GET['version'])) {
 
 if (isset($_GET['status'])) {
     $return = callFTLAPI("stats");
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       if (in_array("status enabled", $return)) {
           $data = array_merge($data, array("status" => "enabled"));
       } else {
@@ -33,7 +35,9 @@ if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET)) {
     require_once("scripts/pi-hole/php/gravity.php");
 
     $return = callFTLAPI("stats");
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $stats = [];
       foreach ($return as $line) {
           $tmp = explode(" ",$line);
@@ -61,7 +65,9 @@ if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET)) {
 
 if (isset($_GET["getMaxlogage"]) && $auth) {
     $return = callFTLAPI("stats");
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       // Convert seconds to hours and rounds to one decimal place.
       $ret = round(intval($return[0]) / 3600, 1);
       // Return 24h if value is 0, empty, null or non numeric.
@@ -73,7 +79,9 @@ if (isset($_GET["getMaxlogage"]) && $auth) {
 
 if (isset($_GET['overTimeData10mins'])) {
     $return = callFTLAPI("overTime");
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $domains_over_time = array();
       $ads_over_time = array();
       foreach ($return as $line) {
@@ -99,7 +107,10 @@ if (isset($_GET['topItems']) && $auth) {
     } else {
         $return = callFTLAPI("top-domains");
     }
-    if (!in_array("FTLnotrunning", $return )) {
+
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $top_queries = array();
       foreach ($return as $line) {
           $tmp = explode(" ",$line);
@@ -118,7 +129,10 @@ if (isset($_GET['topItems']) && $auth) {
     } else {
         $return = callFTLAPI("top-ads");
     }
-    if (!in_array("FTLnotrunning", $return )) {
+
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $top_ads = array();
       foreach ($return as $line) {
           $tmp = explode(" ",$line);
@@ -152,7 +166,9 @@ if ((isset($_GET['topClients']) || isset($_GET['getQuerySources'])) && $auth) {
     } else {
         $return = callFTLAPI("top-clients");
     }
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $top_clients = array();
       foreach ($return as $line) {
           $tmp = explode(" ",$line);
@@ -181,7 +197,9 @@ if (isset($_GET['topClientsBlocked']) && $auth) {
     } else {
         $return = callFTLAPI("top-clients blocked");
     }
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $top_clients = array();
       foreach ($return as $line) {
           $tmp = explode(" ",$line);
@@ -205,7 +223,9 @@ if (isset($_GET['getForwardDestinations']) && $auth) {
     } else {
         $return = callFTLAPI("forward-dest");
     }
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $forward_dest = array();
       foreach ($return as $line) {
           $tmp = explode(" ",$line);
@@ -225,7 +245,9 @@ if (isset($_GET['getForwardDestinations']) && $auth) {
 
 if (isset($_GET['getQueryTypes']) && $auth) {
     $return = callFTLAPI("querytypes");
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $querytypes = array();
       foreach ($return as $ret) {
           $tmp = explode(": ",$ret);
@@ -240,7 +262,9 @@ if (isset($_GET['getQueryTypes']) && $auth) {
 
 if (isset($_GET['getCacheInfo']) && $auth) {
     $return = callFTLAPI("cacheinfo");
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $cacheinfo = array();
       foreach ($return as $ret) {
           $tmp = explode(": ",$ret);
@@ -278,7 +302,10 @@ if (isset($_GET['getAllQueries']) && $auth) {
         // Get all queries
         $return = callFTLAPI("getallqueries");
     }
-    if (!in_array("FTLnotrunning", $return )) {
+
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $allQueries = array();
       foreach ($return as $line) {
           $tmp = str_getcsv($line," ");
@@ -301,7 +328,10 @@ if (isset($_GET["recentBlocked"]) && $auth) {
 
 if (isset($_GET['getForwardDestinationNames']) && $auth) {
     $return = callFTLAPI("forward-names");
-    if (!in_array("FTLnotrunning", $return )) {
+
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $forward_dest = array();
       foreach ($return as $line) {
           $tmp = explode(" ",$line);
@@ -321,8 +351,10 @@ if (isset($_GET['getForwardDestinationNames']) && $auth) {
 
 if (isset($_GET['overTimeDataQueryTypes']) && $auth) {
     $return = callFTLAPI("QueryTypesoverTime");
-    $over_time = array();
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
+      $over_time = array();
       foreach ($return as $line) {
           $tmp = explode(" ",$line);
           for ($i=0; $i < count($tmp)-1; $i++) {
@@ -336,7 +368,9 @@ if (isset($_GET['overTimeDataQueryTypes']) && $auth) {
 
 if (isset($_GET['getClientNames']) && $auth) {
     $return = callFTLAPI("client-names");
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $client_names = array();
       foreach ($return as $line) {
           $tmp = explode(" ", $line);
@@ -354,9 +388,10 @@ if (isset($_GET['getClientNames']) && $auth) {
 if (isset($_GET['overTimeDataClients']) && $auth) {
     $return = callFTLAPI("ClientsoverTime");
 
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $over_time = array();
-
       foreach ($return as $line) {
           $tmp = explode(" ",$line);
           for ($i=0; $i < count($tmp)-1; $i++) {
@@ -370,14 +405,18 @@ if (isset($_GET['overTimeDataClients']) && $auth) {
 
 if (isset($_GET['delete_lease']) && $auth) {
     $return = callFTLAPI("delete-lease ".$_GET['delete_lease']);
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $data["delete_lease"] = $return[0];
   }
 }
 
 if (isset($_GET['dns-port']) && $auth) {
     $return = callFTLAPI("dns-port");
-    if (!in_array("FTLnotrunning", $return )) {
+    if (array_key_exists("FTLnotrunning", $return)) {
+      $data = array("FTLnotrunning" => true);
+    } else {
       $data["dns-port"] = $return[0];
     }
 }

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -297,20 +297,25 @@ $(function () {
       dataSrc: function (data) {
         if ("FTLnotrunning" in data) {
           // if FTL is not running, return empyt array (empty table)
-          utils.showAlert("error","", "Error while deleting DHCP lease for ", "FTL is not running");
+          utils.showAlert(
+            "error",
+            "",
+            "Error while deleting DHCP lease for ",
+            "FTL is not running"
+          );
           data = {};
           return data;
-        } else {
-            var dataIndex = 0;
-            return data.data.map(function (x) {
-              x[0] = x[0] * 1e6 + dataIndex++;
-              var dnssec = x[5];
-              var reply = x[6];
-              x[5] = reply;
-              x[6] = dnssec;
-              return x;
-            });
         }
+
+        var dataIndex = 0;
+        return data.data.map(function (x) {
+          x[0] = x[0] * 1e6 + dataIndex++;
+          var dnssec = x[5];
+          var reply = x[6];
+          x[5] = reply;
+          x[6] = dnssec;
+          return x;
+        });
       },
     },
     autoWidth: false,

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -305,17 +305,17 @@ $(function () {
           );
           data = {};
           return data;
+        } else {
+          var dataIndex = 0;
+          return data.data.map(function (x) {
+            x[0] = x[0] * 1e6 + dataIndex++;
+            var dnssec = x[5];
+            var reply = x[6];
+            x[5] = reply;
+            x[6] = dnssec;
+            return x;
+          });
         }
-
-        var dataIndex = 0;
-        return data.data.map(function (x) {
-          x[0] = x[0] * 1e6 + dataIndex++;
-          var dnssec = x[5];
-          var reply = x[6];
-          x[5] = reply;
-          x[6] = dnssec;
-          return x;
-        });
       },
     },
     autoWidth: false,

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -295,15 +295,22 @@ $(function () {
       url: APIstring,
       error: handleAjaxError,
       dataSrc: function (data) {
-        var dataIndex = 0;
-        return data.data.map(function (x) {
-          x[0] = x[0] * 1e6 + dataIndex++;
-          var dnssec = x[5];
-          var reply = x[6];
-          x[5] = reply;
-          x[6] = dnssec;
-          return x;
-        });
+        if ("FTLnotrunning" in data) {
+          // if FTL is not running, return empyt array (empty table)
+          utils.showAlert("error","", "Error while deleting DHCP lease for ", "FTL is not running");
+          data = {};
+          return data;
+        } else {
+            var dataIndex = 0;
+            return data.data.map(function (x) {
+              x[0] = x[0] * 1e6 + dataIndex++;
+              var dnssec = x[5];
+              var reply = x[6];
+              x[5] = reply;
+              x[6] = dnssec;
+              return x;
+            });
+        }
       },
     },
     autoWidth: false,

--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -79,7 +79,9 @@ function getResponseFTL($socket) {
 }
 
 function disconnectFTL($socket) {
+  if (is_resource($socket)) {
     fclose($socket);
+  }
 }
 
 function callFTLAPI($request, $FTL_IP = DEFAULT_FTL_IP, $port = DEFAULT_FTL_PORT) {
@@ -92,7 +94,6 @@ function callFTLAPI($request, $FTL_IP = DEFAULT_FTL_IP, $port = DEFAULT_FTL_PORT
         $data = getResponseFTL($socket);
     }
     disconnectFTL($socket);
-
     return $data;
 }
 ?>


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [ ] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
When the FTL socket dies unexpectedly (i.e. by Pi-hole restart) and the web interface is still open, `$data = array("FTLnotrunning" => true);` is send to the calling functions. However, there was no guarding so far for this response, which leads to errors within the calling functions. This PR adds a check for the `$data = array("FTLnotrunning" => true);` response and only proceeds the calling function if this data is not present.
Additionally, it guards the `fclose($socket);` by checking for `is_resource($socket))`
