### PR TITLE
Disable prettiers no-else-return rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
       ],
       "no-alert": "off",
       "no-console": "error",
+      "no-else-return": "off",
       "no-negated-condition": "off",
       "no-var": "off",
       "object-shorthand": "off",


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**
Prettier has a `no-else-after-return rule` which errors if an `else` statement follows an `if` clause with a `return`.
https://eslint.org/docs/rules/no-else-return

Although it is technically correct to omit the `else`, I think it greatly enhances the readability of the code. Additionally, the code will not fail, if the `return` within the `if` will be removed by a code change in the future.
Disabling the rule has no negative consequences: the `else` is not mandatory.

**How does this PR accomplish the above?:**
Disables the rule by setting `"no-else-return": "off"` in `package.json`

