### PR TITLE
Use a random name when creating intermediate tmp archive for teleporter backup

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -89,7 +89,7 @@ function archive_restore_table($file, $table, $flush=false)
 	{
 		$tableExists = $db->querySingle("SELECT name FROM sqlite_master WHERE type='table' AND name='".$table."';");
 		if ($tableExists)
-		{			
+		{
 			$db->exec("DELETE FROM \"".$table."\"");
 			array_push($flushed_tables, $table);
 		}
@@ -354,6 +354,7 @@ if(isset($_POST["action"]))
 		}
 
 		$fullfilename = sys_get_temp_dir()."/".$filename;
+
 		if(!move_uploaded_file($source, $fullfilename))
 		{
 			die("Failed moving ".htmlentities($source)." to ".htmlentities($fullfilename));
@@ -603,7 +604,10 @@ else
 	$hostname = gethostname() ? str_replace(".", "_", gethostname())."-" : "";
 	$tarname = "pi-hole-".$hostname."teleporter_".date("Y-m-d_H-i-s").".tar";
 	$filename = $tarname.".gz";
-	$archive_file_name = sys_get_temp_dir() ."/". $tarname;
+    $archive_file_name = tempnam(sys_get_temp_dir(), 'pihole_teleporter_'); //create a random file name in the system's tmp dir for the intermediat archive
+    unlink($archive_file_name); //remove intermediate file created by tempnam()
+    $archive_file_name .= ".tar"; // Append ".tar" extension
+
 	$archive = new PharData($archive_file_name);
 
 	if ($archive->isWritable() !== TRUE) {


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Fixes an issue reported here:
https://discourse.pi-hole.net/t/fatal-php-error-with-teleporter/56264/

The user created teleporter backups via cron. The script was running under `/tmp`. During the backup creation, PHP compresses the data and creates a temporary copy within `/tmp` with the same filename as the backup. This leads to 

```
PHP Fatal error: Uncaught BadMethodCallException: phar "/tmp/pi-hole-pihole-wf-inside-teleporter_2022-06-30_11-21-35.tar.gz" exists and must be unlinked prior to conversion in /var/www/html/admin/scripts/pi-hole/php/teleporter.php:634 Stack trace: #0 /var/www/html/admin/scripts/pi-hole/php/teleporter.php(634): PharData->compress() #1 {main} thrown in /var/www/html/admin/scripts/pi-hole/php/teleporter.php on line 634
```


- **How does this PR accomplish the above?:**

Use a random name when creating intermediate tmp archive for teleporter backup with `tempnam(sys_get_temp_dir())`


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
