### PR TITLE
Show warnings only if logged in

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -384,7 +384,7 @@ if (isset($_GET['getGraphData']) && $auth)
 	$data = array_merge($data, $result);
 }
 
-if (isset($_GET['status']))
+if (isset($_GET['status']) && $auth)
 {
 	$extra = ";";
 	if(isset($_GET["ignore"]) && $_GET["ignore"] === 'DNSMASQ_WARN')


### PR DESCRIPTION
Signed-off-by: Pingger Shikkoken <Pingger@users.noreply.github.com>

**By submitting this pull request, I confirm the following:** 


- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/AdminLTE/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes.
- [X] I am not willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---signoff))

---

**What does this PR aim to accomplish?:**

Removes the warning triangle to reduce the attack surface for malicious clients

**How does this PR accomplish the above?:**

Prevent access to number of warnings without authentication

**What documentation changes (if any) are needed to support this PR?:**

None that I know of
