### PR TITLE
Move rate-limiting from per-client to per-client-per-domain

### DIFF
--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -139,6 +139,19 @@ function renderMessage(data, type, row) {
         "</pre>"
       );
 
+    case "DOMAIN_RATE_LIMIT":
+      return (
+        "Client " +
+        utils.escapeHtml(row.blob1) +
+        " has been rate-limited for domain " +
+        utils.escapeHtml(row.message) +
+        " (current config allows up to " +
+        parseInt(row.blob2, 10) +
+        " queries per client and domain in " +
+        parseInt(row.blob3, 10) +
+        " seconds)"
+      );
+
     default:
       return "Unknown message type<pre>" + JSON.stringify(row) + "</pre>";
   }


### PR DESCRIPTION
# What does this implement/fix?

Handle new message type `DOMAIN_RATE_LIMIT`

**Related issue or feature (if applicable):** https://github.com/pi-hole/FTL/pull/1468

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A for this change

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.