### PR TITLE
Fix htmlentities() is called on already converted data on import

### DIFF
--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -193,7 +193,7 @@ function archive_restore_table($file, $table, $flush = false)
                 default:
                     $sqltype = 'UNK';
             }
-            $stmt->bindValue(':'.$key, htmlentities($value), $sqltype);
+            $stmt->bindValue(':'.$key, $value, $sqltype);
         }
 
         if ($stmt->execute() && $stmt->reset() && $stmt->clear()) {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

The data exported by the teleporter is already converted by the `htmlentities()` method before. Therefore, we do not need to call it again during import, otherwise some characters will be displayed incorrectly.

Example to reproduce this:

1. Add an entry to the adlist with e.g. `'abc'` as comment (don't forget the two single quotation marks)
2. Verify the following entry in the database (`adlist`) `&#039;abc&#039;`
3. Now export the `adlist` table via the teleporter. The JSON entry will also look like this `"&#039;abc&#039"`
4. Now import the `adlist.json` again
5. Verify the following entry in the database (`adlist`) `&amp;#039;abc&amp;#039;`
6. This is then displayed like this in the Web-UI: `&#039;abc&#039;` instead of `'abc'`, as the data got converted again on import via `htmlentities()`

**How does this PR accomplish the above?:**

Do not call `htmlenties()` on import as previously exported data is already converted with `htmlenties()`. You can check this also by checking the database.

`> sqlite3 gravity.db "SELECT * FROM adlist"`

**What documentation changes (if any) are needed to support this PR?:**

/


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
7. I have commented my proposed changes within the code and I have tested my changes.
8. I am willing to help maintain this change if there are issues with it later.
9. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
10. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
