### PR TITLE
Avoid message warnings on Settings page, if session was already started

### DIFF
--- a/scripts/pi-hole/php/auth.php
+++ b/scripts/pi-hole/php/auth.php
@@ -101,7 +101,9 @@ function check_cors()
 function check_csrf($token)
 {
     // Start a new PHP session (or continue an existing one)
-    start_php_session();
+    if (session_status() != PHP_SESSION_ACTIVE) {
+        start_php_session();
+    }
 
     if (!isset($_SESSION['token'])) {
         log_and_die('Session expired! Please re-login on the Pi-hole dashboard.');


### PR DESCRIPTION
### What does this PR aim to accomplish?:

fix #2350

### How does this PR accomplish the above?:

This PR reintroduces a verification to avoid start a new session if the session was already started.

### What documentation changes (if any) are needed to support this PR?:

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
