### PR TITLE
Remove unnecssary <br> from adlist details

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -89,7 +89,7 @@ function format(data) {
     (data.date_updated > 0
       ? utils.datetimeRelative(data.date_updated) +
         "&nbsp;(" +
-        utils.datetime(data.date_updated) +
+        utils.datetime(data.date_updated, false) +
         ")"
       : "N/A") +
     '</td></tr><tr class="dataTables-child"><td>Number of domains on this list:&nbsp;&nbsp;</td><td>' +


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Removes an unnecessary `<br>` between date and time in adlist details when on mobile.

- **How does this PR accomplish the above?:**

Set `false` flag in `utils.datetime` to remove the break.
https://github.com/pi-hole/AdminLTE/blob/1714b082c3a233ea3a0c344b50352c59818676fc/scripts/pi-hole/js/utils.js#L135-L137

Before:
![Bildschirmfoto zu 2022-09-01 07-21-01](https://user-images.githubusercontent.com/26622301/187838565-13856205-64c4-4348-a0d8-c883b5bdcbdf.png)

After:
![Bildschirmfoto zu 2022-09-01 07-23-56](https://user-images.githubusercontent.com/26622301/187838550-a8f22c1c-3aca-487d-b8eb-b5365a277054.png)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
