### PR TITLE
Add the ability to filter domains by type

### DIFF
--- a/groups-domains.php
+++ b/groups-domains.php
@@ -116,6 +116,20 @@ require 'scripts/pi-hole/php/header_authenticated.php';
             </div>
             <!-- /.box-header -->
             <div class="box-body">
+                <div class="row" id="filter_types_group">
+                    <div class="col-sm-12">
+                        <div class="filter_types">
+                            <div class="line">
+                                <span><input type="checkbox" name="typ" value="0" id="typ0" checked><label for="typ0">Exact whitelist</label></span>
+                                <span><input type="checkbox" name="typ" value="1" id="typ1" checked><label for="typ1">Exact blacklist</label></span>
+                            </div>
+                            <div class="line">
+                                <span><input type="checkbox" name="typ" value="2" id="typ2" checked><label for="typ2">Regex whitelist</label></span>
+                                <span><input type="checkbox" name="typ" value="3" id="typ3" checked><label for="typ3">Regex blacklist</label></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
                 <table id="domainsTable" class="table table-striped table-bordered" width="100%">
                     <thead>
                         <tr>

--- a/groups-domains.php
+++ b/groups-domains.php
@@ -116,10 +116,10 @@ require 'scripts/pi-hole/php/header_authenticated.php';
                 <div class="filter_types">
                     <div class="line">
                         <span><input type="checkbox" name="typ" value="0" id="typ0" checked><label for="typ0">Exact whitelist</label></span>
-                        <span><input type="checkbox" name="typ" value="1" id="typ1" checked><label for="typ1">Exact blacklist</label></span>
+                        <span><input type="checkbox" name="typ" value="2" id="typ2" checked><label for="typ2">Regex whitelist</label></span>
                     </div>
                     <div class="line">
-                        <span><input type="checkbox" name="typ" value="2" id="typ2" checked><label for="typ2">Regex whitelist</label></span>
+                        <span><input type="checkbox" name="typ" value="1" id="typ1" checked><label for="typ1">Exact blacklist</label></span>
                         <span><input type="checkbox" name="typ" value="3" id="typ3" checked><label for="typ3">Regex blacklist</label></span>
                     </div>
                 </div>

--- a/groups-domains.php
+++ b/groups-domains.php
@@ -113,23 +113,19 @@ require 'scripts/pi-hole/php/header_authenticated.php';
                 <h3 class="box-title">
                     List of domains
                 </h3>
+                <div class="filter_types">
+                    <div class="line">
+                        <span><input type="checkbox" name="typ" value="0" id="typ0" checked><label for="typ0">Exact whitelist</label></span>
+                        <span><input type="checkbox" name="typ" value="1" id="typ1" checked><label for="typ1">Exact blacklist</label></span>
+                    </div>
+                    <div class="line">
+                        <span><input type="checkbox" name="typ" value="2" id="typ2" checked><label for="typ2">Regex whitelist</label></span>
+                        <span><input type="checkbox" name="typ" value="3" id="typ3" checked><label for="typ3">Regex blacklist</label></span>
+                    </div>
+                </div>
             </div>
             <!-- /.box-header -->
             <div class="box-body">
-                <div class="row" id="filter_types_group">
-                    <div class="col-sm-12">
-                        <div class="filter_types">
-                            <div class="line">
-                                <span><input type="checkbox" name="typ" value="0" id="typ0" checked><label for="typ0">Exact whitelist</label></span>
-                                <span><input type="checkbox" name="typ" value="1" id="typ1" checked><label for="typ1">Exact blacklist</label></span>
-                            </div>
-                            <div class="line">
-                                <span><input type="checkbox" name="typ" value="2" id="typ2" checked><label for="typ2">Regex whitelist</label></span>
-                                <span><input type="checkbox" name="typ" value="3" id="typ3" checked><label for="typ3">Regex blacklist</label></span>
-                            </div>
-                        </div>
-                    </div>
-                </div>
                 <table id="domainsTable" class="table table-striped table-bordered" width="100%">
                     <thead>
                         <tr>

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -335,6 +335,7 @@ function initTable() {
     ],
     dom:
       "<'row'<'col-sm-6'l><'col-sm-6'f>>" +
+      "<'#filter'>" +
       "<'row'<'col-sm-3'B><'col-sm-9'p>>" +
       "<'row'<'col-sm-12'<'table-responsive'tr>>>" +
       "<'row'<'col-sm-3'B><'col-sm-9'p>>" +
@@ -383,6 +384,12 @@ function initTable() {
     input.setAttribute("spellcheck", false);
   }
 
+  table.on("init", function () {
+    // Put the type filter div into Datatables "DOM"
+    $("#filter").append($("#filter_types_group"));
+    $("#filter_types_group").show();
+  });
+
   table.on("init select deselect", function () {
     utils.changeBulkDeleteStates(table);
   });
@@ -401,6 +408,28 @@ function initTable() {
     $("#resetButton").addClass("hidden");
   });
 }
+
+// Enable "filter by type" functionality, using checkboxes
+$.fn.dataTable.ext.search.push(function (settings, searchData, index, rowData) {
+  var types = $(".filter_types input:checkbox:checked")
+    .map(function () {
+      return this.value;
+    })
+    .get();
+
+  if (types.length === 0) {
+    return true;
+  }
+
+  if (types.indexOf(rowData.type.toString()) !== -1) {
+    return true;
+  }
+
+  return false;
+});
+$(".filter_types input:checkbox").on("change", function () {
+  table.draw();
+});
 
 // Remove 'bnt-group' class from container, to avoid grouping
 $.fn.dataTable.Buttons.defaults.dom.container.className = "dt-buttons";

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -410,10 +410,6 @@ $.fn.dataTable.ext.search.push(function (settings, searchData, index, rowData) {
     })
     .get();
 
-  if (types.length === 0) {
-    return true;
-  }
-
   if (types.indexOf(rowData.type.toString()) !== -1) {
     return true;
   }

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -335,7 +335,6 @@ function initTable() {
     ],
     dom:
       "<'row'<'col-sm-6'l><'col-sm-6'f>>" +
-      "<'#filter'>" +
       "<'row'<'col-sm-3'B><'col-sm-9'p>>" +
       "<'row'<'col-sm-12'<'table-responsive'tr>>>" +
       "<'row'<'col-sm-3'B><'col-sm-9'p>>" +
@@ -383,12 +382,6 @@ function initTable() {
     input.setAttribute("autocapitalize", "off");
     input.setAttribute("spellcheck", false);
   }
-
-  table.on("init", function () {
-    // Put the type filter div into Datatables "DOM"
-    $("#filter").append($("#filter_types_group"));
-    $("#filter_types_group").show();
-  });
 
   table.on("init select deselect", function () {
     utils.changeBulkDeleteStates(table);

--- a/scripts/pi-hole/php/header_authenticated.php
+++ b/scripts/pi-hole/php/header_authenticated.php
@@ -137,7 +137,7 @@ $piholeFTLConf = piholeFTLConfig();
 
 require 'header.php';
 ?>
-<body class="hold-transition sidebar-mini<?php if ($boxedlayout) { ?> layout-boxed<?php } ?><?php if ($auth) { ?> logged-in<?php } ?>">
+<body class="<?php echo $theme; ?> hold-transition sidebar-mini<?php if ($boxedlayout) { ?> layout-boxed<?php } ?><?php if ($auth) { ?> logged-in<?php } ?>">
 <noscript>
     <!-- JS Warning -->
     <div>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -729,27 +729,39 @@ li:not(.menu-open) .treeview-menu .warning-count {
 }
 
 /* Domains table: filter by type */
-#filter_types_group {
-  display: none;
+#domains-list .box-header {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 5px 10px;
+}
+#domains-list .box-header h3 {
+  flex: 1 1 auto;
+  margin: 5px 0;
+  width: auto;
+  min-width: 130px;
 }
 .filter_types {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
+  margin: 5px auto;
 }
 .filter_types div {
   flex: 0 0 auto;
+  margin: 2px 0 0;
 }
 .filter_types span {
   display: inline-block;
-  margin: 10px;
+  margin: 0 0 2px 10px !important;
   width: 120px;
+  min-height: 1.2em;
 }
 
 /* Domains table: filter by type - smaller icheck */
 .filter_types .icheck-primary[class*="icheck-"] > label {
   padding-left: 1.5em !important;
   line-height: 1.2em;
+  min-height: 1.2em;
 }
 .filter_types
   .icheck-primary[class*="icheck-"]

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -758,27 +758,29 @@ li:not(.menu-open) .treeview-menu .warning-count {
 }
 
 /* Domains table: filter by type - smaller icheck */
-.filter_types .icheck-primary[class*="icheck-"] > label {
+body:not(.lcars) .filter_types [class*="icheck-"] > label {
   padding-left: 1.5em !important;
   line-height: 1.2em;
   min-height: 1.2em;
 }
-.filter_types
-  .icheck-primary[class*="icheck-"]
+body:not(.lcars)
+  .filter_types
+  [class*="icheck-"]
   > input:first-child
   + input[type="hidden"]
   + label::before,
-.filter_types .icheck-primary[class*="icheck-"] > input:first-child + label::before {
+body:not(.lcars) .filter_types [class*="icheck-"] > input:first-child + label::before {
   width: 1.2em;
   height: 1.2em;
   margin-left: -1.55em;
 }
-.filter_types
-  .icheck-primary[class*="icheck-"]
+body:not(.lcars)
+  .filter_types
+  [class*="icheck-"]
   > input:first-child:checked
   + input[type="hidden"]
   + label::after,
-.filter_types .icheck-primary[class*="icheck-"] > input:first-child:checked + label::after {
+body:not(.lcars) .filter_types [class*="icheck-"] > input:first-child:checked + label::after {
   width: 0.35em;
   height: 0.7em;
   top: -0.2em;

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -728,6 +728,51 @@ li:not(.menu-open) .treeview-menu .warning-count {
   }
 }
 
+/* Domains table: filter by type */
+#filter_types_group {
+  display: none;
+}
+.filter_types {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.filter_types div {
+  flex: 0 0 auto;
+}
+.filter_types span {
+  display: inline-block;
+  margin: 10px;
+  width: 120px;
+}
+
+/* Domains table: filter by type - smaller icheck */
+.filter_types .icheck-primary[class*="icheck-"] > label {
+  padding-left: 1.5em !important;
+  line-height: 1.2em;
+}
+.filter_types
+  .icheck-primary[class*="icheck-"]
+  > input:first-child
+  + input[type="hidden"]
+  + label::before,
+.filter_types .icheck-primary[class*="icheck-"] > input:first-child + label::before {
+  width: 1.2em;
+  height: 1.2em;
+  margin-left: -1.55em;
+}
+.filter_types
+  .icheck-primary[class*="icheck-"]
+  > input:first-child:checked
+  + input[type="hidden"]
+  + label::after,
+.filter_types .icheck-primary[class*="icheck-"] > input:first-child:checked + label::after {
+  width: 0.35em;
+  height: 0.7em;
+  top: -0.2em;
+  left: -0.18em;
+}
+
 /* reverse side menu collapse arrows when menu is closed */
 .sidebar-collapse .sidebar-toggle-svg svg {
   transform: scaleX(-1);

--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -1743,6 +1743,17 @@ table.dataTable {
   }
 }
 
+/* Domains table: filter by type */
+.filter_types span {
+  width: 132px;
+}
+[class*="icheck-"] > label {
+  color: var(--text-color);
+}
+[class*="icheck-"] > label:hover {
+  color: #cde !important;
+}
+
 /*** Used by the long-term pages ***/
 .daterangepicker {
   background-color: #345;


### PR DESCRIPTION
### What does this PR aim to accomplish?:

After a recent update, all domains are shown on the same page.

This PR adds the ability to filter domains by type, allowing turn on/off the visibility of:
- Exact whitelists;
- Exact blacklists;
- Regex whitelists;
- Regex blacklists.

### How does this PR accomplish the above?:

Adding a filter and checkboxes to control the filter. 

![image](https://user-images.githubusercontent.com/1385443/188782343-66bb007a-1102-46e8-89f1-5175e0485530.png)


### What documentation changes (if any) are needed to support this PR?:

none.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
