### PR TITLE
Fix dropdown toggle z-index in LCARS theme

### DIFF
--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -504,7 +504,7 @@ p.login-box-msg,
 }
 
 .dropdown-toggle {
-  z-index: 2000;
+  z-index: 1050;
 }
 
 .main-header li.user-header {


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community! 

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**
 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions

---
- **What does this PR aim to accomplish?:**

This PR aims to fix a small CSS issue in the LCARS theme which causes dropdown toggle buttons to render on top of the actual dropdowns, which causes dropdowns to be nigh-unusable on pages which have multiple close-together dropdown toggles, such as Clients or Adlists.

Example from the Domains page:
![Pi-hole web interface domains tab, showing the dropdown for one domain's group assignment rendering underneath the toggle buttons for subsequent domains.](https://user-images.githubusercontent.com/32107308/196270344-a55d4fa8-d2b9-488f-87df-bec3665bf5cd.png)

- **How does this PR accomplish the above?:**

The z-index of the `.dropdown-toggle` selector was changed to be just below that of the dropdowns (selector `.bootstrap-select.bs-container .dropdown-menu` in `/styles/vendor/bootstrap-select.min.css`), so they render in the right order.


- **What documentation changes (if any) are needed to support this PR?:**

None


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
