### PR TITLE
Show "other" destination as the last graphic item

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -538,8 +538,11 @@ function updateForwardDestinationsPie() {
       values.push([key, value, THEME_COLORS[i++ % THEME_COLORS.length]]);
     });
 
-    // Move the "other" element to the end of the array
-    values.push(values.splice(values.indexOf("other"), 1)[0]);
+    // Show "Other" destination as the last graphic item and only if it's different than zero
+    var other = values.splice(values.findIndex(arr => arr.includes("other")), 1)[0];
+    if (other[1] != 0) {
+      values.push(other);
+    }
 
     // Split data into individual arrays for the graphs
     values.forEach(function (value) {

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -543,7 +543,7 @@ function updateForwardDestinationsPie() {
       values.findIndex(arr => arr.includes("other")),
       1
     )[0];
-    if (other[1] != 0) {
+    if (other[1] !== 0) {
       values.push(other);
     }
 

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -539,7 +539,10 @@ function updateForwardDestinationsPie() {
     });
 
     // Show "Other" destination as the last graphic item and only if it's different than zero
-    var other = values.splice(values.findIndex(arr => arr.includes("other")), 1)[0];
+    var other = values.splice(
+      values.findIndex(arr => arr.includes("other")),
+      1
+    )[0];
     if (other[1] != 0) {
       values.push(other);
     }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Move the "other" destination to the last position on the graphic and legend.

Note:
The item will be shown only if it's different than zero.

**How does this PR accomplish the above?:**

Changing the javascript to move the item to last position. 

**What documentation changes (if any) are needed to support this PR?:**

none