### PR TITLE
Fix doughnutTooltip if total percentage of shown slices is less than 0.1%

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -732,7 +732,7 @@ function doughnutTooltip(tooltipLabel) {
   // in case the item share is really small it could be rounded to 0.0
   // we compensate for this
   var itemPercentage =
-    tooltipLabel.parsed.toFixed(1) === 0 ? "< 0.1" : tooltipLabel.parsed.toFixed(1);
+    tooltipLabel.parsed.toFixed(1) === "0.0" ? "< 0.1" : tooltipLabel.parsed.toFixed(1);
 
   // even if no doughnut slice is hidden, sometimes percentageTotalShown is slightly less then 100
   // we therefore use 99.9 to decide if slices are hidden (we only show with 0.1 precision)
@@ -740,6 +740,9 @@ function doughnutTooltip(tooltipLabel) {
     // All items shown
     return label + ": " + itemPercentage + "%";
   } else {
+    // set percentageTotalShown again without rounding to account
+    // for cases where the total shown percentage would be <0.1% of all
+    percentageTotalShown = tooltipLabel.chart._metasets[0].total;
     return (
       label +
       ":<br>&bull; " +


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes an edge-case where users hide slices from the doughnut charts until the the total shown percentage is really small and we run into rounding errors. 
We round to `0.1%` here

https://github.com/pi-hole/AdminLTE/blob/da2764e58fa5fd3a17391ea7beac93c6b1509d20/scripts/pi-hole/js/index.js#L727

and use this as a base for calculating each slice's share

https://github.com/pi-hole/AdminLTE/blob/da2764e58fa5fd3a17391ea7beac93c6b1509d20/scripts/pi-hole/js/index.js#L748

When `percentageTotalShown` is really small, we run into rounding errors, seen in https://github.com/pi-hole/AdminLTE/issues/2433

To compensate, this PR uses the "raw" total percentage (without prior rounding) to calculate each slice's share and round afterwards.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
