### PR TITLE
Get port number directly from `pihole-FTL.conf`

### DIFF
--- a/scripts/pi-hole/php/FTL.php
+++ b/scripts/pi-hole/php/FTL.php
@@ -10,7 +10,6 @@
 const DEFAULT_FTLCONFFILE = '/etc/pihole/pihole-FTL.conf';
 const DEFAULT_FTL_IP = '127.0.0.1';
 const DEFAULT_FTL_PORT = 4711;
-const DEFAULT_FTL_PORTFILE = '/run/pihole-FTL.port';
 
 function piholeFTLConfig($piholeFTLConfFile = DEFAULT_FTLCONFFILE, $force = false)
 {
@@ -29,18 +28,19 @@ function piholeFTLConfig($piholeFTLConfFile = DEFAULT_FTLCONFFILE, $force = fals
     return $piholeFTLConfig;
 }
 
-function connectFTL($address, $port)
+function connectFTL()
 {
-    if ($address == DEFAULT_FTL_IP) {
-        $config = piholeFTLConfig();
-        // Read port
-        $portfileName = isset($config['PORTFILE']) ? $config['PORTFILE'] : DEFAULT_FTL_PORTFILE;
-        if ($portfileName != '') {
-            $portfileContents = file_get_contents($portfileName);
-            if (is_numeric($portfileContents)) {
-                $port = intval($portfileContents);
-            }
-        }
+    // We only use the default IP
+    $address = DEFAULT_FTL_IP;
+
+    // Try to read port from FTL config. Use default if not found.
+    $config = piholeFTLConfig();
+
+    // Use the port only if the value is numeric
+    if (isset($config['FTLPORT']) && is_numeric($config['FTLPORT'])) {
+        $port = intval($config['FTLPORT']);
+    } else {
+        $port = DEFAULT_FTL_PORT;
     }
 
     // Open Internet socket connection
@@ -89,9 +89,9 @@ function disconnectFTL($socket)
     }
 }
 
-function callFTLAPI($request, $FTL_IP = DEFAULT_FTL_IP, $port = DEFAULT_FTL_PORT)
+function callFTLAPI($request)
 {
-    $socket = connectFTL($FTL_IP, $port);
+    $socket = connectFTL();
 
     if (!is_resource($socket)) {
         $data = array('FTLnotrunning' => true);


### PR DESCRIPTION
### What does this PR aim to accomplish?

This PR simplifies the method used get the port used by FTL.

Please read the details on https://github.com/pi-hole/FTL/pull/1445.

### How does this PR accomplish the above?

- Remove the old code using FTL portfile
- code simplification

### What documentation changes (if any) are needed to support this PR?

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
