### PR TITLE
Don't show detailed doughnut tooltip if sum is > 99.9%

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -725,7 +725,13 @@ function updateSummaryData(runOnce) {
 
 function doughnutTooltip(tooltipLabel) {
   var percentageTotalShown = tooltipLabel.chart._metasets[0].total.toFixed(2);
+  // tooltipLabel.chart._metasets[0].total returns the total percentage of the shown slices
+  // to compensate rounding errors we round to two decimals
+
   var label = " " + tooltipLabel.label;
+
+  // even if no doughnut slice is hidden, sometimes percentageTotalShown is only 99.99
+  // we therefore use this value to decide if slices are hidden
   if (percentageTotalShown >= 99.99) {
     // All items shown
     return label + ": " + tooltipLabel.parsed.toFixed(1) + "%";

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -726,20 +726,24 @@ function updateSummaryData(runOnce) {
 function doughnutTooltip(tooltipLabel) {
   var percentageTotalShown = tooltipLabel.chart._metasets[0].total.toFixed(1);
   // tooltipLabel.chart._metasets[0].total returns the total percentage of the shown slices
-  // to compensate rounding errors we round to two one decimal
+  // to compensate rounding errors we round to one decimal
 
   var label = " " + tooltipLabel.label;
+  // in case the item share is really small it could be rounded to 0.0
+  // we compensate for this
+  var itemPercentage =
+    tooltipLabel.parsed.toFixed(1) === 0 ? "< 0.1" : tooltipLabel.parsed.toFixed(1);
 
   // even if no doughnut slice is hidden, sometimes percentageTotalShown is slightly less then 100
   // we therefore use 99.9 to decide if slices are hidden (we only show with 0.1 precision)
   if (percentageTotalShown > 99.9) {
     // All items shown
-    return label + ": " + tooltipLabel.parsed.toFixed(1) + "%";
+    return label + ": " + itemPercentage + "%";
   } else {
     return (
       label +
       ":<br>&bull; " +
-      tooltipLabel.parsed.toFixed(1) +
+      itemPercentage +
       "% of all queries<br>&bull; " +
       ((tooltipLabel.parsed * 100) / percentageTotalShown).toFixed(1) +
       "% of shown items"

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -726,8 +726,7 @@ function updateSummaryData(runOnce) {
 function doughnutTooltip(tooltipLabel) {
   var percentageTotalShown = tooltipLabel.chart._metasets[0].total.toFixed(2);
   var label = " " + tooltipLabel.label;
-
-  if (percentageTotalShown >= 100) {
+  if (percentageTotalShown >= 99.99) {
     // All items shown
     return label + ": " + tooltipLabel.parsed.toFixed(1) + "%";
   } else {

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -724,15 +724,15 @@ function updateSummaryData(runOnce) {
 }
 
 function doughnutTooltip(tooltipLabel) {
-  var percentageTotalShown = tooltipLabel.chart._metasets[0].total.toFixed(2);
+  var percentageTotalShown = tooltipLabel.chart._metasets[0].total.toFixed(1);
   // tooltipLabel.chart._metasets[0].total returns the total percentage of the shown slices
-  // to compensate rounding errors we round to two decimals
+  // to compensate rounding errors we round to two one decimal
 
   var label = " " + tooltipLabel.label;
 
-  // even if no doughnut slice is hidden, sometimes percentageTotalShown is only 99.99
-  // we therefore use this value to decide if slices are hidden
-  if (percentageTotalShown >= 99.99) {
+  // even if no doughnut slice is hidden, sometimes percentageTotalShown is slightly less then 100
+  // we therefore use 99.9 to decide if slices are hidden (we only show with 0.1 precision)
+  if (percentageTotalShown > 99.9) {
     // All items shown
     return label + ": " + tooltipLabel.parsed.toFixed(1) + "%";
   } else {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

To decide whether some slice of the doughnut chart is hidden, we use `.chart._metasets[0].total` which outputs the percentage of "total shown percent". If it was `>=100` we did not show the detailed doughnut tooltip.

However, even if no slice is hidden `.chart._metasets[0].total` returns percentages between `100.000000001` and `99.9799999`, in the latter case the detailed tooltip is shown despite nothing is hidden.
To compensate the rounding issue, this PR won't show the detailed tooltip if percentage is `> 99.9`.

Before:
![Screenshot at 2022-10-13 09-15-37](https://user-images.githubusercontent.com/26622301/195532264-fa34e6fb-520f-49a6-875b-0cb2f96ab22f.png)


After:
![Screenshot at 2022-10-13 09-28-10](https://user-images.githubusercontent.com/26622301/195532289-dd93b2eb-455b-4d24-b187-64ce32cdb521.png)

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
