### PR TITLE
Read DOCKER_VERSION from version file instead of env variable

### DIFF
--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -59,7 +59,11 @@ if (!is_readable($versionsfile)) {
     }
 
     // Get Pi-hole Docker Tag, if available
-    $docker_current = $versions['DOCKER_VERSION'];
+    if (isset($versions['DOCKER_VERSION'])) {
+        $docker_current = $versions['DOCKER_VERSION'];
+    } else {
+        $docker_current = '';
+    }
 
     // Get data from GitHub
     $core_latest = $versions['GITHUB_CORE_VERSION'];

--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -59,7 +59,7 @@ if (!is_readable($versionsfile)) {
     }
 
     // Get Pi-hole Docker Tag, if available
-    $docker_current = htmlspecialchars(getenv('PIHOLE_DOCKER_TAG'));
+    $docker_current = $versions['DOCKER_VERSION'];
 
     // Get data from GitHub
     $core_latest = $versions['GITHUB_CORE_VERSION'];


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

With https://github.com/pi-hole/pi-hole/pull/4913 we store the docker tag (if available) as `DOCKER_VERSION` in the `versions` file. This PR makes PHP reading `docker_current` from that file instead of using the passed env variable. This makes this assignment work in the same way we assign all the other `version` variables.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
