### PR TITLE
Supress update notice in the web interface if it is in docker

### DIFF
--- a/scripts/pi-hole/php/footer.php
+++ b/scripts/pi-hole/php/footer.php
@@ -91,26 +91,22 @@ $webReleasesUrl = $webUrl.'/releases';
                     <li>
                         <strong>Pi-hole</strong>
                         <a href="<?php echo $coreReleasesUrl.'/'.$core_current; ?>" rel="noopener" target="_blank"><?php echo $core_current; ?></a>
-                        <?php if ($core_update) { ?> &middot; <a class="lookatme" lookatme-text="Update available!" href="<?php echo $coreReleasesUrl.'/latest'; ?>" rel="noopener" target="_blank">Update available!</a><?php } ?>
+                        <?php if ($core_update && !$dockerTag) { ?> &middot; <a class="lookatme" lookatme-text="Update available!" href="<?php echo $coreReleasesUrl.'/latest'; ?>" rel="noopener" target="_blank">Update available!</a><?php } ?>
                     </li>
                     <li>
                         <strong>FTL</strong>
                         <a href="<?php echo $ftlReleasesUrl.'/'.$FTL_current; ?>" rel="noopener" target="_blank"><?php echo $FTL_current; ?></a>
-                        <?php if ($FTL_update) { ?> &middot; <a class="lookatme" lookatme-text="Update available!" href="<?php echo $ftlReleasesUrl.'/latest'; ?>" rel="noopener" target="_blank">Update available!</a><?php } ?>
+                        <?php if ($FTL_update && !$dockerTag) { ?> &middot; <a class="lookatme" lookatme-text="Update available!" href="<?php echo $ftlReleasesUrl.'/latest'; ?>" rel="noopener" target="_blank">Update available!</a><?php } ?>
                     </li>
                     <li>
                         <strong>Web Interface</strong>
                         <a href="<?php echo $webReleasesUrl.'/'.$web_current; ?>" rel="noopener" target="_blank"><?php echo $web_current; ?></a>
-                        <?php if ($web_update) { ?> &middot; <a class="lookatme" lookatme-text="Update available!" href="<?php echo $webReleasesUrl.'/latest'; ?>" rel="noopener" target="_blank">Update available!</a><?php } ?>
+                        <?php if ($web_update && !$dockerTag) { ?> &middot; <a class="lookatme" lookatme-text="Update available!" href="<?php echo $webReleasesUrl.'/latest'; ?>" rel="noopener" target="_blank">Update available!</a><?php } ?>
                     </li>
                 </ul>
-                <?php if ($core_update || $web_update || $FTL_update) { ?>
-                <?php if ($dockerTag) { ?>
-                    <p>To install updates, <a href="https://github.com/pi-hole/docker-pi-hole#upgrading-persistence-and-customizations" rel="noopener" target="_blank">replace this old container with a fresh upgraded image</a>.</p>
-                <?php } else { ?>
-                    <p>To install updates, run <code><a href="https://docs.pi-hole.net/main/update/" rel="noopener" target="_blank">pihole -up</a></code>.</p>
-                <?php } ?>
-                <?php } ?>
+                    <?php if (($core_update || $web_update || $FTL_update) && !$dockerTag) { ?>
+                        <p>To install updates, run <code><a href="https://docs.pi-hole.net/main/update/" rel="noopener" target="_blank">pihole -up</a></code>.</p>
+                    <?php } ?>
                 <?php } ?>
             </div>
         </div>


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

The latest docker image does not always have the latest versions of the Pi-hole components, which can lead to confusion:
 - https://discourse.pi-hole.net/t/updating-pihole-in-docker/57239/2
 - https://github.com/pi-hole/pi-hole/issues/4874

There is no need to show this flashing update notice on an Docker container.


Before: 

![image](https://user-images.githubusercontent.com/1998970/185807549-38cd4707-8e91-4d5a-8ffe-de94377a8e77.png)

After:

![image](https://user-images.githubusercontent.com/1998970/185807536-379ef8de-33e6-4274-9d23-1e73f3fda6be.png)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
