### PR TITLE
Better alert messages for DHCP Static Lease editing

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -48,23 +48,27 @@ if (isset($_POST['submit'])) {
 }
 ?>
 
+<script>
 <?php if (strlen($success) > 0) { ?>
-    <div id="alInfo" class="alert alert-info alert-dismissible fade in" role="alert">
-        <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span>
-        </button>
-        <h4><i class="icon fa fa-info"></i> Info</h4>
-        <?php echo $success; ?>
-    </div>
+    $.notify({
+        icon: "fas fa-check-circle",
+        title: "<b>Success</b><br>",
+        message: "<?php echo $success; ?>"
+    }, {
+        type: "success"
+    });
 <?php } ?>
 
 <?php if (strlen($error) > 0) { ?>
-    <div id="alError" class="alert alert-danger alert-dismissible fade in" role="alert">
-        <button type="button" class="close" data-hide="alert" aria-label="Close"><span aria-hidden="true">&times;</span>
-        </button>
-        <h4><i class="icon fa fa-ban"></i> Error</h4>
-        <?php echo $error; ?>
-    </div>
+    $.notify({
+        icon: "fas fa-times-circle",
+        title: "<b>Error</b><br>",
+        message: "<?php echo $error; ?>"
+    }, {
+        type: "error"
+    });
 <?php } ?>
+</script>
 
 <?php
 if (isset($setupVars['PIHOLE_INTERFACE'])) {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix https://github.com/pi-hole/AdminLTE/issues/2445

**How does this PR accomplish the above?:**

Changing how the Static DHCP Leases are handled.

Currently, clicking on the add or delete buttons triggers a HTML form POST. This action always reloads the page.
Creating an `ajax` call via javascript will avoid the reload and will allow the use of the `utils.showAlert()` function (or something similar).
To achieve this, the code to Add and Delete static leases will need to be moved from `savesettings.php` to `api.php`.
2 new endpoints will be created on `api.php`. 

Warning:
I didn't have time to finish this PR yet. The current code is incomplete.
 
**Link documentation PRs if any are needed to support this PR:**
none

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review.