### PR TITLE
Fix enable/disable side menu buttons

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -435,3 +435,32 @@ if (isset($_GET['dns-port']) && $auth) {
         $data['dns-port'] = $return[0];
     }
 }
+
+// Returns an integer representing pihole blocking status
+if (isset($_GET['pihole-status']) && $auth) {
+    // Retrieve DNS Port calling FTL API directly
+    $port = callFTLAPI('dns-port');
+
+    // Retrieve FTL status
+    $FTLstats = callFTLAPI('stats');
+
+    if (array_key_exists('FTLnotrunning', $port) || array_key_exists('FTLnotrunning', $FTLstats)) {
+        // FTL is not running
+        $data['pihole-status'] = -1;
+    } elseif (in_array('status enabled', $FTLstats)) {
+        // FTL is enabled
+        if (intval($port[0]) <= 0) {
+            // Port=0; FTL is not listening
+            $data['pihole-status'] = -1;
+        } else {
+            // FTL is running on this port
+            $data['pihole-status'] = intval($port[0]);
+        }
+    } elseif (in_array('status disabled', $FTLstats)) {
+        // FTL is disabled
+        $data['pihole-status'] = 0;
+    } else {
+        // Unknown (unexpected) response
+        $data['pihole-status'] = -2;
+    }
+}

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -28,7 +28,6 @@ function countDown() {
   //Stop and remove timer when user enabled early
   if (ena.hasClass("hidden")) {
     enaLabel.text("Enable Blocking");
-    console.log("hidden");
     return;
   }
 
@@ -100,23 +99,22 @@ function updatePiholeStatus(once) {
     var ena = $("#pihole-enable");
     var dis = $("#pihole-disable");
     var restart = $("#pihole-restart");
-
     switch (true) {
-      case pistatus == 53:
+      case pistatus === 53:
         status.html("<i class='fa fa-w fa-circle text-green-light'></i> Active");
         ena.addClass("hidden");
         dis.removeClass("hidden");
         restart.addClass("hidden");
         break;
 
-      case pistatus == 0:
+      case pistatus === 0:
         status.html("<i class='fa fa-w fa-circle text-red'></i> Blocking disabled");
         dis.addClass("hidden");
         ena.removeClass("hidden");
         restart.addClass("hidden");
         break;
 
-      case pistatus == -1:
+      case pistatus === -1:
         status.html("<i class='fa fa-w fa-circle text-red'></i> DNS service not running");
         restart.removeClass("hidden");
         dis.addClass("hidden");

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -25,15 +25,18 @@ function piholeChanged(action) {
   switch (action) {
     case "enabled":
       status.html("<i class='fa fa-circle text-green-light'></i> Active");
-      ena.hide();
-      dis.show();
-      dis.removeClass("active");
+      ena.addClass("hidden");
+      dis.removeClass("hidden");
+
+      // close the "Disable Blocking" menu
+      dis.removeClass("menu-open");
+      dis[0].querySelector("ul").style.display = "none";
       break;
 
     case "disabled":
       status.html("<i class='fa fa-circle text-red'></i> Blocking disabled");
-      ena.show();
-      dis.hide();
+      dis.addClass("hidden");
+      ena.removeClass("hidden");
       break;
 
     default:

--- a/scripts/pi-hole/js/sidebar.js
+++ b/scripts/pi-hole/js/sidebar.js
@@ -1,0 +1,23 @@
+/* Pi-hole: A black hole for Internet advertisements
+ *  (c) 2022 Pi-hole, LLC (https://pi-hole.net)
+ *  Network-wide ad blocking via your own hardware.
+ *
+ *  This file is copyright under the latest version of the EUPL.
+ *  Please see LICENSE file for your rights under this license. */
+
+$(".confirm-restartftl").confirm({
+  text: "Are you sure you want to send a restart command to your DNS server?",
+  title: "Confirmation required",
+  confirm: function () {
+    $("#restartftlform").submit();
+  },
+  cancel: function () {
+    // nothing to do
+  },
+  confirmButton: "Yes, restart DNS",
+  cancelButton: "No, go back",
+  post: true,
+  confirmButtonClass: "btn-danger",
+  cancelButtonClass: "btn-success",
+  dialogClass: "modal-dialog",
+});

--- a/scripts/pi-hole/js/sidebar.js
+++ b/scripts/pi-hole/js/sidebar.js
@@ -4,6 +4,7 @@
  *
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
+/* global utils:false */
 
 $(".confirm-restartftl").confirm({
   text: "Are you sure you want to send a restart command to your DNS server?",

--- a/scripts/pi-hole/js/sidebar.js
+++ b/scripts/pi-hole/js/sidebar.js
@@ -4,7 +4,6 @@
  *
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
-/* global utils:false */
 
 $(".confirm-restartftl").confirm({
   text: "Are you sure you want to send a restart command to your DNS server?",

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -534,38 +534,6 @@ function JSON_warning($message = null)
     ));
 }
 
-// Returns an integer representing pihole blocking status
-function piholeStatus()
-{
-    // Retrieve DNS Port calling FTL API directly
-    $port = callFTLAPI('dns-port');
-
-    // Retrieve FTL status
-    $FTLstats = callFTLAPI('stats');
-
-    if (array_key_exists('FTLnotrunning', $port) || array_key_exists('FTLnotrunning', $FTLstats)) {
-        // FTL is not running
-        $ret = -1;
-    } elseif (in_array('status enabled', $FTLstats)) {
-        // FTL is enabled
-        if (intval($port[0]) <= 0) {
-            // Port=0; FTL is not listening
-            $ret = -1;
-        } else {
-            // FTL is running on this port
-            $ret = intval($port[0]);
-        }
-    } elseif (in_array('status disabled', $FTLstats)) {
-        // FTL is disabled
-        $ret = 0;
-    } else {
-        // Unknown (unexpected) response
-        $ret = -2;
-    }
-
-    return $ret;
-}
-
 // Returns the default gateway address and interface
 function getGateway()
 {

--- a/scripts/pi-hole/php/header_authenticated.php
+++ b/scripts/pi-hole/php/header_authenticated.php
@@ -154,10 +154,6 @@ if ($auth) {
 }
 ?>
 
-<!-- Send token to JS -->
-<div id="enableTimer" hidden><?php if (file_exists('../custom_disable_timer')) {
-    echo file_get_contents('../custom_disable_timer');
-} ?></div>
 <div class="wrapper">
     <header class="main-header">
         <!-- Logo -->

--- a/scripts/pi-hole/php/sidebar.php
+++ b/scripts/pi-hole/php/sidebar.php
@@ -262,7 +262,7 @@
                         </li>
                     </ul>
                 </li>
-                <!-- Settings -->class="
+                <!-- Settings -->
                 <li class="menu-system<?php if ($scriptname === 'settings.php') { ?> active<?php } ?>">
                     <a href="settings.php">
                         <i class="fa fa-fw menu-icon fa-cog"></i> <span>Settings</span>

--- a/scripts/pi-hole/php/sidebar.php
+++ b/scripts/pi-hole/php/sidebar.php
@@ -1,3 +1,8 @@
+    <!-- Send token to JS -->
+    <div id="enableTimer" hidden><?php if (file_exists('../custom_disable_timer')) {
+        echo file_get_contents('../custom_disable_timer');
+    } ?></div>
+
     <!-- Left side column. contains the logo and sidebar -->
     <aside class="main-sidebar">
         <!-- sidebar: style can be found in sidebar.less -->
@@ -9,57 +14,44 @@
                 </div>
                 <div class="pull-left info">
                     <p>Status</p>
-                    <?php
-                    $pistatus = piholeStatus();
-                    if ($pistatus == 53) {
-                        echo '<span id="status"><i class="fa fa-w fa-circle text-green-light"></i> Active</span>';
-                    } elseif ($pistatus == 0) {
-                        echo '<span id="status"><i class="fa fa-w fa-circle text-red"></i> Blocking disabled</span>';
-                    } elseif ($pistatus == -1) {
-                        echo '<span id="status"><i class="fa fa-w fa-circle text-red"></i> DNS service not running</span>';
-                    } elseif ($pistatus == -2) {
-                        echo '<span id="status"><i class="fa fa-w fa-circle text-red"></i> Unknown</span>';
-                    } else {
-                        echo '<span id="status"><i class="fa fa-w fa-circle text-orange"></i> DNS service on port '.$pistatus.'</span>';
-                    }
-                    ?>
+                    <span id="status"></span>
                     <br/>
                     <?php
                     echo '<span title="Detected '.$nproc.' cores"><i class="fa fa-w fa-circle ';
-                    if ($loaddata[0] > $nproc) {
-                        echo 'text-red';
-                    } else {
-                        echo 'text-green-light';
-                    }
-                    echo '"></i> Load:&nbsp;&nbsp;'.$loaddata[0].'&nbsp;&nbsp;'.$loaddata[1].'&nbsp;&nbsp;'.$loaddata[2].'</span>';
-                    ?>
+    if ($loaddata[0] > $nproc) {
+        echo 'text-red';
+    } else {
+        echo 'text-green-light';
+    }
+    echo '"></i> Load:&nbsp;&nbsp;'.$loaddata[0].'&nbsp;&nbsp;'.$loaddata[1].'&nbsp;&nbsp;'.$loaddata[2].'</span>';
+    ?>
                     <br/>
                     <?php
-                    echo '<span><i class="fa fa-w fa-circle ';
-                    if ($memory_usage > 0.75 || $memory_usage < 0.0) {
-                        echo 'text-red';
-                    } else {
-                        echo 'text-green-light';
-                    }
-                    if ($memory_usage > 0.0) {
-                        echo '"></i> Memory usage:&nbsp;&nbsp;'.sprintf('%.1f', 100.0 * $memory_usage).'&thinsp;%</span>';
-                    } else {
-                        echo '"></i> Memory usage:&nbsp;&nbsp; N/A</span>';
-                    }
-                    ?>
+    echo '<span><i class="fa fa-w fa-circle ';
+    if ($memory_usage > 0.75 || $memory_usage < 0.0) {
+        echo 'text-red';
+    } else {
+        echo 'text-green-light';
+    }
+    if ($memory_usage > 0.0) {
+        echo '"></i> Memory usage:&nbsp;&nbsp;'.sprintf('%.1f', 100.0 * $memory_usage).'&thinsp;%</span>';
+    } else {
+        echo '"></i> Memory usage:&nbsp;&nbsp; N/A</span>';
+    }
+    ?>
                     <br/>
                     <?php
-                    if ($celsius >= -273.15) {
-                        // Only show temp info if any data is available -->
-                        $tempcolor = 'text-vivid-blue';
-                        if (isset($temperaturelimit) && $celsius > $temperaturelimit) {
-                            $tempcolor = 'text-red';
-                        }
-                        echo '<span id="temperature"><i class="fa fa-w fa-fire '.$tempcolor.'" style="width: 1em !important"></i> ';
-                        echo 'Temp:&nbsp;<span id="rawtemp" hidden>'.$celsius.'</span>';
-                        echo '<span id="tempdisplay"></span></span>';
-                    }
-                    ?>
+    if ($celsius >= -273.15) {
+        // Only show temp info if any data is available -->
+        $tempcolor = 'text-vivid-blue';
+        if (isset($temperaturelimit) && $celsius > $temperaturelimit) {
+            $tempcolor = 'text-red';
+        }
+        echo '<span id="temperature"><i class="fa fa-w fa-fire '.$tempcolor.'" style="width: 1em !important"></i> ';
+        echo 'Temp:&nbsp;<span id="rawtemp" hidden>'.$celsius.'</span>';
+        echo '<span id="tempdisplay"></span></span>';
+    }
+    ?>
                 </div>
             </div>
             <!-- sidebar menu: : style can be found in sidebar.less -->
@@ -71,7 +63,6 @@
                         <i class="fa fa-fw menu-icon fa-home"></i> <span>Dashboard</span>
                     </a>
                 </li>
-
                 <li class="header text-uppercase">Analysis</li>
                 <!-- Query Log -->
                 <li class="menu-analysis<?php if ($scriptname === 'queries.php') { ?> active<?php } ?>">
@@ -132,7 +123,7 @@
                 <li class="header text-uppercase">DNS Control</li>
                 <!-- Local DNS Records -->
                 <!-- Enable/Disable Blocking -->
-                <li id="pihole-disable" class="menu-dns treeview<?php if ($pistatus <= 0) { ?> hidden<?php } ?>">
+                <li id="pihole-disable" class="menu-dns treeview">
                     <a href="#">
                         <i class="fa fa-fw menu-icon fa-stop"></i> <span>Disable Blocking&nbsp;&nbsp;&nbsp;<span id="flip-status-disable"></span></span>
                         <span class="pull-right-container">
@@ -168,7 +159,7 @@
                     </ul>
                     <!-- <a href="#" id="flip-status"><i class="fa fa-stop"></i> <span>Disable</span></a> -->
                 </li>
-                <li id="pihole-enable" class="menu-dns<?php if ($pistatus != 0) { ?> hidden<?php } ?>">
+                <li id="pihole-enable" class="menu-dns hidden">
                     <a href="#">
                         <i class="fa fa-fw menu-icon fa-play"></i>
                         <span id="enableLabel">Enable Blocking&nbsp;&nbsp;&nbsp;
@@ -177,7 +168,7 @@
                     </a>
                 </li>
                 <!-- Restart FTL -->
-                <li class="menu-dns<?php if (!in_array($pistatus, array('-1', '-2'))) { ?> hidden<?php } ?>">
+                <li id="pihole-restart" class="menu-dns hidden">
                     <a href="#" class="confirm-restartftl">
                         <i class="menu-icon fa fa-fw fa-sync"></i> <span>Restart DNS Resolver</span>
                     </a>
@@ -296,7 +287,7 @@ if (isset($_POST['field'])) {
         pihole_execute('-a restartdns');
     }
 }
-                    ?>
+    ?>
 
 <script src="scripts/vendor/jquery.confirm.min.js?v=<?php echo $cacheVer; ?>"></script>
 <script src="scripts/pi-hole/js/sidebar.js?v=<?php echo $cacheVer; ?>"></script>

--- a/scripts/pi-hole/php/sidebar.php
+++ b/scripts/pi-hole/php/sidebar.php
@@ -132,7 +132,7 @@
                 <li class="header text-uppercase">DNS Control</li>
                 <!-- Local DNS Records -->
                 <!-- Enable/Disable Blocking -->
-                <li id="pihole-disable" class="menu-dns treeview"<?php if ($pistatus == '0') { ?> hidden<?php } ?>>
+                <li id="pihole-disable" class="menu-dns treeview<?php if ($pistatus <= 0) { ?> hidden<?php } ?>">
                     <a href="#">
                         <i class="fa fa-fw menu-icon fa-stop"></i> <span>Disable Blocking&nbsp;&nbsp;&nbsp;<span id="flip-status-disable"></span></span>
                         <span class="pull-right-container">
@@ -168,7 +168,7 @@
                     </ul>
                     <!-- <a href="#" id="flip-status"><i class="fa fa-stop"></i> <span>Disable</span></a> -->
                 </li>
-                <li id="pihole-enable" class="menu-dns treeview"<?php if (!in_array($pistatus, array('0', '-1', '-2'))) { ?> hidden<?php } ?>>
+                <li id="pihole-enable" class="menu-dns<?php if ($pistatus != 0) { ?> hidden<?php } ?>">
                     <a href="#">
                         <i class="fa fa-fw menu-icon fa-play"></i>
                         <span id="enableLabel">Enable Blocking&nbsp;&nbsp;&nbsp;

--- a/scripts/pi-hole/php/sidebar.php
+++ b/scripts/pi-hole/php/sidebar.php
@@ -176,6 +176,16 @@
                         </span>
                     </a>
                 </li>
+                <!-- Restart FTL -->
+                <li class="menu-dns<?php if (!in_array($pistatus, array('-1', '-2'))) { ?> hidden<?php } ?>">
+                    <a href="#" class="confirm-restartftl">
+                        <i class="menu-icon fa fa-fw fa-sync"></i> <span>Restart DNS Resolver</span>
+                    </a>
+                <form role="form" method="post" id="restartftlform">
+                    <input type="hidden" name="field" value="restartftl">
+                </form>
+                </li>
+                <!-- Local DNS Records -->
                 <li class="menu-dns treeview <?php if (in_array($scriptname, array('dns_records.php', 'cname_records.php'))) { ?>active<?php } ?>">
                     <a href="#">
                         <i class="fa fa-fw menu-icon fa-address-book"></i> <span>Local DNS</span>
@@ -261,7 +271,7 @@
                         </li>
                     </ul>
                 </li>
-                <!-- Settings -->
+                <!-- Settings -->class="
                 <li class="menu-system<?php if ($scriptname === 'settings.php') { ?> active<?php } ?>">
                     <a href="settings.php">
                         <i class="fa fa-fw menu-icon fa-cog"></i> <span>Settings</span>
@@ -279,3 +289,15 @@
         </section>
         <!-- /.sidebar -->
     </aside>
+
+<?php
+if (isset($_POST['field'])) {
+    if ($_POST['field'] == 'restartftl') {
+        pihole_execute('-a restartdns');
+    }
+}
+                    ?>
+
+<script src="scripts/vendor/jquery.confirm.min.js?v=<?php echo $cacheVer; ?>"></script>
+<script src="scripts/pi-hole/js/sidebar.js?v=<?php echo $cacheVer; ?>"></script>
+


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Fixes the logic behind the "Enable/Disable" button in the side menu. So far, if `FTL` was not running (`$pistatus=-1`), both buttons were shown.

![Bildschirmfoto zu 2022-08-13 15-09-40](https://user-images.githubusercontent.com/26622301/184509973-718aad6d-6ba8-4d0f-aa6e-0d63b074965f.png)

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
