### PR TITLE
Avoid PHP warning in groups.php when adding a domain

### DIFF
--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -596,7 +596,7 @@ if ($_POST['action'] == 'get_groups') {
                 continue;
             }
 
-            if ($_POST['type'] != '2' && $_POST['type'] != '3') {
+            if (isset($_POST['type']) && $_POST['type'] != '2' && $_POST['type'] != '3') {
                 // If not adding a RegEx....
                 $input = $domain;
                 // Convert domain name to IDNA ASCII form for international domains


### PR DESCRIPTION
### What does this PR aim to accomplish?

When adding a domain from query log, a warning is generated by PHP because `$_POST["type"]` is not defined:
```
2022-09-17 02:07:33: mod_fastcgi.c.487) FastCGI-stderr:PHP Notice:  Undefined index: type in /var/www/html/admin/scripts/pi-hole/php/groups.php on line 599
2022-09-17 02:07:33: mod_fastcgi.c.487) FastCGI-stderr:PHP Notice:  Undefined index: type in /var/www/html/admin/scripts/pi-hole/php/groups.php on line 599
```

### How does this PR accomplish the above?

Adding a test to verify if the variable exists before trying to read it.

### What documentation changes (if any) are needed to support this PR?

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
