### PR TITLE
Fix file pointer position if file was truncated

### DIFF
--- a/scripts/pi-hole/php/tailLog.php
+++ b/scripts/pi-hole/php/tailLog.php
@@ -43,6 +43,12 @@ if (!$file) {
 if (isset($_GET['offset'])) {
     $offset = intval($_GET['offset']);
     if ($offset > 0) {
+        // If offset is grater then current file end it means the file was truncated (log rotation)
+        fseek($file, 0, SEEK_END);
+        if ($offset > ftell($file)) {
+            $offset = 0;
+        }
+
         // Seeks on the file pointer where we want to continue reading is known
         fseek($file, $offset);
 


### PR DESCRIPTION
### What is the problem?

To ensure that the page always displays the most recent lines, the page first finds the end of the log and then starts reading new information from there.
Then while the page is kept open PHP will continue reading the new lines and will update the pointer.

The problem happens when `logrotate` truncates the file.
The pointer isn't updated and continues at the previous position, but there is no text to read at this position, so nothing is displayed.

The code continues to run without displaying anything until the file exceeds the previous file size (before rotation).

### How does this PR solves the problem?

Simple solution:
We need to check if the pointer is beyond the end of the file.
If it is, it means the file has been truncated and we need to read it from the beginning.

### What documentation changes (if any) are needed to support this PR?

none

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
