### PR TITLE
Fix glitch of password manager button in dark themes (macOS Safari)

### DIFF
--- a/style/themes/default-dark.css
+++ b/style/themes/default-dark.css
@@ -554,9 +554,6 @@ fieldset[disabled] .form-control {
   background-color: #367fa9 !important;
   border: 1px solid #367fa9;
 }
-input[type="password"]::-webkit-credentials-auto-fill-button {
-  background: #bfc5ca;
-}
 input[type="password"]::-webkit-caps-lock-indicator {
   filter: invert(100%);
 }

--- a/style/themes/default-darker.css
+++ b/style/themes/default-darker.css
@@ -3653,9 +3653,6 @@ a:focus {
 .register-box-body .form-control-feedback {
   color: rgb(157, 148, 136);
 }
-input[type="password"]::-webkit-credentials-auto-fill-button {
-  background: #b1aca3;
-}
 input[type="password"]::-webkit-caps-lock-indicator {
   filter: invert(100%);
 }

--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -1853,10 +1853,6 @@ input[type="number"]::-webkit-outer-spin-button {
   margin: 0;
 }
 
-input[type="password"]::-webkit-credentials-auto-fill-button {
-  background: white;
-}
-
 input[type="password"]::-webkit-caps-lock-indicator {
   filter: invert(100%);
 }


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

This PR fixes a glitch with the password manager button in dark themes that affects macOS Safari.

 Before:
![before](https://user-images.githubusercontent.com/17005217/190380212-1694073b-e777-4720-a6cd-3c55e1e49038.png)

After:
![after](https://user-images.githubusercontent.com/17005217/190380229-017b143e-2692-4e99-9dc5-801d3b260a70.png)


- **How does this PR accomplish the above?:**

In #2020, a workaround was introduced to fix the appearance of the password manager button on dark backgrounds in macOS Safari. Apple has since fixed the issue. The workaround now breaks the button, so it has been removed.

(The workaround for the caps lock button also introduced in #2020 is still needed, and works fine.)

- **What documentation changes (if any) are needed to support this PR?:**

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
