### PR TITLE
Add suggested domains in group domains page

### DIFF
--- a/groups-domains.php
+++ b/groups-domains.php
@@ -48,7 +48,8 @@
                                 <div class="col-md-6">
                                     <div class="form-group">
                                         <label for="new_domain">Domain:</label>
-                                            <input id="new_domain" type="url" class="form-control active" placeholder="Domain to be added" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="new_domain" type="url" class="form-control active" placeholder="Domain to be added" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <div id="suggest_domains" class="table-responsive no-border"></div>
                                     </div>
                                 </div>
                                 <div class="col-md-6 form-group">


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Make adding domains easier by suggesting (sub-)domains when typing or pasting an URL into the group domains page:

![suggest_when_typing](https://user-images.githubusercontent.com/11158888/171594187-3fd61e40-2243-4b34-80d1-b1f57376a03f.gif)

![suggest_when_pasting](https://user-images.githubusercontent.com/11158888/169887731-39aecbfd-c0c0-41ee-8b6c-b0db67d42411.gif)

**How does this PR accomplish the above?:**

Adding a `input` event listener on the `#new_domain` input element with a debounce of 1000ms. When executed it checks for a valid URL by passing the `#new_domain` value into `new URL(...)`. If the value is a valid URL it creates a table with the suggested (sub-)domains. Clicking on a suggested (sub-)domain sets the value of `#new_domain` to the selected (sub-)domain and hides the table.

**What documentation changes (if any) are needed to support this PR?:**

None that I'm aware of.