### PR TITLE
Provide fake username on login form

### DIFF
--- a/login.php
+++ b/login.php
@@ -42,6 +42,8 @@ require 'scripts/pi-hole/php/header.php';
                 <form action="" id="loginform" method="post">
                     <div class="form-group login-options has-feedback<?php if ($wrongpassword) { ?> has-error<?php } ?>">
                         <div class="pwd-field">
+                            <!-- hidden username input field to help password managers to autfill the password -->
+                            <input type="text" id="username" value="pi.hole" autocomplete="username" hidden>
                             <input type="password" id="loginpw" name="pw" class="form-control" placeholder="Password" spellcheck="false" autocomplete="current-password" autofocus>
                             <span class="fa fa-key form-control-feedback"></span>
                         </div>

--- a/style/themes/default-dark.css
+++ b/style/themes/default-dark.css
@@ -504,6 +504,16 @@ div.dataTables_wrapper div.dataTables_length select {
   color: #bec5cb;
   border: 1px solid #3d444b;
 }
+
+/*** Overwrite chrome's input field auto-filling ***/
+input:-webkit-autofill,
+input:-webkit-autofill:focus,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+  -webkit-text-fill-color: #bec5cb !important;
+  -webkit-box-shadow: 0 0 0px 1000px #353c42 inset;
+  transition: background-color 1s ease-in-out 0s;
+}
 .form-control[disabled],
 .form-control[readonly],
 fieldset[disabled] .form-control {

--- a/style/themes/default-darker.css
+++ b/style/themes/default-darker.css
@@ -56,11 +56,15 @@ table {
   color: #b2aba1;
   opacity: 0.5 !important;
 }
+
+/*** Overwrite chrome's input field auto-filling ***/
 input:-webkit-autofill,
+input:-webkit-autofill:focus,
 textarea:-webkit-autofill,
 select:-webkit-autofill {
-  background-color: #555b00 !important;
-  color: #e8e6e3 !important;
+  -webkit-text-fill-color: #b2aba1 !important;
+  -webkit-box-shadow: 0 0 0px 1000px #181a1b inset;
+  transition: background-color 1s ease-in-out 0s;
 }
 ::-webkit-scrollbar {
   background-color: #202324;

--- a/style/themes/default-light.css
+++ b/style/themes/default-light.css
@@ -291,3 +291,13 @@ td.highlight {
   border-color: #337ab7;
   color: #fff;
 }
+
+/*** Overwrite chrome's input field auto-filling ***/
+input:-webkit-autofill,
+input:-webkit-autofill:focus,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+  -webkit-text-fill-color: #666 !important;
+  -webkit-box-shadow: 0 0 0px 1000px #fff inset;
+  transition: background-color 1s ease-in-out 0s;
+}

--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -285,6 +285,16 @@ div.dataTables_wrapper div.dataTables_length select {
   border-radius: 8px;
 }
 
+/*** Overwrite chrome's input field auto-filling ***/
+input:-webkit-autofill,
+input:-webkit-autofill:focus,
+textarea:-webkit-autofill,
+select:-webkit-autofill {
+  -webkit-text-fill-color: #fff !important;
+  -webkit-box-shadow: 0 0 0px 1000px #000 inset;
+  transition: background-color 1s ease-in-out 0s;
+}
+
 input.form-control,
 textarea.form-control {
   border-radius: 8px;


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When a password is set for the web interface, we use `autocomplete="current-password"` on the password login form to allow browsers and password managers to auto-fill the input field. This works well with e.g. Firefox, but fails on Chrome (see https://github.com/pi-hole/AdminLTE/issues/2418).
To fix this, we add a hidden input field providing a fake username (`pi.hole`).

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_
