### PR TITLE
Filter `$versions` values before print them on footer

### DIFF
--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -30,9 +30,6 @@ if (!is_readable($versionsfile)) {
 } else {
     $versions = parse_ini_file($versionsfile);
 
-    // Allow only valid characters
-    $versions = preg_replace('/[^[:alnum:]._:\/-]/i', '', $versions);
-
     // Get Pi-hole core branch / version / commit
     // Check if on a dev branch
     $core_branch = $versions['CORE_BRANCH'];
@@ -108,28 +105,28 @@ $webUrl = 'https://github.com/pi-hole/AdminLTE/releases';
 $ftlUrl = 'https://github.com/pi-hole/FTL/releases';
 $dockerUrl = 'https://github.com/pi-hole/docker-pi-hole/releases';
 
-// Version strings
+// Version strings (encoded to avoid code execution)
 // If "vDev" show branch/commit, else show link
 if (isset($core_commit)) {
-    $coreVersionStr = $core_current.' ('.$core_branch.', '.$core_commit.')';
+    $coreVersionStr = htmlentities($core_current.' ('.$core_branch.', '.$core_commit.')');
 } else {
-    $coreVersionStr = '<a href="'.$coreUrl.'/'.$core_current.'" rel="noopener" target="_blank">'.$core_current.'</a>';
+    $coreVersionStr = '<a href="'.$coreUrl.'/'.rawurlencode($core_current).'" rel="noopener" target="_blank">'.htmlentities($core_current).'</a>';
 }
 
 if (isset($web_commit)) {
-    $webVersionStr = $web_current.' ('.$web_branch.', '.$web_commit.')';
+    $webVersionStr = htmlentities($web_current.' ('.$web_branch.', '.$web_commit.')');
 } else {
-    $webVersionStr = '<a href="'.$webUrl.'/'.$web_current.'" rel="noopener" target="_blank">'.$web_current.'</a>';
+    $webVersionStr = '<a href="'.$webUrl.'/'.rawurlencode($web_current).'" rel="noopener" target="_blank">'.htmlentities($web_current).'</a>';
 }
 
 if (isset($FTL_commit)) {
-    $ftlVersionStr = $FTL_current.' ('.$FTL_branch.', '.$FTL_commit.')';
+    $ftlVersionStr = htmlentities($FTL_current.' ('.$FTL_branch.', '.$FTL_commit.')');
 } else {
-    $ftlVersionStr = '<a href="'.$ftlUrl.'/'.$FTL_current.'" rel="noopener" target="_blank">'.$FTL_current.'</a>';
+    $ftlVersionStr = '<a href="'.$ftlUrl.'/'.rawurlencode($FTL_current).'" rel="noopener" target="_blank">'.htmlentities($FTL_current).'</a>';
 }
 
 if ($docker_current) {
-    $dockerVersionStr = '<a href="'.$dockerUrl.'/'.$docker_current.'" rel="noopener" target="_blank">'.$docker_current.'</a>';
+    $dockerVersionStr = '<a href="'.$dockerUrl.'/'.rawurlencode($docker_current).'" rel="noopener" target="_blank">'.htmlentities($docker_current).'</a>';
 } else {
     $dockerVersionStr = '';
 }

--- a/scripts/pi-hole/php/update_checker.php
+++ b/scripts/pi-hole/php/update_checker.php
@@ -30,6 +30,9 @@ if (!is_readable($versionsfile)) {
 } else {
     $versions = parse_ini_file($versionsfile);
 
+    // Allow only valid characters
+    $versions = preg_replace('/[^[:alnum:]._:\/-]/i', '', $versions);
+
     // Get Pi-hole core branch / version / commit
     // Check if on a dev branch
     $core_branch = $versions['CORE_BRANCH'];


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix https://github.com/pi-hole/AdminLTE/issues/2367.
This assures no unwanted scripts could be passed to the browser, to avoid arbitrary code is injection. 

### How does this PR accomplish the above?

~~Allowing only a minimum set of characters for version/branch/commit values.
(Upper and lowercase letters, digits, dot, colon, dash, underscore and slash).~~

We decided to allow any strings on the file and encode the output before printing on HTML page.

### What documentation changes (if any) are needed to support this PR?

none

---

**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
