### PR TITLE
Add 'edit' action to Custom DNS endpoint

### DIFF
--- a/api.php
+++ b/api.php
@@ -147,6 +147,11 @@ if (isset($_GET['enable']) && $auth) {
 
             break;
 
+        case 'edit':
+            $data = editCustomDNSEntry();
+
+            break;
+
         case 'delete':
             $data = deleteCustomDNSEntry();
 

--- a/scripts/pi-hole/php/customdns.php
+++ b/scripts/pi-hole/php/customdns.php
@@ -13,11 +13,14 @@ if (!isset($api)) {
     }
 }
 
-switch ($_POST['action']) {
+switch ($_REQUEST['action']) {
     case 'get':     echo json_encode(echoCustomDNSEntries());
         break;
 
     case 'add':     echo json_encode(addCustomDNSEntry());
+        break;
+
+    case 'edit': echo json_encode(editCustomDNSEntry());
         break;
 
     case 'delete':  echo json_encode(deleteCustomDNSEntry());

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -253,6 +253,52 @@ function addCustomDNSEntry($ip = '', $domain = '', $reload = '', $json = true)
     }
 }
 
+function editCustomDNSEntry($ip = '', $domain = '', $reload = '', $json = true)
+{
+    try {
+        $ip = !empty($_REQUEST['ip']) ? trim($_REQUEST['ip']) : $ip;
+        $domain = !empty($_REQUEST['domain']) ? trim($_REQUEST['domain']) : $domain;
+        $reload = !empty($_REQUEST['reload']) ? trim($_REQUEST['reload']) : $reload;
+
+        if (empty($ip)) {
+            return returnError('IP must be set', $json);
+        }
+
+        $ipType = get_ip_type($ip);
+
+        if (!$ipType) {
+            return returnError('IP must be valid', $json);
+        }
+
+        if (empty($domain)) {
+            return returnError('Domain must be set', $json);
+        }
+
+        if (!validDomain($domain)) {
+            return returnError('Domain must be valid', $json);
+        }
+
+        $existingEntries = getCustomDNSEntries();
+
+        foreach ($existingEntries as $entry) {
+            if ($entry->domain == $domain) {
+                $old_ip = $entry->ip;
+                break;
+            }
+        }
+
+        if (isset($old_ip)) {
+            pihole_execute('-a removecustomdns '.$old_ip.' '.$domain);
+        }
+
+        pihole_execute('-a addcustomdns '.$ip.' '.$domain.' '.$reload);
+
+        return returnSuccess('', $json);
+    } catch (\Exception $ex) {
+        return returnError($ex->getMessage(), $json);
+    }
+}
+
 function deleteCustomDNSEntry()
 {
     try {


### PR DESCRIPTION
- **What does this PR aim to accomplish?:**

This PR adds an 'edit' action to the custom DNS endpoint. The reason for this is to allow existing Dynamic DNS clients the ability to update the custom DNS records.

### Example use case
An individual has several devices on their local network. They have a Dynamic DNS client (Inadyn, ddclient, etc) installed on the devices to report their local IP to an external service so they can SSH to them easily. Currently, these DNS records become part of the public DNS records. The addresses for example could be 192.168.0.101-105. There are two downsides to having them listed as public DNS records, a) this exposes information about the individual's local network, and b) these addresses serve no purpose outside of the individual's local network. Pi Hole's Custom DNS entries are a solution for this, but the current implementation is not easy for Dynamic DNS clients to work with.

Before this commit the Dynamic DNS client would need to a) know the old IP address registered to the hostname to delete it, which is not something the current popular Dynamic DNS clients have easy access to, and b) make two API calls (one to delete and one to add the new entry). Most popular Dynamic DNS clients only have the option to hit one endpoint.

- **How does this PR accomplish the above?:**

I have extended the API to add a new 'edit' action, which can look up and delete the previous hostname entry (if it exists) and add the new one.

- **What documentation changes (if any) are needed to support this PR?:**

*Replace this with a detailed list of any necessary changes*

If there is documentation on the current API, please let me know where it is and I'll update it.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
