### PR TITLE
Switch to node 16.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "14.x"
+          node-version: "16.x"
           cache: npm
 
       - name: Install npm dependencies


### PR DESCRIPTION
Upgrades the node version we use for our test to `node 16`.

https://nodejs.org/en/about/releases/