### PR TITLE
Add interpretation for Pi-hole message type ADLIST

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -10,6 +10,7 @@
 var table;
 var groups = [];
 var token = $("#token").text();
+var GETDict = {};
 
 function getGroups() {
   $.post(
@@ -24,6 +25,13 @@ function getGroups() {
 }
 
 $(function () {
+  window.location.search
+    .substr(1)
+    .split("&")
+    .forEach(function (item) {
+      GETDict[item.split("=")[0]] = item.split("=")[1];
+    });
+
   $("#btnAdd").on("click", addAdlist);
 
   utils.setBsSelectDefaults();
@@ -289,6 +297,11 @@ function initTable() {
 
       var applyBtn = "#btn_apply_" + data.id;
 
+      // Highlight row (if url parameter "adlistid=" is used)
+      if ("adlistid" in GETDict && data.id === parseInt(GETDict.adlistid, 10)) {
+        $(row).find("td").addClass("highlight");
+      }
+
       var button =
         '<button type="button" class="btn btn-danger btn-xs" id="deleteAdlist_' +
         data.id +
@@ -370,6 +383,18 @@ function initTable() {
       data.columns[0].visible = false;
       // Apply loaded state to table
       return data;
+    },
+    initComplete: function () {
+      if ("adlistid" in GETDict) {
+        var pos = table
+          .column(0, { order: "current" })
+          .data()
+          .indexOf(parseInt(GETDict.adlistid, 10));
+        if (pos >= 0) {
+          var page = Math.floor(pos / table.page.info().length);
+          table.page(page).draw(false);
+        }
+      }
     },
   });
 

--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -129,7 +129,7 @@ function renderMessage(data, type, row) {
     case "ADLIST":
       return (
         '<a href="groups-adlists.php?adlistid=' +
-        row.blob1 +
+        parseInt(row.blob1, 10) +
         '">' +
         "Adlist with ID " +
         parseInt(row.blob1, 10) +

--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -126,6 +126,19 @@ function renderMessage(data, type, row) {
         "</pre>"
       );
 
+    case "ADLIST":
+      return (
+        '<a href="groups-adlists.php?adlistid=' +
+        row.blob1 +
+        '">' +
+        "Adlist with ID " +
+        parseInt(row.blob1, 10) +
+        "</a> was inaccessible during last gravity run." +
+        "<pre>" +
+        utils.escapeHtml(row.message) +
+        "</pre>"
+      );
+
     default:
       return "Unknown message type<pre>" + JSON.stringify(row) + "</pre>";
   }


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

Accompany https://github.com/pi-hole/FTL/pull/1415.


- **How does this PR accomplish the above?:**

Adding code necessary to pretty-print `ADLIST` database messages.

Example:
![Bildschirmfoto zu 2022-09-01 09-02-16](https://user-images.githubusercontent.com/26622301/187852679-bce7a224-51dd-494c-9040-093ad03b8a08.png)

It also adds the code to link back to a specific `adlistid` by re-using code from https://github.com/pi-hole/AdminLTE/commit/a97f52ad768a77d151296a7fe60d41f0f0c67ebb


- **What documentation changes (if any) are needed to support this PR?:**

None


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
