### PR TITLE
Do not use IPvX from setupVars in $AUTHORIZED_HOSTNAMES

### DIFF
--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -30,14 +30,11 @@ function log_and_die($message) {
 }
 
 function check_cors() {
-    $setupVars = parse_ini_file("/etc/pihole/setupVars.conf");
-    $ipv4 = isset($setupVars["IPV4_ADDRESS"]) ? explode("/", $setupVars["IPV4_ADDRESS"])[0] : $_SERVER['SERVER_ADDR'];
-    $ipv6 = isset($setupVars["IPV6_ADDRESS"]) ? explode("/", $setupVars["IPV6_ADDRESS"])[0] : $_SERVER['SERVER_ADDR'];
+    $ip = $_SERVER['SERVER_ADDR'];
 
     // Check CORS
     $AUTHORIZED_HOSTNAMES = array(
-        $ipv4,
-        $ipv6,
+        $ip,
         str_replace(array("[","]"), array("",""), $_SERVER["SERVER_NAME"]),
         "pi.hole",
         "localhost"


### PR DESCRIPTION
- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [ ] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

We try to get rid of `IPv4_ADDRESS` and `IPv6_ADDRESS` from `setupVars.conf` (https://github.com/pi-hole/pi-hole/pull/4356). This PR removes both addresses from `$AUTHORIZED_HOSTNAMES` in the CORS check. For details and implications see

https://github.com/pi-hole/pi-hole/pull/4356#issuecomment-937126922 
