### PR TITLE
Specify record types at Local DNS records page

### DIFF
--- a/dns_records.php
+++ b/dns_records.php
@@ -12,7 +12,7 @@ require "scripts/pi-hole/php/header.php";
 
 <!-- Title -->
 <div class="page-header">
-    <h1>Local DNS Records</h1>
+    <h1>Local DNS Records [A/AAAA]</h1>
     <small>On this page, you can add domain/IP associations</small>
 </div>
 


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Small change on "Local DNS Records" to make it clear that both IPv4 and IPv6 addresses are supported.

![Bildschirmfoto zu 2022-07-26 09-10-21](https://user-images.githubusercontent.com/26622301/180945640-52315ac1-1331-4330-8d25-78938f16a955.png)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
