### PR TITLE
Fix line/area graph (broken after recent changes)

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -339,6 +339,19 @@ if (isset($_GET['getGraphData']) && $auth) {
             }
         }
 
+        // It is unpredictable what the first timestamp returned by the database will be.
+        // This depends on live data. The bar graph can handle "gaps", but the Area graph can't.
+        // Hence, we filling the "missing" timeslots with 0 to avoid wrong graphic render.
+        // (https://github.com/pi-hole/AdminLTE/pull/2374#issuecomment-1261865428)
+        $aligned_from = $from + (($first_db_timestamp - $from) % $interval);
+
+        // Fill gaps in returned data
+        for ($i = $aligned_from; $i < $until; $i += $interval) {
+            if (!array_key_exists($i, $data)) {
+                $data[$i] = 0;
+            }
+        }
+
         return $data;
     }
 

--- a/api_db.php
+++ b/api_db.php
@@ -324,7 +324,7 @@ if (isset($_GET['getGraphData']) && $auth) {
                 ELSE 0
             END) AS domains,
             SUM(CASE
-                WHEN status IN (1,4,5,6,7,8,9,10,11) THEN 1
+                WHEN status IN (1,4,5,6,7,8,9,10,11,15,16) THEN 1
                 ELSE 0
             END) AS blocked
         FROM queries

--- a/api_db.php
+++ b/api_db.php
@@ -332,7 +332,6 @@ if (isset($_GET['getGraphData']) && $auth) {
         GROUP BY interval
         ORDER BY interval";
 
-    // Count permitted queries in intervals
     $stmt = $db->prepare($sqlcommand);
     $stmt->bindValue(':from', $from, SQLITE3_INTEGER);
     $stmt->bindValue(':until', $until, SQLITE3_INTEGER);

--- a/api_db.php
+++ b/api_db.php
@@ -295,11 +295,11 @@ if (isset($_GET['getGraphData']) && $auth) {
     $limit = '';
 
     if (isset($_GET['from'], $_GET['until'])) {
-        $limit = ' AND timestamp >= :from AND timestamp <= :until';
+        $limit = 'timestamp >= :from AND timestamp <= :until';
     } elseif (isset($_GET['from']) && !isset($_GET['until'])) {
-        $limit = ' AND timestamp >= :from';
+        $limit = 'timestamp >= :from';
     } elseif (!isset($_GET['from']) && isset($_GET['until'])) {
-        $limit = ' AND timestamp <= :until';
+        $limit = 'timestamp <= :until';
     }
 
     $interval = 600;
@@ -315,8 +315,25 @@ if (isset($_GET['getGraphData']) && $auth) {
     $from = intval((intval($_GET['from']) / $interval) * $interval);
     $until = intval((intval($_GET['until']) / $interval) * $interval);
 
+    // Count domains and blocked queries using the same intervals
+    $sqlcommand = "
+        SELECT
+            (timestamp / :interval) * :interval AS interval,
+            SUM(CASE
+                WHEN status !=0 THEN 1
+                ELSE 0
+            END) AS domains,
+            SUM(CASE
+                WHEN status IN (1,4,5,6,7,8,9,10,11) THEN 1
+                ELSE 0
+            END) AS blocked
+        FROM queries
+        WHERE $limit
+        GROUP BY interval
+        ORDER BY interval";
+
     // Count permitted queries in intervals
-    $stmt = $db->prepare('SELECT (timestamp/:interval)*:interval interval, COUNT(*) FROM queries WHERE (status != 0 )'.$limit.' GROUP by interval ORDER by interval');
+    $stmt = $db->prepare($sqlcommand);
     $stmt->bindValue(':from', $from, SQLITE3_INTEGER);
     $stmt->bindValue(':until', $until, SQLITE3_INTEGER);
     $stmt->bindValue(':interval', $interval, SQLITE3_INTEGER);
@@ -325,14 +342,15 @@ if (isset($_GET['getGraphData']) && $auth) {
     // Parse the DB result into graph data, filling in missing interval sections with zero
     function parseDBData($results, $interval, $from, $until)
     {
-        $data = array();
+        $domains = array();
+        $blocked = array();
         $first_db_timestamp = -1;
 
         if (!is_bool($results)) {
             // Read in the data
             while ($row = $results->fetchArray()) {
-                // $data[timestamp] = value_in_this_interval
-                $data[$row[0]] = intval($row[1]);
+                $domains[$row['interval']] = intval($row['domains']);
+                $blocked[$row['interval']] = intval($row['blocked']);
                 if ($first_db_timestamp === -1) {
                     $first_db_timestamp = intval($row[0]);
                 }
@@ -347,30 +365,17 @@ if (isset($_GET['getGraphData']) && $auth) {
 
         // Fill gaps in returned data
         for ($i = $aligned_from; $i < $until; $i += $interval) {
-            if (!array_key_exists($i, $data)) {
-                $data[$i] = 0;
+            if (!array_key_exists($i, $domains)) {
+                $domains[$i] = 0;
+                $blocked[$i] = 0;
             }
         }
 
-        return $data;
+        return array('domains_over_time' => $domains, 'ads_over_time' => $blocked);
     }
 
-    $domains = parseDBData($results, $interval, $from, $until);
-
-    $result = array('domains_over_time' => $domains);
-    $data = array_merge($data, $result);
-
-    // Count blocked queries in intervals
-    $stmt = $db->prepare('SELECT (timestamp/:interval)*:interval interval, COUNT(*) FROM queries WHERE status IN (1,4,5,6,7,8,9,10,11)'.$limit.' GROUP by interval ORDER by interval');
-    $stmt->bindValue(':from', $from, SQLITE3_INTEGER);
-    $stmt->bindValue(':until', $until, SQLITE3_INTEGER);
-    $stmt->bindValue(':interval', $interval, SQLITE3_INTEGER);
-    $results = $stmt->execute();
-
-    $addomains = parseDBData($results, $interval, $from, $until);
-
-    $result = array('ads_over_time' => $addomains);
-    $data = array_merge($data, $result);
+    $over_time = parseDBData($results, $interval, $from, $until);
+    $data = array_merge($data, $over_time);
 }
 
 if (isset($_GET['status']) && $auth) {


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix 3 small issues:

- A recent optimization (#2374) broke the line graph in specific situations.
  Details: https://github.com/pi-hole/AdminLTE/pull/2374#issuecomment-1261865428

- Also, in some cases the 2 values (domains and blocked queries) were "out of sync", showing slightly different timestamps, possibly creating more bars than expected.

- Queries with status code equal 15 or 16 are not counted as blocked, but they should be, as noted by @yubiuser.

### How does this PR accomplish the above?

- Re-add the function to fill the "gaps" with zeros;
- Simplify SQL using a single query to retrieve both values (domains and blocked queries) using the exact same timestamps.
- Add queries with codes 15 or 16 to the blocked count. 

### What documentation changes (if any) are needed to support this PR?

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
