### PR TITLE
Base DHCP settings on default gateway address and not on IPV4_ADDRESS from setupVars.conf

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -544,4 +544,15 @@ function piholeStatus() {
 
     return $ret;
 }
+
+//Returns the default gateway address and interface
+function getGateway() {
+    $gateway= callFTLAPI("gateway");
+    if (array_key_exists("FTLnotrunning", $gateway)) {
+      $ret = array("ip" => -1);
+    } else {
+      $ret = array_combine(["ip", "iface"], explode(" ", $gateway[0]));  
+    }
+    return $ret;
+}
 ?>

--- a/settings.php
+++ b/settings.php
@@ -8,7 +8,6 @@
 require "scripts/pi-hole/php/header.php";
 require "scripts/pi-hole/php/savesettings.php";
 require_once "scripts/pi-hole/php/FTL.php";
-require_once "scripts/pi-hole/php/func.php";
 // Reread ini file as things might have been changed
 // DEFAULT_FTLCONFFILE is set in "scripts/pi-hole/php/FTL.php";
 $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");

--- a/settings.php
+++ b/settings.php
@@ -76,10 +76,16 @@ if (isset($setupVars["PIHOLE_INTERFACE"])) {
 } else {
     $piHoleInterface = "unknown";
 }
-if (isset($setupVars["IPV4_ADDRESS"])) {
-    $piHoleIPv4 = $setupVars["IPV4_ADDRESS"];
+
+// get the gateway address for the default route on the Pi-hole interface
+if ($piHoleInterface !== "unknown") {
+$IPv4GW=shell_exec("ip -4 route | grep default | grep '${piHoleInterface}' | cut -d ' ' -f 3");
 } else {
-    $piHoleIPv4 = "unknown";
+    $IPv4GW = "unknown";
+}
+// if the route did not return anything
+if (empty($IPv4GW)) {
+    $IPv4GW = "unknown";
 }
 
 // DNS settings
@@ -432,8 +438,8 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                     } else {
                         $DHCP = false;
                         // Try to guess initial settings
-                        if ($piHoleIPv4 !== "unknown") {
-                            $DHCPdomain = explode(".", $piHoleIPv4);
+                        if ($IPv4GW !== "unknown") {
+                            $DHCPdomain = explode(".", $IPv4GW);
                             $DHCPstart = $DHCPdomain[0] . "." . $DHCPdomain[1] . "." . $DHCPdomain[2] . ".201";
                             $DHCPend = $DHCPdomain[0] . "." . $DHCPdomain[1] . "." . $DHCPdomain[2] . ".251";
                             $DHCProuter = $DHCPdomain[0] . "." . $DHCPdomain[1] . "." . $DHCPdomain[2] . ".1";

--- a/settings.php
+++ b/settings.php
@@ -437,10 +437,10 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array("sysadmin", "dns", "piho
                         $DHCP = false;
                         // Try to guess initial settings
                         if ($IPv4GW !== "unknown") {
-                            $DHCPdomain = explode(".", $IPv4GW);
-                            $DHCPstart = $DHCPdomain[0] . "." . $DHCPdomain[1] . "." . $DHCPdomain[2] . ".201";
-                            $DHCPend = $DHCPdomain[0] . "." . $DHCPdomain[1] . "." . $DHCPdomain[2] . ".251";
-                            $DHCProuter = $DHCPdomain[0] . "." . $DHCPdomain[1] . "." . $DHCPdomain[2] . ".1";
+                            $DHCPparts = explode(".", $IPv4GW);
+                            $DHCPstart = $DHCPparts[0] . "." . $DHCPparts[1] . "." . $DHCPparts[2] . ".201";
+                            $DHCPend = $DHCPparts[0] . "." . $DHCPparts[1] . "." . $DHCPparts[2] . ".251";
+                            $DHCProuter = $IPv4GW;
                         } else {
                             $DHCPstart = "";
                             $DHCPend = "";

--- a/settings.php
+++ b/settings.php
@@ -8,6 +8,7 @@
 require "scripts/pi-hole/php/header.php";
 require "scripts/pi-hole/php/savesettings.php";
 require_once "scripts/pi-hole/php/FTL.php";
+require_once "scripts/pi-hole/php/func.php";
 // Reread ini file as things might have been changed
 // DEFAULT_FTLCONFFILE is set in "scripts/pi-hole/php/FTL.php";
 $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
@@ -77,12 +78,11 @@ if (isset($setupVars["PIHOLE_INTERFACE"])) {
     $piHoleInterface = "unknown";
 }
 
-// get the gateway address for the default route on the Pi-hole interface
-if ($piHoleInterface !== "unknown") {
-    $IPv4GW=shell_exec("ip -4 route | grep default | grep '${piHoleInterface}' | cut -d ' ' -f 3");
-}
-// if the route did not return anything or $piHoleInterface is unknown
-if (empty($IPv4GW)) {
+// get the gateway IP
+$IPv4GW=getGateway()["ip"];
+
+// if the default gateway address is unknown or FTL is not running
+if ($IPv4GW == "0.0.0.0"|| $IPv4GW == -1) {
     $IPv4GW = "unknown";
 }
 

--- a/settings.php
+++ b/settings.php
@@ -80,10 +80,8 @@ if (isset($setupVars["PIHOLE_INTERFACE"])) {
 // get the gateway address for the default route on the Pi-hole interface
 if ($piHoleInterface !== "unknown") {
     $IPv4GW=shell_exec("ip -4 route | grep default | grep '${piHoleInterface}' | cut -d ' ' -f 3");
-} else {
-    $IPv4GW = "unknown";
 }
-// if the route did not return anything
+// if the route did not return anything or $piHoleInterface is unknown
 if (empty($IPv4GW)) {
     $IPv4GW = "unknown";
 }

--- a/settings.php
+++ b/settings.php
@@ -79,7 +79,7 @@ if (isset($setupVars["PIHOLE_INTERFACE"])) {
 
 // get the gateway address for the default route on the Pi-hole interface
 if ($piHoleInterface !== "unknown") {
-$IPv4GW=shell_exec("ip -4 route | grep default | grep '${piHoleInterface}' | cut -d ' ' -f 3");
+    $IPv4GW=shell_exec("ip -4 route | grep default | grep '${piHoleInterface}' | cut -d ' ' -f 3");
 } else {
     $IPv4GW = "unknown";
 }


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:** 

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [x] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

So far, we base our guessing of the correct DHCP server settings on the `IPV4_ADDRESS` from `setupVars.conf`. However, we try to get rid of this setting (https://github.com/pi-hole/pi-hole/pull/4356).
This PR bases the setting not on the `IPV4_ADDRESS` anymore, ~~but tries to determine the default gateway for the Pi-hole interface and use this instead. We use the same code in the debug script when we ping the default gateway.~~
~~https://github.com/pi-hole/pi-hole/blob/2735481da8fac3cb521338b7af2259da7b621e88/advanced/Scripts/piholeDebug.sh#L683~~

but instead uses FTL's API endpoint `>gateway` introduced by https://github.com/pi-hole/FTL/pull/1354
