### PR TITLE
Add stale cache query status

### DIFF
--- a/api_db.php
+++ b/api_db.php
@@ -192,7 +192,7 @@ if (isset($_GET['topDomains']) && $auth) {
         $limit = ' AND timestamp <= :until';
     }
     // Select top permitted domains only
-    $stmt = $db->prepare('SELECT domain,count(domain) FROM queries WHERE status IN (2,3,12,13,14)'.$limit.' GROUP by domain order by count(domain) desc limit 20');
+    $stmt = $db->prepare('SELECT domain,count(domain) FROM queries WHERE status IN (2,3,12,13,14,17)'.$limit.' GROUP by domain order by count(domain) desc limit 20');
     $stmt->bindValue(':from', intval($_GET['from']), SQLITE3_INTEGER);
     $stmt->bindValue(':until', intval($_GET['until']), SQLITE3_INTEGER);
     $results = $stmt->execute();

--- a/db_queries.php
+++ b/db_queries.php
@@ -49,6 +49,7 @@ require 'scripts/pi-hole/php/header_authenticated.php';
                         <div class="col-md-3">
                             <div><input type="checkbox" id="type_forwarded" checked><label for="type_forwarded">Permitted: forwarded</label><br></div>
                             <div><input type="checkbox" id="type_cached" checked><label for="type_cached">Permitted: cached</label></div>
+                            <div><input type="checkbox" id="type_cached" checked><label for="type_cached_stale">Permitted: stale cache</label></div>
                             <div><input type="checkbox" id="type_retried" checked><label for="type_retried">Permitted: retried</label></div>
                         </div>
                         <div class="col-md-3">

--- a/db_queries.php
+++ b/db_queries.php
@@ -49,7 +49,7 @@ require 'scripts/pi-hole/php/header_authenticated.php';
                         <div class="col-md-3">
                             <div><input type="checkbox" id="type_forwarded" checked><label for="type_forwarded">Permitted: forwarded</label><br></div>
                             <div><input type="checkbox" id="type_cached" checked><label for="type_cached">Permitted: cached</label></div>
-                            <div><input type="checkbox" id="type_cached" checked><label for="type_cached_stale">Permitted: stale cache</label></div>
+                            <div><input type="checkbox" id="type_cached_stale" checked><label for="type_cached_stale">Permitted: stale cache</label></div>
                             <div><input type="checkbox" id="type_retried" checked><label for="type_retried">Permitted: retried</label></div>
                         </div>
                         <div class="col-md-3">

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -180,7 +180,7 @@ var reloadCallback = function () {
   var data = tableApi.rows().data();
   for (var i = 0; i < data.length; i++) {
     statistics[0]++; // TOTAL query
-    if (data[i][4] === 1 || (data[i][4] > 4 && ![10, 12, 13, 14].includes(data[i][4]))) {
+    if (data[i][4] === 1 || (data[i][4] > 4 && ![10, 12, 13, 14, 17].includes(data[i][4]))) {
       statistics[2]++; // EXACT blocked
     } else if (data[i][4] === 3) {
       statistics[1]++; // CACHE query

--- a/scripts/pi-hole/js/db_queries.js
+++ b/scripts/pi-hole/js/db_queries.js
@@ -167,6 +167,10 @@ function excludeStatusTypes() {
     statusType.push(16);
   }
 
+  if ($("#type_cached_stale").prop("checked") === false) {
+    statusType.push(17);
+  }
+
   return statusType.join(",");
 }
 
@@ -348,6 +352,13 @@ $(function () {
           fieldtext =
             "<span class='text-orange'>Blocked <br class='hidden-lg'>(special domain)</span>";
           blocked = true;
+          break;
+        case 17:
+          fieldtext =
+            "<span class='text-orange'>OK</span> <br class='hidden-lg'>(stale cache)" +
+            dnssecStatus;
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
           break;
         default:
           fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -471,7 +471,7 @@ $(function () {
 
   $("#all-queries tbody").on("click", "button", function () {
     var data = tableApi.row($(this).parents("tr")).data();
-    if (data[4] === "2" || data[4] === "3" || data[4] === "14") {
+    if (data[4] === "2" || data[4] === "3" || data[4] === "14" || data[4] === "17") {
       utils.addFromQueryLog(data[2], "black");
     } else {
       utils.addFromQueryLog(data[2], "white");

--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -219,6 +219,13 @@ $(function () {
             "<span class='text-orange'>Blocked <br class='hidden-lg'>(special domain)</span>";
           blocked = true;
           break;
+        case "17":
+          fieldtext =
+            "<span class='text-orange'>OK</span> <br class='hidden-lg'>(stale cache)" +
+            dnssecStatus;
+          buttontext =
+            '<button type="button" class="btn btn-default btn-sm text-red"><i class="fa fa-ban"></i> Blacklist</button>';
+          break;
         default:
           fieldtext = "Unknown (" + parseInt(data[4], 10) + ")";
       }


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

See title

To be able to review this PR, you have to:
1. Run FTL on branch `update/dnsmasq` (https://github.com/pi-hole/FTL/pull/1469)
2. Add `use-stale-cache` to any of your `*.conf` files in `/etc/dnsmasq.d/`

An example of what you will see:

![Screenshot 2022-11-07 at 14-14-10 Pi-hole - ryzen](https://user-images.githubusercontent.com/16748619/200321494-02be7ad8-82a1-4a31-94d9-37fd47aec0f1.png)

The green box at the end shows the first queries to this domain (it is frequently queried as long as you have https://discourse.pi-hole.net/ open). Notice the almost 100 msec delay. This domain has a particularly small TTL making it an ideal test case for this.

Typically, once the query expired (orange box), it'd have to be forwarded again, causing an additional delay of (again) roughly 100ms until the reply arrived and can be forwarded to the client. However, with `use-stale-cache`, FTL instead *immediately* replies with the "old" data and does a lookup of this domain in the background (not logged). You see that subsequent queries are again served from cache as usual as the background lookup already succeeded. If it would not have arrived, FTL would again serve stale data from cache and retried the cache-refreshing lookup.

**How does this PR accomplish the above?:**

Add interpretation of the new query status 17

**Link documentation PRs if any are needed to support this PR:**

TBD

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
3. I have commented my proposed changes within the code and I have tested my changes.
4. I am willing to help maintain this change if there are issues with it later.
5. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
6. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
7. I have checked that another pull request for this purpose does not exist.
8. I have considered, and confirmed that this submission will be valuable to others.
9. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
10. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
