### PR TITLE
Add query type "Blocked (special domain)"

### DIFF
--- a/db_queries.php
+++ b/db_queries.php
@@ -56,6 +56,7 @@
                 <div class="col-md-3">
                     <div><input type="checkbox" id="type_blacklist" checked><label for="type_blacklist">Blocked: exact blacklist</label><br></div>
                     <div><input type="checkbox" id="type_regex" checked><label for="type_regex">Blocked: regex blacklist</label></div>
+                    <div><input type="checkbox" id="type_special_domain" checked><label for="type_special_domain">Blocked: special domain</label></div>
                 </div>
                 <div class="col-md-3">
                     <div><input type="checkbox" id="type_gravity_CNAME" checked><label for="type_gravity_CNAME">Blocked: gravity (CNAME)</label><br></div>

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -292,8 +292,13 @@ $(function () {
             "<span class='text-orange'>Blocked <br class='hidden-lg'>(database is busy)</span>";
           blocked = true;
           break;
+        case 16:
+          fieldtext =
+            "<span class='text-orange'>Blocked <br class='hidden-lg'>(special domain)</span>";
+          blocked = true;
+          break;
         default:
-          fieldtext = "Unknown";
+          fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";
       }
 
       $(row).addClass(blocked === true ? "blocked-row" : "allowed-row");

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -146,6 +146,10 @@ function getQueryTypes() {
     queryType.push(15);
   }
 
+  if ($("#type_special_domain").prop("checked")) {
+    queryType.push(16);
+  }
+
   return queryType.join(",");
 }
 
@@ -184,7 +188,7 @@ function refreshTableData() {
   var APIstring = "api_db.php?getAllQueries&from=" + from + "&until=" + until;
   // Check if query type filtering is enabled
   var queryType = getQueryTypes();
-  if (queryType !== "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15") {
+  if (queryType !== "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16") {
     APIstring += "&types=" + queryType;
   }
 

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -218,6 +218,11 @@ $(function () {
             "<span class='text-orange'>Blocked <br class='hidden-lg'>(database is busy)</span>";
           blocked = true;
           break;
+        case "16":
+          fieldtext =
+            "<span class='text-orange'>Blocked <br class='hidden-lg'>(special domain)</span>";
+          blocked = true;
+          break;
         default:
           fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";
       }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
**What does this PR aim to accomplish?:**

Add new query type "Blocked (special domain)"

![Screenshot from 2022-04-24 09-19-46](https://user-images.githubusercontent.com/16748619/164964980-33296a8d-890f-4773-af11-8d09da7671ae.png)

I used the same orange color we are using for the other special blocking type "database busy" as this type really isn't something like other *ads* we want to block. Whether it should be orange or rather red is open for discussion, comments are appreciated.

**How does this PR accomplish the above?:**

Adds interpretation for the new query type implemented in https://github.com/pi-hole/FTL/pull/1338. This PR won't do anything without FTL being updated/switched to a version that contains the code from https://github.com/pi-hole/FTL/pull/1338, however, it is also harmless without and may be merged at any time.

**What documentation changes (if any) are needed to support this PR?:**

None