### PR TITLE
Revert empty domain dot replacement

### DIFF
--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -377,7 +377,15 @@ $(function () {
         $("td:eq(5)", row).append(" (" + (1000 * data[7]).toFixed(1) + "ms)");
       }
 
+      // Substitute domain by "." if empty
+      // This was introduced by https://github.com/pi-hole/AdminLTE/pull/1244 but is considered obsolete since
+      // https://github.com/pi-hole/FTL/pull/1413. However, we keep the conversion here to keep user's
+      // statistic accurat when they import older data with empty domain fields
       var domain = data[2];
+      if (domain.length === 0) {
+        domain = ".";
+      }
+
       $("td:eq(2)", row).text(domain);
     },
     dom:

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -377,12 +377,7 @@ $(function () {
         $("td:eq(5)", row).append(" (" + (1000 * data[7]).toFixed(1) + "ms)");
       }
 
-      // Substitute domain by "." if empty
       var domain = data[2];
-      if (domain.length === 0) {
-        domain = ".";
-      }
-
       $("td:eq(2)", row).text(domain);
     },
     dom:

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -703,7 +703,7 @@ function updateTopLists() {
     $("#ad-frequency td").parent().remove();
     var domaintable = $("#domain-frequency").find("tbody:last");
     var adtable = $("#ad-frequency").find("tbody:last");
-    var url, domain, percentage, urlText;
+    var url, domain, percentage;
     for (domain in data.top_queries) {
       if (Object.prototype.hasOwnProperty.call(data.top_queries, domain)) {
         // Sanitize domain
@@ -713,8 +713,7 @@ function updateTopLists() {
         }
 
         domain = utils.escapeHtml(domain);
-        urlText = domain === "" ? "." : domain;
-        url = '<a href="queries.php?domain=' + domain + '">' + urlText + "</a>";
+        url = '<a href="queries.php?domain=' + domain + '">' + domain + "</a>";
         percentage = (data.top_queries[domain] / data.dns_queries_today) * 100;
         domaintable.append(
           "<tr> " +
@@ -740,8 +739,7 @@ function updateTopLists() {
         }
 
         domain = utils.escapeHtml(domain);
-        urlText = domain === "" ? "." : domain;
-        url = '<a href="queries.php?domain=' + domain + '">' + urlText + "</a>";
+        url = '<a href="queries.php?domain=' + domain + '">' + domain + "</a>";
         percentage = (data.top_ads[domain] / data.ads_blocked_today) * 100;
         adtable.append(
           "<tr> " +

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -262,12 +262,7 @@ $(function () {
         $("td:eq(4)", row).addClass("text-underline pointer");
       }
 
-      // Substitute domain by "." if empty
       var domain = data[2];
-      if (domain.length === 0) {
-        domain = ".";
-      }
-
       if (isCNAME) {
         var CNAMEDomain = data[8];
         // Add domain in CNAME chain causing the query to have been blocked

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -12,6 +12,11 @@
 ini_set('pcre.recursion_limit', 1500);
 function validDomain($domain_name, &$message = null)
 {
+    // special handling of the root zone `.`
+    if ($domain_name == '.') {
+        return true;
+    }
+
     if (!preg_match('/^((-|_)*[a-z\\d]((-|_)*[a-z\\d])*(-|_)*)(\\.(-|_)*([a-z\\d]((-|_)*[a-z\\d])*))*$/i', $domain_name)) {
         if ($message !== null) {
             $message = 'it contains invalid characters';

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -510,11 +510,14 @@ if ($_POST['action'] == 'get_groups') {
             $res['groups'] = $groups;
             if ($res['type'] === ListType::whitelist || $res['type'] === ListType::blacklist) {
                 // Convert domain name to international form
-                $utf8_domain = convertIDNAToUnicode($res['domain']);
+                // Skip this for the root zone `.`
+                if ($res['domain'] != '.') {
+                    $utf8_domain = convertIDNAToUnicode($res['domain']);
 
-                // if domain and international form are different, show both
-                if ($res['domain'] !== $utf8_domain) {
-                    $res['domain'] = $utf8_domain.' ('.$res['domain'].')';
+                    // if domain and international form are different, show both
+                    if ($res['domain'] !== $utf8_domain) {
+                        $res['domain'] = $utf8_domain.' ('.$res['domain'].')';
+                    }
                 }
             }
             // Prevent domain and comment fields from returning any arbitrary javascript code which could be executed on the browser.
@@ -595,8 +598,10 @@ if ($_POST['action'] == 'get_groups') {
 
             $input = $domain;
             // Convert domain name to IDNA ASCII form for international domains
-            $domain = convertUnicodeToIDNA($domain);
-
+            // Skip this for the root zone `.`
+            if ($domain != '.') {
+                $domain = convertUnicodeToIDNA($domain);
+            }
             if ($_POST['type'] != '2' && $_POST['type'] != '3') {
                 // If not adding a RegEx, we convert the domain lower case and check whether it is valid
                 $domain = strtolower($domain);


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Reverts https://github.com/pi-hole/AdminLTE/pull/1244. This was introduced to replace "empty" domain strings with a dot (`.`). For historic reasons, `dnsmasq` strippes all trailing dots. If a query consists only of the dot (root zone), `FTL` has been seeing only an empty domain so far. FTL PR https://github.com/pi-hole/FTL/pull/1413 changes this behavior, therefore, the mock-up introduced by https://github.com/pi-hole/AdminLTE/pull/1244 is no longer needed.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
