### PR TITLE
Remove dedicated black/whitelist pages + redesign menu

### DIFF
--- a/groups-adlists.php
+++ b/groups-adlists.php
@@ -53,7 +53,7 @@
         <div class="box" id="adlists-list">
             <div class="box-header with-border">
                 <h3 class="box-title">
-                    List of configured adlists
+                    List of adlists
                 </h3>
             </div>
             <!-- /.box-header -->

--- a/groups-domains.php
+++ b/groups-domains.php
@@ -88,14 +88,12 @@
                     </p>
                 </div>
                 <div class="btn-toolbar pull-right" role="toolbar" aria-label="Toolbar with buttons">
-                    <?php { ?>
                     <div class="btn-group" role="group" aria-label="Third group">
                         <button type="button" class="btn btn-primary" id="add2black">Add to Blacklist</button>
                     </div>
                     <div class="btn-group" role="group" aria-label="Third group">
                         <button type="button" class="btn btn-primary" id="add2white">Add to Whitelist</button>
                     </div>
-                    <?php } ?>
                 </div>
             </div>
             <!-- /.box-body -->
@@ -110,7 +108,7 @@
         <div class="box" id="domains-list">
             <div class="box-header with-border">
                 <h3 class="box-title">
-                    List of configured domains
+                    List of domains
                 </h3>
             </div>
             <!-- /.box-header -->

--- a/groups-domains.php
+++ b/groups-domains.php
@@ -6,19 +6,11 @@
 *    This file is copyright under the latest version of the EUPL.
 *    Please see LICENSE file for your rights under this license. */
     require "scripts/pi-hole/php/header.php";
-    $type = "all";
-    $pagetitle = "Domain";
-    $adjective = "";
-    if (isset($_GET['type']) && ($_GET['type'] === "white" || $_GET['type'] === "black")) {
-        $type = $_GET['type'];
-        $pagetitle = ucfirst($type)."list";
-        $adjective = $type."listed";
-    }
 ?>
 
 <!-- Title -->
 <div class="page-header">
-    <h1><?php echo $pagetitle; ?> management</h1>
+    <h1>Domain management</h1>
 </div>
 
 <!-- Domain Input -->
@@ -27,7 +19,7 @@
         <div class="box" id="add-group">
             <div class="box-header with-border">
                 <h3 class="box-title">
-                    Add a new <?php echo $adjective; ?> domain or regex filter
+                    Add a new domain or regex filter
                 </h3>
             </div>
             <!-- /.box-header -->
@@ -92,19 +84,14 @@
                 <div>
                     <p><strong>Note:</strong><br>
                        The domain or regex filter will be automatically assigned to the Default Group.<br>
-                       Other groups can optionally be assigned
-                       <?php if ($type === "white" || $type === "black") { ?>
-                       within <a href="groups-domains.php">Group Management > Domains</a>.
-                       <?php } else {?>
-                       in the list below (using <b>Group assignment</b>).
-                       <?php } ?></p>
+                       Other groups can optionally be assigned in the list below (using <b>Group assignment</b>).
+                    </p>
                 </div>
                 <div class="btn-toolbar pull-right" role="toolbar" aria-label="Toolbar with buttons">
-                    <?php if ( $type !== "white" ) { ?>
+                    <?php { ?>
                     <div class="btn-group" role="group" aria-label="Third group">
                         <button type="button" class="btn btn-primary" id="add2black">Add to Blacklist</button>
                     </div>
-                    <?php } if ( $type !== "black" ) { ?>
                     <div class="btn-group" role="group" aria-label="Third group">
                         <button type="button" class="btn btn-primary" id="add2white">Add to Whitelist</button>
                     </div>
@@ -123,7 +110,7 @@
         <div class="box" id="domains-list">
             <div class="box-header with-border">
                 <h3 class="box-title">
-                    List of <?php echo $adjective; ?> entries
+                    List of configured domains
                 </h3>
             </div>
             <!-- /.box-header -->

--- a/groups.php
+++ b/groups.php
@@ -52,7 +52,7 @@
         <div class="box" id="groups-list">
             <div class="box-header with-border">
                 <h3 class="box-title">
-                    List of configured groups
+                    List of groups
                 </h3>
             </div>
             <!-- /.box-header -->

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -49,15 +49,15 @@ function countDown() {
 
   //Stop and remove timer when user enabled early
   if ($("#pihole-enable").is(":hidden")) {
-    ena.text("Enable");
+    ena.text("Enable Blocking");
     return;
   }
 
   if (seconds > 0) {
     setTimeout(countDown, 1000);
-    ena.text("Enable (" + secondsTimeSpanToHMS(seconds) + ")");
+    ena.text("Enable Blocking (" + secondsTimeSpanToHMS(seconds) + ")");
   } else {
-    ena.text("Enable");
+    ena.text("Enable Blocking");
     piholeChanged("enabled");
     if (localStorage) {
       localStorage.removeItem("countDownTarget");

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -122,7 +122,7 @@ function initTable() {
       { data: "type", searchable: false },
       { data: "enabled", searchable: false },
       { data: "comment" },
-      { data: "groups", searchable: false, visible: true },
+      { data: "groups", searchable: false },
       { data: null, width: "22px", orderable: false },
     ],
     columnDefs: [
@@ -207,71 +207,69 @@ function initTable() {
       commentEl.val(utils.unescapeHtml(data.comment));
       commentEl.on("change", editDomain);
 
-      // Show group assignment field only if in full domain management mode
-      if (table.column(6).visible()) {
-        $("td:eq(5)", row).empty();
-        $("td:eq(5)", row).append(
-          '<select class="selectpicker" id="multiselect_' + data.id + '" multiple></select>'
-        );
-        var selectEl = $("#multiselect_" + data.id, row);
-        // Add all known groups
-        for (var i = 0; i < groups.length; i++) {
-          var dataSub = "";
-          if (!groups[i].enabled) {
-            dataSub = 'data-subtext="(disabled)"';
-          }
-
-          selectEl.append(
-            $("<option " + dataSub + "/>")
-              .val(groups[i].id)
-              .text(groups[i].name)
-          );
+      // Group assignment field
+      $("td:eq(5)", row).empty();
+      $("td:eq(5)", row).append(
+        '<select class="selectpicker" id="multiselect_' + data.id + '" multiple></select>'
+      );
+      var selectEl = $("#multiselect_" + data.id, row);
+      // Add all known groups
+      for (var i = 0; i < groups.length; i++) {
+        var dataSub = "";
+        if (!groups[i].enabled) {
+          dataSub = 'data-subtext="(disabled)"';
         }
 
-        // Select assigned groups
-        selectEl.val(data.groups);
-        // Initialize bootstrap-select
-        selectEl
-          // fix dropdown if it would stick out right of the viewport
-          .on("show.bs.select", function () {
-            var winWidth = $(window).width();
-            var dropdownEl = $("body > .bootstrap-select.dropdown");
-            if (dropdownEl.length > 0) {
-              dropdownEl.removeClass("align-right");
-              var width = dropdownEl.width();
-              var left = dropdownEl.offset().left;
-              if (left + width > winWidth) {
-                dropdownEl.addClass("align-right");
-              }
-            }
-          })
-          .on("changed.bs.select", function () {
-            // enable Apply button
-            if ($(applyBtn).prop("disabled")) {
-              $(applyBtn)
-                .addClass("btn-success")
-                .prop("disabled", false)
-                .on("click", function () {
-                  editDomain.call(selectEl);
-                });
-            }
-          })
-          .on("hide.bs.select", function () {
-            // Restore values if drop-down menu is closed without clicking the Apply button
-            if (!$(applyBtn).prop("disabled")) {
-              $(this).val(data.groups).selectpicker("refresh");
-              $(applyBtn).removeClass("btn-success").prop("disabled", true).off("click");
-            }
-          })
-          .selectpicker()
-          .siblings(".dropdown-menu")
-          .find(".bs-actionsbox")
-          .prepend(
-            '<button type="button" id=btn_apply_' +
-              data.id +
-              ' class="btn btn-block btn-sm" disabled>Apply</button>'
-          );
+        selectEl.append(
+          $("<option " + dataSub + "/>")
+            .val(groups[i].id)
+            .text(groups[i].name)
+        );
       }
+
+      // Select assigned groups
+      selectEl.val(data.groups);
+      // Initialize bootstrap-select
+      selectEl
+        // fix dropdown if it would stick out right of the viewport
+        .on("show.bs.select", function () {
+          var winWidth = $(window).width();
+          var dropdownEl = $("body > .bootstrap-select.dropdown");
+          if (dropdownEl.length > 0) {
+            dropdownEl.removeClass("align-right");
+            var width = dropdownEl.width();
+            var left = dropdownEl.offset().left;
+            if (left + width > winWidth) {
+              dropdownEl.addClass("align-right");
+            }
+          }
+        })
+        .on("changed.bs.select", function () {
+          // enable Apply button
+          if ($(applyBtn).prop("disabled")) {
+            $(applyBtn)
+              .addClass("btn-success")
+              .prop("disabled", false)
+              .on("click", function () {
+                editDomain.call(selectEl);
+              });
+          }
+        })
+        .on("hide.bs.select", function () {
+          // Restore values if drop-down menu is closed without clicking the Apply button
+          if (!$(applyBtn).prop("disabled")) {
+            $(this).val(data.groups).selectpicker("refresh");
+            $(applyBtn).removeClass("btn-success").prop("disabled", true).off("click");
+          }
+        })
+        .selectpicker()
+        .siblings(".dropdown-menu")
+        .find(".bs-actionsbox")
+        .prepend(
+          '<button type="button" id=btn_apply_' +
+            data.id +
+            ' class="btn btn-block btn-sm" disabled>Apply</button>'
+        );
 
       var applyBtn = "#btn_apply_" + data.id;
 
@@ -280,6 +278,7 @@ function initTable() {
         $(row).find("td").addClass("highlight");
       }
 
+      // Add delete domain button
       var button =
         '<button type="button" class="btn btn-danger btn-xs" id="deleteDomain_' +
         data.id +
@@ -288,11 +287,7 @@ function initTable() {
         '">' +
         '<span class="far fa-trash-alt"></span>' +
         "</button>";
-      if (table.column(6).visible()) {
-        $("td:eq(6)", row).html(button);
-      } else {
-        $("td:eq(5)", row).html(button);
-      }
+      $("td:eq(6)", row).html(button);
     },
     select: {
       style: "multi",
@@ -363,8 +358,6 @@ function initTable() {
 
       // Reset visibility of ID column
       data.columns[0].visible = false;
-      // Show group assignment
-      data.columns[6].visible = true;
       // Apply loaded state to table
       return data;
     },

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -492,11 +492,7 @@ if ($_POST['action'] == 'get_groups') {
     // List all available groups
     try {
         $limit = "";
-        if (isset($_POST["showtype"]) && $_POST["showtype"] === "white"){
-            $limit = " WHERE type = 0 OR type = 2";
-        } elseif (isset($_POST["showtype"]) && $_POST["showtype"] === "black"){
-            $limit = " WHERE type = 1 OR type = 3";
-        } elseif (isset($_POST["type"]) && is_numeric($_POST["type"])){
+        if (isset($_POST["type"]) && is_numeric($_POST["type"])){
             $limit = " WHERE type = " . $_POST["type"];
         }
         $query = $db->query('SELECT * FROM domainlist'.$limit);

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -443,18 +443,6 @@ if($auth) {
                     </li>
                   </ul>
                 </li>
-                <!-- Whitelist -->
-                <li<?php if($scriptname === "whitelist"){ ?> class="active"<?php } ?>>
-                    <a href="groups-domains.php?type=white">
-                        <i class="fa fa-fw menu-icon fa-check-circle"></i> <span>Whitelist</span>
-                    </a>
-                </li>
-                <!-- Blacklist -->
-                <li<?php if($scriptname === "blacklist"){ ?> class="active"<?php } ?>>
-                    <a href="groups-domains.php?type=black">
-                        <i class="fa fa-fw menu-icon fa-ban"></i> <span>Blacklist</span>
-                    </a>
-                </li>
                 <!-- Group Management -->
                 <li class="treeview<?php if (in_array($scriptname, array("groups.php", "groups-adlists.php", "groups-clients.php", "groups-domains.php"))){ ?> active<?php } ?>">
                   <a href="#">

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -386,6 +386,12 @@ if($auth) {
                 </div>
             </div>
             <!-- sidebar menu: : style can be found in sidebar.less -->
+            <?php
+            if(!$auth && (!isset($indexpage) || isset($_GET['login'])))
+            {
+                $scriptname = "login";
+            }
+            ?>
             <ul class="sidebar-menu" data-widget="tree">
                 <li class="header text-uppercase">Main</li>
                 <!-- Home Page -->
@@ -453,22 +459,22 @@ if($auth) {
                 <!-- Group Management -->
                 <li<?php if($scriptname === "groups.php"){ ?> class="active"<?php } ?>>
                     <a href="groups.php">
-                        <i class="fa fa-fw menu-icon fa-user-friends"></i> Groups
+                        <i class="fa fa-fw menu-icon fa-user-friends"></i> <span>Groups</span>
                     </a>
                 </li>
                 <li<?php if($scriptname === "groups-clients.php"){ ?> class="active"<?php } ?>>
                     <a href="groups-clients.php">
-                        <i class="fa fa-fw menu-icon fa-laptop"></i> Clients
+                        <i class="fa fa-fw menu-icon fa-laptop"></i> <span>Clients</span>
                     </a>
                 </li>
                 <li<?php if($scriptname === "groups-domains.php"){ ?> class="active"<?php } ?>>
                     <a href="groups-domains.php">
-                        <i class="fa fa-fw menu-icon fa-list"></i> Domains
+                        <i class="fa fa-fw menu-icon fa-list"></i> <span>Domains</span>
                     </a>
                 </li>
                 <li<?php if($scriptname === "groups-adlists.php"){ ?> class="active"<?php } ?>>
                     <a href="groups-adlists.php">
-                        <i class="fa fa-fw menu-icon fa-shield-alt"></i> Adlists
+                        <i class="fa fa-fw menu-icon fa-shield-alt"></i> <span>Adlists</span>
                     </a>
                 </li>
                 <li class="header text-uppercase">DNS Control</li>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -386,23 +386,6 @@ if($auth) {
                 </div>
             </div>
             <!-- sidebar menu: : style can be found in sidebar.less -->
-            <?php
-            if($scriptname === "groups-domains.php" && isset($_GET['type']))
-            {
-                if($_GET["type"] === "white")
-                {
-                    $scriptname = "whitelist";
-                }
-                elseif($_GET["type"] === "black")
-                {
-                    $scriptname = "blacklist";
-                }
-            }
-            if(!$auth && (!isset($indexpage) || isset($_GET['login'])))
-            {
-                $scriptname = "login";
-            }
-            ?>
             <ul class="sidebar-menu" data-widget="tree">
                 <li class="header text-uppercase">Main</li>
                 <!-- Home Page -->

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -445,7 +445,7 @@ if($auth) {
                     </li>
                     <li<?php if($scriptname === "db_queries.php"){ ?> class="active"<?php } ?>>
                         <a href="db_queries.php">
-                            <i class="fa fa-fwDNS Control menu-icon fa-file-alt"></i> Query Log
+                            <i class="fa fa-fw menu-icon fa-file-alt"></i> Query Log
                         </a>
                     </li>
                     <li<?php if($scriptname === "db_lists.php"){ ?> class="active"<?php } ?>>

--- a/scripts/pi-hole/php/header.php
+++ b/scripts/pi-hole/php/header.php
@@ -404,23 +404,46 @@ if($auth) {
             }
             ?>
             <ul class="sidebar-menu" data-widget="tree">
-                <li class="header text-uppercase">Main navigation</li>
+                <li class="header text-uppercase">Main</li>
                 <!-- Home Page -->
                 <li<?php if($scriptname === "index.php"){ ?> class="active"<?php } ?>>
                     <a href="index.php">
                         <i class="fa fa-fw menu-icon fa-home"></i> <span>Dashboard</span>
                     </a>
                 </li>
+                <!-- Logout -->
+                <?php
+                // Show Logout button if $auth is set and authorization is required
+                if(strlen($pwhash) > 0 && $auth) { ?>
+                <li>
+                    <a href="?logout">
+                        <i class="fa fa-fw menu-icon fa-sign-out-alt"></i> <span>Logout</span>
+                    </a>
+                </li>
+                <?php } ?>
+                <!-- Login -->
+                <?php
+                // Show Login button if $auth is *not* set and authorization is required
+                if(strlen($pwhash) > 0 && !$auth) { ?>
+                <li<?php if($scriptname === "login"){ ?> class="active"<?php } ?>>
+                    <a href="index.php?login">
+                        <i class="fa fa-fw menu-icon fa-user"></i> <span>Login</span>
+                    </a>
+                </li>
+                <?php } ?>
                 <?php if($auth){ ?>
+
+                <li class="header text-uppercase">Analysis</li>
                 <!-- Query Log -->
                 <li<?php if($scriptname === "queries.php"){ ?> class="active"<?php } ?>>
                     <a href="queries.php">
                         <i class="fa fa-fw menu-icon fa-file-alt"></i> <span>Query Log</span>
                     </a>
                 </li>
+                <!-- Long-term database -->
                 <li class="treeview<?php if($scriptname === "db_queries.php" || $scriptname === "db_lists.php" || $scriptname === "db_graph.php"){ ?> active<?php } ?>">
                   <a href="#">
-                    <i class="fa fa-fw menu-icon fa-history"></i> <span>Long-term data</span>
+                    <i class="fa fa-fw menu-icon fa-history"></i> <span>Long-term Data</span>
                     <span class="pull-right-container">
                       <i class="fa fa-angle-left pull-right"></i>
                     </span>
@@ -433,7 +456,7 @@ if($auth) {
                     </li>
                     <li<?php if($scriptname === "db_queries.php"){ ?> class="active"<?php } ?>>
                         <a href="db_queries.php">
-                            <i class="fa fa-fw menu-icon fa-file-alt"></i> Query Log
+                            <i class="fa fa-fwDNS Control menu-icon fa-file-alt"></i> Query Log
                         </a>
                     </li>
                     <li<?php if($scriptname === "db_lists.php"){ ?> class="active"<?php } ?>>
@@ -443,41 +466,33 @@ if($auth) {
                     </li>
                   </ul>
                 </li>
+                <li class="header text-uppercase">Group Management</li>
                 <!-- Group Management -->
-                <li class="treeview<?php if (in_array($scriptname, array("groups.php", "groups-adlists.php", "groups-clients.php", "groups-domains.php"))){ ?> active<?php } ?>">
-                  <a href="#">
-                    <i class="fa fa-fw menu-icon fa-users-cog"></i> <span>Group Management</span>
-                    <span class="pull-right-container">
-                      <i class="fa fa-angle-left pull-right"></i>
-                    </span>
-                  </a>
-                  <ul class="treeview-menu">
-                    <li<?php if($scriptname === "groups.php"){ ?> class="active"<?php } ?>>
-                        <a href="groups.php">
-                            <i class="fa fa-fw menu-icon fa-user-friends"></i> Groups
-                        </a>
-                    </li>
-                    <li<?php if($scriptname === "groups-clients.php"){ ?> class="active"<?php } ?>>
-                        <a href="groups-clients.php">
-                            <i class="fa fa-fw menu-icon fa-laptop"></i> Clients
-                        </a>
-                    </li>
-                    <li<?php if($scriptname === "groups-domains.php"){ ?> class="active"<?php } ?>>
-                        <a href="groups-domains.php">
-                            <i class="fa fa-fw menu-icon fa-list"></i> Domains
-                        </a>
-                    </li>
-                    <li<?php if($scriptname === "groups-adlists.php"){ ?> class="active"<?php } ?>>
-                        <a href="groups-adlists.php">
-                            <i class="fa fa-fw menu-icon fa-shield-alt"></i> Adlists
-                        </a>
-                    </li>
-                  </ul>
+                <li<?php if($scriptname === "groups.php"){ ?> class="active"<?php } ?>>
+                    <a href="groups.php">
+                        <i class="fa fa-fw menu-icon fa-user-friends"></i> Groups
+                    </a>
                 </li>
-                <!-- Toggle -->
+                <li<?php if($scriptname === "groups-clients.php"){ ?> class="active"<?php } ?>>
+                    <a href="groups-clients.php">
+                        <i class="fa fa-fw menu-icon fa-laptop"></i> Clients
+                    </a>
+                </li>
+                <li<?php if($scriptname === "groups-domains.php"){ ?> class="active"<?php } ?>>
+                    <a href="groups-domains.php">
+                        <i class="fa fa-fw menu-icon fa-list"></i> Domains
+                    </a>
+                </li>
+                <li<?php if($scriptname === "groups-adlists.php"){ ?> class="active"<?php } ?>>
+                    <a href="groups-adlists.php">
+                        <i class="fa fa-fw menu-icon fa-shield-alt"></i> Adlists
+                    </a>
+                </li>
+                <li class="header text-uppercase">DNS Control</li>
+                <!-- Enable/Disable Blocking -->
                 <li id="pihole-disable" class="treeview"<?php if ($pistatus == "0") { ?> hidden<?php } ?>>
                   <a href="#">
-                    <i class="fa fa-fw menu-icon fa-stop"></i> <span>Disable&nbsp;&nbsp;&nbsp;<span id="flip-status-disable"></span></span>
+                    <i class="fa fa-fw menu-icon fa-stop"></i> <span>Disable Blocking&nbsp;&nbsp;&nbsp;<span id="flip-status-disable"></span></span>
                     <span class="pull-right-container">
                       <i class="fa fa-angle-left pull-right"></i>
                     </span>
@@ -514,11 +529,33 @@ if($auth) {
                 <li id="pihole-enable" class="treeview"<?php if (!in_array($pistatus,["0","-1","-2"])) { ?> hidden<?php } ?>>
                     <a href="#">
                       <i class="fa fa-fw menu-icon fa-play"></i>
-                      <span id="enableLabel">Enable&nbsp;&nbsp;&nbsp;
+                      <span id="enableLabel">Enable Blocking&nbsp;&nbsp;&nbsp;
                         <span id="flip-status-enable"></span>
                       </span>
                     </a>
                 </li>
+                <!-- Local DNS Records -->
+                <li class="treeview <?php if(in_array($scriptname, array("dns_records.php", "cname_records.php"))){ ?>active<?php } ?>">
+                  <a href="#">
+                    <i class="fa fa-fw menu-icon fa-address-book"></i> <span>Local DNS</span>
+                    <span class="pull-right-container">
+                      <i class="fa fa-angle-left pull-right"></i>
+                    </span>
+                  </a>
+                  <ul class="treeview-menu">
+                    <li<?php if($scriptname === "dns_records.php"){ ?> class="active"<?php } ?>>
+                        <a href="dns_records.php">
+                            <i class="fa fa-fw menu-icon fa-address-book"></i> DNS Records
+                        </a>
+                    </li>
+                    <li<?php if($scriptname === "cname_records.php"){ ?> class="active"<?php } ?>>
+                        <a href="cname_records.php">
+                            <i class="fa fa-fw menu-icon fa-address-book"></i> CNAME Records
+                        </a>
+                    </li>
+                  </ul>
+                </li>
+                <li class="header text-uppercase">System</li>
                 <!-- Tools -->
                 <li class="treeview<?php if (in_array($scriptname, array("messages.php", "gravity.php", "queryads.php", "auditlog.php", "taillog.php", "taillog-FTL.php", "debug.php", "network.php"))){ ?> active<?php } ?>">
                   <a href="#">
@@ -606,58 +643,24 @@ if($auth) {
                         <i class="fa fa-fw menu-icon fa-cog"></i> <span>Settings</span>
                     </a>
                 </li>
-                <!-- Local DNS Records -->
-                <li class="treeview <?php if(in_array($scriptname, array("dns_records.php", "cname_records.php"))){ ?>active<?php } ?>">
-                  <a href="#">
-                    <i class="fa fa-fw menu-icon fa-address-book"></i> <span>Local DNS</span>
-                    <span class="pull-right-container">
-                      <i class="fa fa-angle-left pull-right"></i>
-                    </span>
-                  </a>
-                  <ul class="treeview-menu">
-                    <li<?php if($scriptname === "dns_records.php"){ ?> class="active"<?php } ?>>
-                        <a href="dns_records.php">
-                            <i class="fa fa-fw menu-icon fa-address-book"></i> DNS Records
-                        </a>
-                    </li>
-                    <li<?php if($scriptname === "cname_records.php"){ ?> class="active"<?php } ?>>
-                        <a href="cname_records.php">
-                            <i class="fa fa-fw menu-icon fa-address-book"></i> CNAME Records
-                        </a>
-                    </li>
-                  </ul>
-                </li>
-                <!-- Logout -->
-                <?php
-                // Show Logout button if $auth is set and authorization is required
-                if(strlen($pwhash) > 0) { ?>
-                <li>
-                    <a href="?logout">
-                        <i class="fa fa-fw menu-icon fa-sign-out-alt"></i> <span>Logout</span>
-                    </a>
-                </li>
                 <?php } ?>
-                <?php } ?>
-                <!-- Login -->
-                <?php
-                // Show Login button if $auth is *not* set and authorization is required
-                if(strlen($pwhash) > 0 && !$auth) { ?>
-                <li<?php if($scriptname === "login"){ ?> class="active"<?php } ?>>
-                    <a href="index.php?login">
-                        <i class="fa fa-fw menu-icon fa-user"></i> <span>Login</span>
-                    </a>
-                </li>
-                <?php } ?>
-                <!-- Donate -->
-                <li>
-                    <a href="https://pi-hole.net/donate/" rel="noopener" target="_blank">
-                        <i class="fas fa-fw menu-icon fa-donate"></i> <span>Donate</span>
-                    </a>
-                </li>
+                <li class="header text-uppercase">Support</li>
                  <!-- Docs -->
                  <li>
                     <a href="https://docs.pi-hole.net/" rel="noopener" target="_blank">
                         <i class="fa fa-fw menu-icon fa-question-circle"></i> <span>Documentation</span>
+                    </a>
+                </li>
+                <!-- Discourse -->
+                <li>
+                    <a href="https://discourse.pi-hole.net/" rel="noopener" target="_blank">
+                        <i class="fa fa-fw menu-icon fab fa-discourse"></i> <span>Pi-hole Forum</span>
+                    </a>
+                </li>
+                <!-- Donate -->
+                <li>
+                    <a href="https://pi-hole.net/donate/" rel="noopener" target="_blank">
+                        <i class="fas fa-fw menu-icon fa-donate"></i> <span>Donate</span>
                     </a>
                 </li>
             </ul>

--- a/style/themes/default-dark.css
+++ b/style/themes/default-dark.css
@@ -92,7 +92,7 @@ h4 {
   color: #fff;
 }
 .sidebar-menu > li.header {
-  color: rgb(173, 166, 156);
+  color: #8e989d;
   background-color: #1e2225;
 }
 .sidebar-menu > li > a {

--- a/style/themes/default-dark.css
+++ b/style/themes/default-dark.css
@@ -92,7 +92,7 @@ h4 {
   color: #fff;
 }
 .sidebar-menu > li.header {
-  color: #556068;
+  color: rgb(173, 166, 156);
   background-color: #1e2225;
 }
 .sidebar-menu > li > a {

--- a/style/themes/default-light.css
+++ b/style/themes/default-light.css
@@ -64,7 +64,7 @@
   color: #fff;
 }
 .sidebar-menu > li.header {
-  color: rgb(173, 166, 156);
+  color: #808a90;
   background-color: #1a2226;
 }
 .sidebar-menu > li > a {

--- a/style/themes/default-light.css
+++ b/style/themes/default-light.css
@@ -64,7 +64,7 @@
   color: #fff;
 }
 .sidebar-menu > li.header {
-  color: #4b646f;
+  color: rgb(173, 166, 156);
   background-color: #1a2226;
 }
 .sidebar-menu > li > a {


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

This PR removes the separate Black/Whitelist pages from the nav menu. They have been there to aid new users and to make the transition pre-v5 -> v5 more easy. It was always planed to remove them at some point.
They have been only a font-end for `groups-domais.php` where the `group` column was hidden.

The whole functionality can still be accessed via `Group Management` -> `Domains`. 

After removing the two entries the menu looked quite empty so I re-structured it a bit. Additional, added a link to our Discourse forum.


- **How does this PR accomplish the above?:**

Remove now unused code.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
