### PR TITLE
Allow the root zone `.` to be excluded from top lists

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -45,6 +45,10 @@ function validDomain($domain_name, &$message = null)
 
 function validDomainWildcard($domain_name)
 {
+    // Skip this checks for the root zone `.`
+    if ($domain_name == '.') {
+        return true;
+    }
     // There has to be either no or at most one "*" at the beginning of a line
     $validChars = preg_match('/^((\\*\\.)?[_a-z\\d](-*[_a-z\\d])*)(\\.([_a-z\\d](-*[a-z\\d])*))*(\\.([_a-z\\d])*)*$/i', $domain_name);
     $lengthCheck = preg_match('/^.{1,253}$/', $domain_name);


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Allows the root zone (`.`) to be excluded form the dashboard's top list. See discourse discussion here: https://discourse.pi-hole.net/t/root-zone-cant-be-excluded-from-the-top-lists/58043

In `savesettings.php` we check every domain with `validDomainWildcard` from `func.php`. This PR adds a bypass of those checks for the root zone.

https://github.com/pi-hole/AdminLTE/blob/b110eccceac2473697f8fac59e5de5d12c08c56e/scripts/pi-hole/php/savesettings.php#L365-L374

https://github.com/pi-hole/AdminLTE/blob/b110eccceac2473697f8fac59e5de5d12c08c56e/scripts/pi-hole/php/func.php#L46-L54

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
