### PR TITLE
Allow to delete IDN via API

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -554,4 +554,18 @@ function getGateway() {
     }
     return $ret;
 }
+
+//Convert a given (unicode) domain to IDNA ASCII
+function convertDomainToIDNA($IDNA) {
+    if (extension_loaded("intl")) {
+        // Be prepared that this may fail and see our comments about "idn_to_utf8
+        if (defined("INTL_IDNA_VARIANT_UTS46")) {
+            $IDNA = idn_to_ascii($IDNA, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+        } elseif (defined("INTL_IDNA_VARIANT_2003")) {
+            $IDNA = idn_to_ascii($IDNA, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
+        }
+    }
+
+    return $IDNA;
+}
 ?>

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -555,10 +555,37 @@ function getGateway() {
     return $ret;
 }
 
-//Convert a given (unicode) domain to IDNA ASCII
-function convertDomainToIDNA($IDNA) {
+// Try to convert possible IDNA domain to Unicode
+function convertIDNAToUnicode($unicode) {
     if (extension_loaded("intl")) {
-        // Be prepared that this may fail and see our comments about "idn_to_utf8
+        // we try the UTS #46 standard first
+        // as this is the new default, see https://sourceforge.net/p/icu/mailman/message/32980778/
+        // We know that this fails for some Google domains violating the standard
+        // see https://github.com/pi-hole/AdminLTE/issues/1223
+        if (defined("INTL_IDNA_VARIANT_UTS46")) {
+            // We have to use the option IDNA_NONTRANSITIONAL_TO_ASCII here
+            // to ensure sparkasse-gießen.de is not converted into
+            // sparkass-giessen.de but into xn--sparkasse-gieen-2ib.de
+            // as mandated by the UTS #46 standard
+            $unicode = idn_to_utf8($unicode, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+        } elseif (defined("INTL_IDNA_VARIANT_2003")) {
+            // If conversion failed, try with the (deprecated!) IDNA 2003 variant
+            // We have to check for its existence as support of this variant is
+            // scheduled for removal with PHP 8.0
+            // see https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
+            $unicode = idn_to_utf8($unicode, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
+        }
+
+    }
+
+    return $unicode;
+
+}
+
+//Convert a given (unicode) domain to IDNA ASCII
+function convertUnicodeToIDNA($IDNA) {
+    if (extension_loaded("intl")) {
+        // Be prepared that this may fail and see our comments about convertIDNAToUnicode()
         if (defined("INTL_IDNA_VARIANT_UTS46")) {
             $IDNA = idn_to_ascii($IDNA, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
         } elseif (defined("INTL_IDNA_VARIANT_2003")) {

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -516,34 +516,12 @@ if ($_POST['action'] == 'get_groups') {
                 array_push($groups, $gres['group_id']);
             }
             $res['groups'] = $groups;
-            if (extension_loaded("intl") &&
-                ($res['type'] === ListType::whitelist ||
-                 $res['type'] === ListType::blacklist) ) {
-
-                // Try to convert possible IDNA domain to Unicode, we try the UTS #46 standard first
-                // as this is the new default, see https://sourceforge.net/p/icu/mailman/message/32980778/
-                // We know that this fails for some Google domains violating the standard
-                // see https://github.com/pi-hole/AdminLTE/issues/1223
-                $utf8_domain = false;
-                if (defined("INTL_IDNA_VARIANT_UTS46")) {
-                    // We have to use the option IDNA_NONTRANSITIONAL_TO_ASCII here
-                    // to ensure sparkasse-gießen.de is not converted into
-                    // sparkass-giessen.de but into xn--sparkasse-gieen-2ib.de
-                    // as mandated by the UTS #46 standard
-                    $utf8_domain = idn_to_utf8($res['domain'], IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
-                }
-
-                // If conversion failed, try with the (deprecated!) IDNA 2003 variant
-                // We have to check for its existence as support of this variant is
-                // scheduled for removal with PHP 8.0
-                // see https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
-                if ($utf8_domain === false && defined("INTL_IDNA_VARIANT_2003")) {
-                    $utf8_domain = idn_to_utf8($res['domain'], IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
-                }
-
+            if ($res['type'] === ListType::whitelist || $res['type'] === ListType::blacklist) {
                 // Convert domain name to international form
-                // if applicable and extension is available
-                if ($utf8_domain !== false && $res['domain'] !== $utf8_domain) {
+                $utf8_domain = convertIDNAToUnicode($res['domain']);
+
+                // if domain and international form are different, show both
+                if ($res['domain'] !== $utf8_domain) {
                     $res['domain'] = $utf8_domain.' ('.$res['domain'].')';
                 }
             }
@@ -625,7 +603,7 @@ if ($_POST['action'] == 'get_groups') {
 
             $input = $domain;
             // Convert domain name to IDNA ASCII form for international domains
-            $domain = convertDomainToIDNA($domain);
+            $domain = convertUnicodeToIDNA($domain);
 
             if( $_POST['type'] != '2' && $_POST['type'] != '3')
             {
@@ -634,7 +612,7 @@ if ($_POST['action'] == 'get_groups') {
                 $msg = "";
                 if(!validDomain($domain, $msg))
                 {
-                    // This is the case when convertDomainToIDNA() modified the string
+                    // This is the case when convertUnicodeToIDNA() modified the string
                     if($input !== $domain && strlen($domain) > 0)
                         $errormsg = 'Domain ' . htmlentities($input) . ' (converted to "' . htmlentities(utf8_encode($domain)) . '") is not a valid domain because ' . $msg . '.';
                     elseif($input !== $domain)
@@ -866,7 +844,7 @@ if ($_POST['action'] == 'get_groups') {
 
         $domain = html_entity_decode(trim($_POST['domain']));
         // Convert domain name to IDNA ASCII form for international domains
-        $domain = convertDomainToIDNA($domain);
+        $domain = convertUnicodeToIDNA($domain);
 
         $stmt = $db->prepare('DELETE FROM domainlist_by_group WHERE domainlist_id=(SELECT id FROM domainlist WHERE domain=:domain AND type=:type);');
         if (!$stmt) {

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -625,20 +625,7 @@ if ($_POST['action'] == 'get_groups') {
 
             $input = $domain;
             // Convert domain name to IDNA ASCII form for international domains
-            if (extension_loaded("intl")) {
-                // Be prepared that this may fail and see our comments above
-                // (search for "idn_to_utf8)
-                $idn_domain = false;
-                if (defined("INTL_IDNA_VARIANT_UTS46")) {
-                    $idn_domain = idn_to_ascii($domain, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
-                }
-                if ($idn_domain === false && defined("INTL_IDNA_VARIANT_2003")) {
-                    $idn_domain = idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
-                }
-                if($idn_domain !== false) {
-                    $domain = $idn_domain;
-                }
-            }
+            $domain = convertDomainToIDNA($domain);
 
             if( $_POST['type'] != '2' && $_POST['type'] != '3')
             {
@@ -647,7 +634,7 @@ if ($_POST['action'] == 'get_groups') {
                 $msg = "";
                 if(!validDomain($domain, $msg))
                 {
-                    // This is the case when idn_to_ascii() modified the string
+                    // This is the case when convertDomainToIDNA() modified the string
                     if($input !== $domain && strlen($domain) > 0)
                         $errormsg = 'Domain ' . htmlentities($input) . ' (converted to "' . htmlentities(utf8_encode($domain)) . '") is not a valid domain because ' . $msg . '.';
                     elseif($input !== $domain)
@@ -879,15 +866,7 @@ if ($_POST['action'] == 'get_groups') {
 
         $domain = html_entity_decode(trim($_POST['domain']));
         // Convert domain name to IDNA ASCII form for international domains
-        if (extension_loaded("intl")) {
-            // Be prepared that this may fail and see our comments above
-            // (search for "idn_to_utf8)
-            if (defined("INTL_IDNA_VARIANT_UTS46")) {
-                $domain = idn_to_ascii($domain, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
-            } elseif (defined("INTL_IDNA_VARIANT_2003")) {
-                $domain = idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
-            }
-        }
+        $domain = convertDomainToIDNA($domain);
 
         $stmt = $db->prepare('DELETE FROM domainlist_by_group WHERE domainlist_id=(SELECT id FROM domainlist WHERE domain=:domain AND type=:type);');
         if (!$stmt) {

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -882,15 +882,10 @@ if ($_POST['action'] == 'get_groups') {
         if (extension_loaded("intl")) {
             // Be prepared that this may fail and see our comments above
             // (search for "idn_to_utf8)
-            $idn_domain = false;
             if (defined("INTL_IDNA_VARIANT_UTS46")) {
-                $idn_domain = idn_to_ascii($domain, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
-            }
-            if ($idn_domain === false && defined("INTL_IDNA_VARIANT_2003")) {
-                $idn_domain = idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
-            }
-            if($idn_domain !== false) {
-                $domain = $idn_domain;
+                $domain = idn_to_ascii($domain, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+            } elseif (defined("INTL_IDNA_VARIANT_2003")) {
+                $domain = idn_to_ascii($domain, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
             }
         }
 

--- a/scripts/pi-hole/php/queryads.php
+++ b/scripts/pi-hole/php/queryads.php
@@ -26,7 +26,8 @@ function echoEvent($datatext) {
 if(isset($_GET["domain"]))
 {
     // Is this a valid domain?
-    $url = idn_to_ascii($_GET["domain"]);
+    // Convert domain name to IDNA ASCII form for international domains
+    $url = convertDomainToIDNA($_GET["domain"]);
     if (!validDomain($url)) {
         echoEvent(htmlentities($url)." is an invalid domain!");
         die();

--- a/scripts/pi-hole/php/queryads.php
+++ b/scripts/pi-hole/php/queryads.php
@@ -27,7 +27,7 @@ if(isset($_GET["domain"]))
 {
     // Is this a valid domain?
     // Convert domain name to IDNA ASCII form for international domains
-    $url = convertDomainToIDNA($_GET["domain"]);
+    $url = convertUnicodeToIDNA($_GET["domain"]);
     if (!validDomain($url)) {
         echoEvent(htmlentities($url)." is an invalid domain!");
         die();


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

If IDN's were added they are converted to punycode before saved in the database. However, when deleting them via API, there was no punycode conversion, which prevented the domain from being deleted.
Fixes https://github.com/pi-hole/AdminLTE/issues/2257


- **How does this PR accomplish the above?:**

Convert domains to punycode before trying to delete them.
Note: the domains could already be deleted successfully from the web interface because it didn't use `delete_domain_string` but `delete_domain` which uses the database IDs rather than the domain names to identify the database entry.
___

Additionally, this PR cleans the IDNA conversion a bit by creating two re-usable functions in `func.php`

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
