### PR TITLE
Remove unused parameter

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -137,9 +137,8 @@ if(!function_exists('hash_equals')) {
  * and returns output of that command as a string.
  *
  * @param $argument_string String of arguments to run pihole with.
- * @param $error_on_failure If true, a warning is raised if command execution fails. Defaults to true.
  */
-function pihole_execute($argument_string, $error_on_failure = true) {
+function pihole_execute($argument_string) {
     $escaped = escapeshellcmd($argument_string);
     $output = null;
     $return_status = -1;
@@ -551,7 +550,7 @@ function getGateway() {
     if (array_key_exists("FTLnotrunning", $gateway)) {
       $ret = array("ip" => -1);
     } else {
-      $ret = array_combine(["ip", "iface"], explode(" ", $gateway[0]));  
+      $ret = array_combine(["ip", "iface"], explode(" ", $gateway[0]));
     }
     return $ret;
 }


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

  The parameter `$error_on_failure` wasn't used inside `pihole_execute` function.

- **How does this PR accomplish the above?:**

  Remove unused parameter from the function.

- **What documentation changes (if any) are needed to support this PR?:**

  none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
