### PR TITLE
Fix PHP warninigs + Show Docker tag for `nightly` and `dev`

### DIFF
--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -83,9 +83,6 @@ if (!is_readable($versionsfile)) {
             $docker_update = false;
         } else {
             $docker_update = checkUpdate($docker_current, $docker_latest);
-
-            $dockerUrl = 'https://github.com/pi-hole/docker-pi-hole/releases';
-            $dockerVersionStr = '<a href="'.$dockerUrl.'/'.$docker_current.'" rel="noopener" target="_blank">'.$docker_current.'</a>';
         }
     } else {
         // Components comparison
@@ -102,26 +99,30 @@ if (!is_readable($versionsfile)) {
 $coreUrl = 'https://github.com/pi-hole/pi-hole/releases';
 $webUrl = 'https://github.com/pi-hole/AdminLTE/releases';
 $ftlUrl = 'https://github.com/pi-hole/FTL/releases';
+$dockerUrl = 'https://github.com/pi-hole/docker-pi-hole/releases';
 
 // Version strings
 // If "vDev" show branch/commit, else show link
-$coreVersionStr = $core_current;
 if (isset($core_commit)) {
-    $coreVersionStr .= ' ('.$core_branch.', '.$core_commit.')';
+    $coreVersionStr = $core_current.' ('.$core_branch.', '.$core_commit.')';
 } else {
     $coreVersionStr = '<a href="'.$coreUrl.'/'.$core_current.'" rel="noopener" target="_blank">'.$core_current.'</a>';
 }
 
-$webVersionStr = $web_current;
 if (isset($web_commit)) {
-    $webVersionStr .= ' ('.$web_branch.', '.$web_commit.')';
+    $webVersionStr = $web_current.' ('.$web_branch.', '.$web_commit.')';
 } else {
     $webVersionStr = '<a href="'.$webUrl.'/'.$web_current.'" rel="noopener" target="_blank">'.$web_current.'</a>';
 }
 
-$ftlVersionStr = $FTL_current;
 if (isset($FTL_commit)) {
-    $ftlVersionStr .= ' ('.$FTL_branch.', '.$FTL_commit.')';
+    $ftlVersionStr = $FTL_current.' ('.$FTL_branch.', '.$FTL_commit.')';
 } else {
     $ftlVersionStr = '<a href="'.$ftlUrl.'/'.$FTL_current.'" rel="noopener" target="_blank">'.$FTL_current.'</a>';
+}
+
+if ($docker_current) {
+    $dockerVersionStr = '<a href="'.$dockerUrl.'/'.$docker_current.'" rel="noopener" target="_blank">'.$docker_current.'</a>';
+} else {
+    $dockerVersionStr = '';
 }


### PR DESCRIPTION
### What does this PR aim to accomplish?:

Fix #2328 

### How does this PR accomplish the above?:

- Show the Docker tag for every image, including `nightly` and `dev`.
- Always declare version strings, to avoid "Undefined variable" PHP warnings. 

### What documentation changes (if any) are needed to support this PR?:

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
