### PR TITLE
Do not apply IDNA conversion to RegEx domains

### DIFF
--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -596,14 +596,15 @@ if ($_POST['action'] == 'get_groups') {
                 continue;
             }
 
-            $input = $domain;
-            // Convert domain name to IDNA ASCII form for international domains
-            // Skip this for the root zone `.`
-            if ($domain != '.') {
-                $domain = convertUnicodeToIDNA($domain);
-            }
             if ($_POST['type'] != '2' && $_POST['type'] != '3') {
-                // If not adding a RegEx, we convert the domain lower case and check whether it is valid
+                // If not adding a RegEx....
+                $input = $domain;
+                // Convert domain name to IDNA ASCII form for international domains
+                // Skip this for the root zone `.`
+                if ($domain != '.') {
+                    $domain = convertUnicodeToIDNA($domain);
+                }
+                // convert the domain lower case and check whether it is valid
                 $domain = strtolower($domain);
                 $msg = '';
                 if (!validDomain($domain, $msg)) {


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/AdminLTE/issues/2335.

When adding domains to the database we do a `convertUnicodeToIDNA` before. However, this is not needed for RegEx and can instead lead to side effects seen in the linked issue. This PR moves the conversion into the already existing `if` clause that only triggers if **no** RegEx is added.

P.S. The used `PHP` function `idn_to_ascii` does not convert "invalid" domains  but instead returns `false` which will add an empty domain to the database

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
