### PR TITLE
Pass config file path when reloading pihole-FTL.conf

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -10,7 +10,7 @@ require "scripts/pi-hole/php/savesettings.php";
 require_once "scripts/pi-hole/php/FTL.php";
 // Reread ini file as things might have been changed
 $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
-$piholeFTLConf = piholeFTLConfig(true);
+$piholeFTLConf = piholeFTLConfig("/etc/pihole/pihole-FTL.conf" ,true);
 
 // Handling of PHP internal errors
 $last_error = error_get_last();

--- a/settings.php
+++ b/settings.php
@@ -9,8 +9,9 @@ require "scripts/pi-hole/php/header.php";
 require "scripts/pi-hole/php/savesettings.php";
 require_once "scripts/pi-hole/php/FTL.php";
 // Reread ini file as things might have been changed
+// DEFAULT_FTLCONFFILE is set in "scripts/pi-hole/php/FTL.php";
 $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
-$piholeFTLConf = piholeFTLConfig("/etc/pihole/pihole-FTL.conf" ,true);
+$piholeFTLConf = piholeFTLConfig(DEFAULT_FTLCONFFILE ,true);
 
 // Handling of PHP internal errors
 $last_error = error_get_last();


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/AdminLTE/issues/1783

PR https://github.com/pi-hole/AdminLTE/pull/2130 added the flag `force` to the `piholeFTLConfig` function that forces the page to re-read the config file on reload if `true` was passed. This fixed https://github.com/pi-hole/AdminLTE/issues/1783 already. 
However, https://github.com/pi-hole/AdminLTE/pull/2126 added a second argument (the config file path) without passing two arguments to `piholeFTLConfig`. So the forced reload was never happening, which re-introduced https://github.com/pi-hole/AdminLTE/issues/1783.

This PR solves this by simply passing the default config file path to `piholeFTLConfig` 