### PR TITLE
Fix PHP warnings in docker (Complement of #2316)

### DIFF
--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -71,18 +71,27 @@ if (!is_readable($versionsfile)) {
         $docker_latest = '';
     }
 
+    $core_update = false;
+    $web_update = false;
+    $FTL_update = false;
+
     // Version comparison
-    $core_update = checkUpdate($core_current, $core_latest);
-    $web_update = checkUpdate($web_current, $web_latest);
-    $FTL_update = checkUpdate($FTL_current, $FTL_latest);
-    if (!$docker_current) {
+    if ($docker_current) {
+        // It's a container: do not check for individual component updates
+        if ($docker_current == 'nightly' || $docker_current == 'dev') {
+            // Special container - no update messages
+            $docker_update = false;
+        } else {
+            $docker_update = checkUpdate($docker_current, $docker_latest);
+        }
+    } else {
+        // Components comparison
+        $core_update = checkUpdate($core_current, $core_latest);
+        $web_update = checkUpdate($web_current, $web_latest);
+        $FTL_update = checkUpdate($FTL_current, $FTL_latest);
+
         // Not a docker container
         $docker_update = false;
-    } elseif ($docker_current == 'nightly' || $docker_current == 'dev') {
-        // Special container - no update messages
-        $docker_update = false;
-    } else {
-        $docker_update = checkUpdate($docker_current, $docker_latest);
     }
 }
 

--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -72,11 +72,11 @@ if (!is_readable($versionsfile)) {
     }
 
     // Version comparison
+    $core_update = checkUpdate($core_current, $core_latest);
+    $web_update = checkUpdate($web_current, $web_latest);
+    $FTL_update = checkUpdate($FTL_current, $FTL_latest);
     if (!$docker_current) {
         // Not a docker container
-        $core_update = checkUpdate($core_current, $core_latest);
-        $web_update = checkUpdate($web_current, $web_latest);
-        $FTL_update = checkUpdate($FTL_current, $FTL_latest);
         $docker_update = false;
     } elseif ($docker_current == 'nightly' || $docker_current == 'dev') {
         // Special container - no update messages


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Fix "undefined variable" PHP warnings in docker.
#2316 fixed the warnings for normal installs, but created warnings in docker.

### **How does this PR accomplish the above?:**

Always adding values for the variables.

### **What documentation changes (if any) are needed to support this PR?:**

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
