### PR TITLE
Allow addding more than one local DNS/CNAME record

### DIFF
--- a/cname_records.php
+++ b/cname_records.php
@@ -32,7 +32,7 @@ require 'scripts/pi-hole/php/header_authenticated.php';
                 <div class="row">
                     <div class="form-group col-md-6">
                         <label for="domain">Domain:</label>
-                        <input id="domain" type="url" class="form-control" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                        <input id="domain" type="url" class="form-control" placeholder="Domain or comma-separated list of domains" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                     </div>
                     <div class="form-group col-md-6">
                         <label for="target">Target Domain:</label>

--- a/dns_records.php
+++ b/dns_records.php
@@ -32,7 +32,7 @@ require 'scripts/pi-hole/php/header_authenticated.php';
                 <div class="row">
                     <div class="form-group col-md-6">
                         <label for="domain">Domain:</label>
-                        <input id="domain" type="url" class="form-control" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                        <input id="domain" type="url" class="form-control" placeholder="Domain or comma-separated list of domains" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                     </div>
                     <div class="form-group col-md-6">
                         <label for="ip">IP Address:</label>

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -196,6 +196,7 @@ function getCustomDNSEntries()
             $data = new \stdClass();
             $data->ip = $explodedLine[0];
             $data->domain = $explodedLine[1];
+            $data->domains = array_slice($explodedLine, 0, -1);
             $entries[] = $data;
         }
 
@@ -234,22 +235,39 @@ function addCustomDNSEntry($ip = '', $domain = '', $reload = '', $json = true)
             return returnError('Domain must be set', $json);
         }
 
-        if (!validDomain($domain)) {
-            return returnError('Domain must be valid', $json);
+        $num = 0;
+        // Check if each submitted domain is valid
+        $domains = array_map('trim', explode(',', $domain));
+        foreach ($domains as $d) {
+            if (!validDomain($d)) {
+                return returnError("Domain '{$d}' is not valid", $json);
+            }
+            ++$num;
         }
 
         // Only check for duplicates if adding new records from the web UI (not through Teleporter)
         if (isset($_REQUEST['ip']) || isset($_REQUEST['domain'])) {
             $existingEntries = getCustomDNSEntries();
             foreach ($existingEntries as $entry) {
-                if ($entry->domain == $domain && get_ip_type($entry->ip) == $ipType) {
-                    return returnError('This domain already has a custom DNS entry for an IPv'.$ipType, $json);
+                foreach ($domains as $d) {
+                    if ($entry->domain == $d && get_ip_type($entry->ip) == $ipType) {
+                        return returnError("The domain {$d} already has a custom DNS entry for an IPv".$ipType, $json);
+                    }
                 }
             }
         }
 
-        // Add record
-        pihole_execute('-a addcustomdns '.$ip.' '.$domain.' '.$reload);
+        // if $reload is not set and more then one domain is supplied, restart FTL only once after all entries were added
+        if (($num > 0) && (empty($reload))) {
+            $reload = 'false';
+        }
+        // Add records
+        foreach ($domains as $domain) {
+            pihole_execute('-a addcustomdns '.$ip.' '.$domain.' '.$reload);
+        }
+        if ($num > 0) {
+            pihole_execute('restartdns');
+        }
 
         return returnSuccess('', $json);
     } catch (\Exception $ex) {
@@ -392,6 +410,7 @@ function addCustomCNAMEEntry($domain = '', $target = '', $reload = '', $json = t
             return returnError('Target must be valid', $json);
         }
 
+        $num = 0;
         $domains = array_map('trim', explode(',', $domain));
         foreach ($domains as $d) {
             // Check if each submitted domain is valid
@@ -403,6 +422,8 @@ function addCustomCNAMEEntry($domain = '', $target = '', $reload = '', $json = t
             if (strtolower($d) === strtolower($target)) {
                 return returnError('Domain and target cannot be the same', $json);
             }
+
+            ++$num;
         }
 
         $existingEntries = getCustomCNAMEEntries();
@@ -416,7 +437,18 @@ function addCustomCNAMEEntry($domain = '', $target = '', $reload = '', $json = t
             }
         }
 
-        pihole_execute('-a addcustomcname '.$domain.' '.$target.' '.$reload);
+        // if $reload is not set and more then one domain is supplied, restart FTL only once after all entries were added
+        if (($num > 0) && (empty($reload))) {
+            $reload = 'false';
+        }
+        // add records
+        foreach ($domains as $d) {
+            pihole_execute('-a addcustomcname '.$d.' '.$target.' '.$reload);
+        }
+
+        if ($num > 0) {
+            pihole_execute('restartdns');
+        }
 
         return returnSuccess('', $json);
     } catch (\Exception $ex) {


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Adds the ability to add multiple local DNS records/CNAMEs via web interface (comma-separated). The code for adding multiple CNAME records was written already, but missed the last step (a loop to add them) so only one record was added.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
