### PR TITLE
Add stickler-CI to test yaml and mkdown files

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,4 @@
+---
+linters:
+  yamllint:
+  remarklint:

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -2,3 +2,7 @@
 linters:
   yamllint:
   remarklint:
+files:
+  ignore:
+    - 'scripts/vendor/*'
+    - 'style/vendor/*'


### PR DESCRIPTION
This adds stickler-CI workflow to lint markdown and yaml files.

Uses https://pypi.org/project/yamllint/ and https://github.com/remarkjs/remark-lint internally
