### PR TITLE
Add a default option for PORTFILE

### DIFF
--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -9,6 +9,7 @@
 const DEFAULT_FTLCONFFILE = "/etc/pihole/pihole-FTL.conf";
 const DEFAULT_FTL_IP = "127.0.0.1";
 const DEFAULT_FTL_PORT = 4711;
+const DEFAULT_FTL_PORTFILE = "/run/pihole-FTL.port";
 
 function piholeFTLConfig($piholeFTLConfFile = DEFAULT_FTLCONFFILE, $force = false) {
     static $piholeFTLConfig;
@@ -30,7 +31,7 @@ function connectFTL($address, $port) {
     if ($address == DEFAULT_FTL_IP) {
         $config = piholeFTLConfig();
         // Read port
-        $portfileName = isset($config['PORTFILE']) ? $config['PORTFILE'] : '';
+        $portfileName = isset($config['PORTFILE']) ? $config['PORTFILE'] : DEFAULT_FTL_PORTFILE;
         if ($portfileName != '') {
             $portfileContents = file_get_contents($portfileName);
             if (is_numeric($portfileContents)) {
@@ -79,9 +80,9 @@ function getResponseFTL($socket) {
 }
 
 function disconnectFTL($socket) {
-  if (is_resource($socket)) {
-    fclose($socket);
-  }
+    if (is_resource($socket)) {
+        fclose($socket);
+    }
 }
 
 function callFTLAPI($request, $FTL_IP = DEFAULT_FTL_IP, $port = DEFAULT_FTL_PORT) {


### PR DESCRIPTION
**By submitting this pull request, I confirm the following:**

- [x] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [x] I have made only one major change in my proposed changes.
- [ ] I have commented my proposed changes within the code.
- [x] I have tested my proposed changes.
- [x] I am willing to help maintain this change if there are issues with it later.
- [x] I give this submission freely and claim no ownership.
- [x] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [x] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [x] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Fix #2221 

**How does this PR accomplish the above?:**

When an alternative port was used without setting a different `PORTFILE`, the web interface wasn't able to read the port number. Adding a default value for `PORTFILE` fixed the problem.

**What documentation changes (if any) are needed to support this PR?:**

none