### PR TITLE
Fix editing domains from blacklist/whitelist pages

### DIFF
--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -592,7 +592,7 @@ function editDomain() {
   // Show group assignment field only if in full domain management mode
   // if not included, just use the row data.
   var rowData = table.row(tr).data();
-  var groups = table.column(5).visible() ? tr.find("#multiselect_" + id).val() : rowData.groups;
+  var groups = table.column(6).visible() ? tr.find("#multiselect_" + id).val() : rowData.groups;
 
   var domainRegex;
   if (type === "0" || type === "1") {


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Fixes an issue reported on discourse: https://discourse.pi-hole.net/t/domains-lose-group-assignment-if-enabled-disabled-modified-on-blacklist-management-page/56474

When domains were edited from black/whitelist page they loose their group assignment. 

Reason is PR https://github.com/pi-hole/AdminLTE/pull/2177, which added an additional column, but did not increase the column count here:

https://github.com/pi-hole/AdminLTE/blob/1714b082c3a233ea3a0c344b50352c59818676fc/scripts/pi-hole/js/groups-domains.js#L595


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
