### PR TITLE
Use constants in place of class constants

### DIFF
--- a/api.php
+++ b/api.php
@@ -86,22 +86,22 @@ if (isset($_GET['enable']) && $auth) {
 
     switch ($_GET['list']) {
         case 'black':
-            $_POST['type'] = ListType::blacklist;
+            $_POST['type'] = LISTTYPE_BLACKLIST;
 
             break;
 
         case 'regex_black':
-            $_POST['type'] = ListType::regex_blacklist;
+            $_POST['type'] = LISTTYPE_REGEX_BLACKLIST;
 
             break;
 
         case 'white':
-            $_POST['type'] = ListType::whitelist;
+            $_POST['type'] = LISTTYPE_WHITELIST;
 
             break;
 
         case 'regex_white':
-            $_POST['type'] = ListType::regex_whitelist;
+            $_POST['type'] = LISTTYPE_REGEX_WHITELIST;
 
             break;
 

--- a/scripts/pi-hole/php/database.php
+++ b/scripts/pi-hole/php/database.php
@@ -7,6 +7,12 @@
 *    Please see LICENSE file for your rights under this license
 */
 
+// List Type Constants
+const LISTTYPE_WHITELIST = 0;
+const LISTTYPE_BLACKLIST = 1;
+const LISTTYPE_REGEX_WHITELIST = 2;
+const LISTTYPE_REGEX_BLACKLIST = 3;
+
 function getGravityDBFilename()
 {
     // Get possible non-standard location of FTL's database
@@ -277,14 +283,4 @@ function remove_from_table($db, $table, $domains, $returnnum = false, $type = -1
     }
 
     return 'Success, removed '.$num.' domain'.$plural;
-}
-
-if (!class_exists('ListType')) {
-    class ListType
-    {
-        public const whitelist = 0;
-        public const blacklist = 1;
-        public const regex_whitelist = 2;
-        public const regex_blacklist = 3;
-    }
 }

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -508,7 +508,7 @@ if ($_POST['action'] == 'get_groups') {
                 array_push($groups, $gres['group_id']);
             }
             $res['groups'] = $groups;
-            if ($res['type'] === ListType::whitelist || $res['type'] === ListType::blacklist) {
+            if ($res['type'] === LISTTYPE_WHITELIST || $res['type'] === LISTTYPE_BLACKLIST) {
                 // Convert domain name to international form
                 // Skip this for the root zone `.`
                 if ($res['domain'] != '.') {
@@ -571,9 +571,9 @@ if ($_POST['action'] == 'get_groups') {
         if (isset($_POST['type'])) {
             $type = intval($_POST['type']);
         } elseif (isset($_POST['list']) && $_POST['list'] === 'white') {
-            $type = ListType::whitelist;
+            $type = LISTTYPE_WHITELIST;
         } elseif (isset($_POST['list']) && $_POST['list'] === 'black') {
-            $type = ListType::blacklist;
+            $type = LISTTYPE_BLACKLIST;
         }
 
         if (!$insert_stmt->bindValue(':type', $type, SQLITE3_TEXT)

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -242,13 +242,13 @@ function archive_insert_into_table($file, $table, $flush = false, $wildcardstyle
     $type = null;
     if ($table === 'whitelist') {
         $table = 'domainlist';
-        $type = ListType::whitelist;
+        $type = LISTTYPE_WHITELIST;
     } elseif ($table === 'blacklist') {
         $table = 'domainlist';
-        $type = ListType::blacklist;
+        $type = LISTTYPE_BLACKLIST;
     } elseif ($table === 'regex_blacklist') {
         $table = 'domainlist';
-        $type = ListType::regex_blacklist;
+        $type = LISTTYPE_REGEX_BLACKLIST;
     } elseif ($table === 'domain_audit') {
         $table = 'domain_audit';
         $type = -1; // -1 -> not used inside add_to_table()
@@ -578,10 +578,10 @@ if (isset($_POST['action'])) {
         exit('cannot open/create '.htmlentities($archive_file_name)."<br>\nPHP user: ".exec('whoami')."\n");
     }
 
-    archive_add_table('whitelist.exact.json', 'domainlist', ListType::whitelist);
-    archive_add_table('whitelist.regex.json', 'domainlist', ListType::regex_whitelist);
-    archive_add_table('blacklist.exact.json', 'domainlist', ListType::blacklist);
-    archive_add_table('blacklist.regex.json', 'domainlist', ListType::regex_blacklist);
+    archive_add_table('whitelist.exact.json', 'domainlist', LISTTYPE_WHITELIST);
+    archive_add_table('whitelist.regex.json', 'domainlist', LISTTYPE_REGEX_WHITELIST);
+    archive_add_table('blacklist.exact.json', 'domainlist', LISTTYPE_BLACKLIST);
+    archive_add_table('blacklist.regex.json', 'domainlist', LISTTYPE_REGEX_BLACKLIST);
     archive_add_table('adlist.json', 'adlist');
     archive_add_table('domain_audit.json', 'domain_audit');
     archive_add_table('group.json', 'group');


### PR DESCRIPTION
### What does this PR aim to accomplish?:

Fix #2340 
Avoid the PHP Parse error when running a version < `PHP 7.1`.

### How does this PR accomplish the above?:

The previous code was declaring constants inside a class, but this class did nothing and its only purpose was to group some constants.
The new code simply use constants, in the global scope. 

### What documentation changes (if any) are needed to support this PR?:

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
