### PR TITLE
Adjust debug log scroll position

### DIFF
--- a/scripts/pi-hole/js/debug.js
+++ b/scripts/pi-hole/js/debug.js
@@ -39,8 +39,9 @@ function eventsource() {
     "message",
     function (e) {
       ta.append(e.data);
-      // scroll page to the bottom (to the last received data)
-      $("html, body").scrollTop($(document).height());
+      // scroll to the bottom of #output (most recent data)
+      var taBottom = ta.offset().top + ta.outerHeight(true);
+      $("html, body").scrollTop(taBottom - $(window).height());
     },
     false
   );


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

  While the debug log is streamed, the page scrolls to the end to show the most recent entries.
  The original code was scrolling until the bottom of the footer, always, even if there wasn't enough text.

- **How does this PR accomplish the above?:**

  The new code scrolls to the bottom of the `#output` element (not footer) and only when the element height is grater than viewport.

- **What documentation changes (if any) are needed to support this PR?:**

  none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
