### PR TITLE
Make it clearer where to find the debug token

### DIFF
--- a/debug.php
+++ b/debug.php
@@ -13,7 +13,7 @@
 </div>
 <div>
     <input type="checkbox" id="upload">
-    <label for="upload">Upload debug log and provide token once finished</label>
+    <label for="upload">Upload debug log and provide token (shown at the end of the report) once finished</label>
 </div>
 <p>Once you click this button a debug log will be generated and can automatically be uploaded if we detect a working internet connection.</p>
 <button type="button" id="debugBtn" class="btn btn-lg btn-primary btn-block">Generate debug log</button>


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Makes it clearer where the **token** of the debug log is located.

Fixes https://discourse.pi-hole.net/t/suggestion-about-uploading-debug-reports/55753