### PR TITLE
Fix position and size of the overlay spinner

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1011,3 +1011,13 @@ table.dataTable tbody > tr > .selected {
   line-height: 1;
   animation: 2s infinite Pulse steps(20);
 }
+
+/* Loading spinner (Dashboard and Long-term data) */
+.overlay .fa-spin {
+  position: relative;
+  opacity: 0.5;
+  font-size: 2.5em;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+}


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix position and size of the overlay spinner used on the dashboard and long-term data pages, while the page is loading data.

Context:
This was caused by a change almost 2 years ago, when SVG icons where introduced and it was never fixed (and probably never noticed until recently).

### How does this PR accomplish the above?

Adding a new CSS rule.

### What documentation changes (if any) are needed to support this PR?

none

---

**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
