### PR TITLE
Use the correct endpoint for MAXLOGAGE

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -64,7 +64,7 @@ if (isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET)) {
 }
 
 if (isset($_GET["getMaxlogage"]) && $auth) {
-    $return = callFTLAPI("stats");
+    $return = callFTLAPI("maxlogage");
     if (array_key_exists("FTLnotrunning", $return)) {
       $data = array("FTLnotrunning" => true);
     } else {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix the response of `api.php?getMaxlogage` 
The response for this call was always returning the default value (24), because it was not asking for the correct information.

**How does this PR accomplish the above?:**

The API call now receives the value of "maxlogage" from FTL, as expected.

**What documentation changes (if any) are needed to support this PR?:**

none.