### PR TITLE
Set tooltip interaction mode for overtime graphs

### DIFF
--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -236,12 +236,15 @@ $(function () {
     },
     options: {
       responsive: true,
+      interaction: {
+        mode: 'nearest',
+        axis: 'x',
+      },
       plugins: {
         tooltip: {
           enabled: true,
           yAlign: "bottom",
           intersect: false,
-          mode: "x",
           itemSort: function (a, b) {
             return b.datasetIndex - a.datasetIndex;
           },

--- a/scripts/pi-hole/js/db_graph.js
+++ b/scripts/pi-hole/js/db_graph.js
@@ -237,8 +237,8 @@ $(function () {
     options: {
       responsive: true,
       interaction: {
-        mode: 'nearest',
-        axis: 'x',
+        mode: "nearest",
+        axis: "x",
       },
       plugins: {
         tooltip: {

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -864,6 +864,10 @@ $(function () {
     options: {
       responsive: true,
       maintainAspectRatio: false,
+      interaction: {
+        mode: 'nearest',
+        axis: 'x',
+      },
       plugins: {
         legend: {
           display: false,
@@ -871,7 +875,6 @@ $(function () {
         tooltip: {
           enabled: true,
           intersect: false,
-          mode: "x",
           yAlign: "bottom",
           itemSort: function (a, b) {
             return b.datasetIndex - a.datasetIndex;
@@ -972,6 +975,10 @@ $(function () {
       options: {
         responsive: true,
         maintainAspectRatio: false,
+        interaction: {
+          mode: 'nearest',
+          axis: 'x',
+        },
         plugins: {
           legend: {
             display: false,
@@ -980,7 +987,6 @@ $(function () {
             // Disable the on-canvas tooltip
             enabled: false,
             intersect: false,
-            mode: "x",
             external: customTooltips,
             yAlign: "top",
             itemSort: function (a, b) {

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -865,8 +865,8 @@ $(function () {
       responsive: true,
       maintainAspectRatio: false,
       interaction: {
-        mode: 'nearest',
-        axis: 'x',
+        mode: "nearest",
+        axis: "x",
       },
       plugins: {
         legend: {
@@ -976,8 +976,8 @@ $(function () {
         responsive: true,
         maintainAspectRatio: false,
         interaction: {
-          mode: 'nearest',
-          axis: 'x',
+          mode: "nearest",
+          axis: "x",
         },
         plugins: {
           legend: {


### PR DESCRIPTION
 **What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/AdminLTE/issues/2412.

When using the line graph style, multiple tooltips with partly doubled entries were shown for the same time slot. Setting the interaction mode to nearest (regarding the x-Axis) fixes the issue.

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
