### PR TITLE
Reverse logic of in/exlcuding queries from long-term database and rename queryType => statusType

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -78,14 +78,14 @@ if (isset($_GET['getAllQueries']) && $auth) {
         $dbquery .= ' WHERE timestamp >= :from AND timestamp <= :until ';
         if (isset($_GET['status'])) {
             // if some query status should be excluded
-            $status = $_GET['status'];
-            if (preg_match('/^[0-9]+(?:,[0-9]+)*$/', $status) === 1) {
+            $excludedStatus = $_GET['status'];
+            if (preg_match('/^[0-9]+(?:,[0-9]+)*$/', $excludedStatus) === 1) {
                 // Append selector to DB query. The used regex ensures
                 // that only numbers, separated by commas are accepted
                 // to avoid code injection and other malicious things
                 // We accept only valid lists like "1,2,3"
                 // We reject ",2,3", "1,2," and similar arguments
-                $dbquery .= 'AND status NOT IN ('.$status.') ';
+                $dbquery .= 'AND status NOT IN ('.$excludedStatus.') ';
             } else {
                 exit('Error. Selector status specified using an invalid format.');
             }

--- a/api_db.php
+++ b/api_db.php
@@ -76,17 +76,18 @@ if (isset($_GET['getAllQueries']) && $auth) {
         $dbquery .= ' status, reply_type, reply_time, dnssec';
         $dbquery .= ' FROM query_storage q';
         $dbquery .= ' WHERE timestamp >= :from AND timestamp <= :until ';
-        if (isset($_GET['types'])) {
-            $types = $_GET['types'];
-            if (preg_match('/^[0-9]+(?:,[0-9]+)*$/', $types) === 1) {
+        if (isset($_GET['status'])) {
+            // if some query status should be excluded
+            $status = $_GET['status'];
+            if (preg_match('/^[0-9]+(?:,[0-9]+)*$/', $status) === 1) {
                 // Append selector to DB query. The used regex ensures
                 // that only numbers, separated by commas are accepted
                 // to avoid code injection and other malicious things
                 // We accept only valid lists like "1,2,3"
                 // We reject ",2,3", "1,2," and similar arguments
-                $dbquery .= 'AND status IN ('.$types.') ';
+                $dbquery .= 'AND status NOT IN ('.$status.') ';
             } else {
-                exit('Error. Selector types specified using an invalid format.');
+                exit('Error. Selector status specified using an invalid format.');
             }
         }
         $dbquery .= 'ORDER BY timestamp ASC';

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -111,63 +111,63 @@ function handleAjaxError(xhr, textStatus) {
   tableApi.draw();
 }
 
-function getQueryTypes() {
-  var queryType = [];
-  if ($("#type_gravity").prop("checked")) {
-    queryType.push(1);
+function excludeStatusTypes() {
+  var statusType = [];
+  if ($("#type_gravity").prop("checked") === false) {
+    statusType.push(1);
   }
 
-  if ($("#type_forwarded").prop("checked")) {
-    queryType.push([2, 14]);
+  if ($("#type_forwarded").prop("checked") === false) {
+    statusType.push([2, 14]);
   }
 
-  if ($("#type_cached").prop("checked")) {
-    queryType.push(3);
+  if ($("#type_cached").prop("checked") === false) {
+    statusType.push(3);
   }
 
-  if ($("#type_regex").prop("checked")) {
-    queryType.push(4);
+  if ($("#type_regex").prop("checked") === false) {
+    statusType.push(4);
   }
 
-  if ($("#type_blacklist").prop("checked")) {
-    queryType.push(5);
+  if ($("#type_blacklist").prop("checked") === false) {
+    statusType.push(5);
   }
 
-  if ($("#type_external").prop("checked")) {
+  if ($("#type_external").prop("checked") === false) {
     // Multiple IDs correspond to this status
     // We request queries with all of them
-    queryType.push([6, 7, 8]);
+    statusType.push([6, 7, 8]);
   }
 
-  if ($("#type_gravity_CNAME").prop("checked")) {
-    queryType.push(9);
+  if ($("#type_gravity_CNAME").prop("checked") === false) {
+    statusType.push(9);
   }
 
-  if ($("#type_regex_CNAME").prop("checked")) {
-    queryType.push(10);
+  if ($("#type_regex_CNAME").prop("checked") === false) {
+    statusType.push(10);
   }
 
-  if ($("#type_blacklist_CNAME").prop("checked")) {
-    queryType.push(11);
+  if ($("#type_blacklist_CNAME").prop("checked") === false) {
+    statusType.push(11);
   }
 
-  if ($("#type_retried").prop("checked")) {
+  if ($("#type_retried").prop("checked") === false) {
     // Multiple IDs correspond to this status
     // We request queries with all of them
-    queryType.push([12, 13]);
+    statusType.push([12, 13]);
   }
 
   // 14 is defined above
 
-  if ($("#type_dbbusy").prop("checked")) {
-    queryType.push(15);
+  if ($("#type_dbbusy").prop("checked") === false) {
+    statusType.push(15);
   }
 
-  if ($("#type_special_domain").prop("checked")) {
-    queryType.push(16);
+  if ($("#type_special_domain").prop("checked") === false) {
+    statusType.push(16);
   }
 
-  return queryType.join(",");
+  return statusType.join(",");
 }
 
 var reloadCallback = function () {
@@ -203,10 +203,10 @@ function refreshTableData() {
   timeoutWarning.show();
   reloadBox.hide();
   var APIstring = "api_db.php?getAllQueries&from=" + from + "&until=" + until;
-  // Check if query type filtering is enabled
-  var queryType = getQueryTypes();
-  if (queryType !== "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16") {
-    APIstring += "&types=" + queryType;
+  // If status types should be excluded ("unchecked") we add them to the query
+  var statusType = excludeStatusTypes();
+  if (statusType.length > 0) {
+    APIstring += "&status=" + statusType;
   }
 
   statistics = [0, 0, 0];
@@ -218,11 +218,10 @@ $(function () {
     ? "api_db.php?getAllQueries&from=" + from + "&until=" + until
     : "api_db.php?getAllQueries=empty";
 
-  // Check if query type filtering is enabled
-  var queryType = getQueryTypes();
-  if (queryType !== 63) {
-    // 63 (0b00111111) = all possible query types are selected
-    APIstring += "&types=" + queryType;
+  // If status types should be excluded ("unchecked") we add them to the query
+  var statusType = excludeStatusTypes();
+  if (statusType.length > 0) {
+    APIstring += "&status=" + statusType;
   }
 
   tableApi = $("#all-queries").DataTable({


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

If users choose to deselect all "query" types (which are truly `status` types) on the long-term data page an PHP error occurs. The expected behavior is that no error occurs (and (very likely) no data is available).


- **How does this PR accomplish the above?:**

1) To match the documentation ([https://docs.pi-hole.net/database/ftl/#supported-status-types](https://docs.pi-hole.net/database/ftl/#supported-status-types)), everything related to "queryType" was renamed to "statusType".
2)  Instead of querying the the database for the selected statusTypes, this PR reverses the logic and excludes the unchecked statusTypes. This solved the mentioned issue with all unchecked boxes, but additionally allows to retrieve queries with a statusType not explicitly defined. If, for example a new statusType was added by `FTL` we had no chance to see this unless we explicitly added it to the selection. Now it will always be shown. 

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
