### PR TITLE
Update PHPStan

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,14 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3.1.0
-    - name: Change PHP version
-      run: |
-        sudo update-alternatives --set php /usr/bin/php8.0
-        sudo update-alternatives --set phar /usr/bin/phar8.0
-        sudo update-alternatives --set phpdbg /usr/bin/phpdbg8.0
-        sudo update-alternatives --set php-cgi /usr/bin/php-cgi8.0
-        sudo update-alternatives --set phar.phar /usr/bin/phar.phar8.0
-        php -version
     - name: Validate composer.json and composer.lock
       run: composer validate
     - name: Cache Composer packages

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,18 +9,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3.1.0
-    - name: Validate composer.json and composer.lock
-      run: composer validate
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v3.0.11
+
+    - name: Install composer
+      uses: php-actions/composer@v6
+
+    - name: Run PHPStan
+      uses: php-actions/phpstan@v3
       with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
-    - name: Install dependencies
-      if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
-    - name: Run phpstan
-      run: composer run-script phpstan
+        configuration: phpstan.neon.dist
+        memory_limit: 256M
+

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Pi-hole Dashboard for stats and more",
     "require": {
         "php": ">=5.4",
-        "phpstan/phpstan": "^0.12.42"
+        "phpstan/phpstan": "1.*"
     },
     "license": "EUPL-1.2",
     "minimum-stability": "stable",
@@ -12,8 +12,5 @@
         "files": [
             "scripts/vendor/qrcode.php"
         ]
-    },
-    "scripts": {
-        "phpstan": "vendor/phpstan/phpstan/phpstan analyse -c phpstan.neon.dist"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,6 @@
 parameters:
     level: 0
-    excludes_analyse:
+    excludePaths:
         - vendor
     scanDirectories:
         - .


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

We've been using `phpstan` natively  in our github workflows. In order to make it work, we needed to set a fixed `php` version (introduced by  https://github.com/pi-hole/AdminLTE/pull/2007). This broke recently, as `ubuntu-latest` as GH runner updated to `22.04` which ships with `php 8.1` instead of `8.0`.
To avoid using updating the action with every new `ubuntu` release, I switched the workflow to use this `phpstan` action: 
https://github.com/php-actions/phpstan

It will continue to use our configuration at `phpstan.neon.dist`. The option`excludes_analyse` is deprecated and replaced with `excludePaths`.

Side note: I updated the `phpstan` version in `composer.json` from `^0.12.42` to `^1*`. The `composer.lock` is not updated yet, but I'll add `composer` as environment to `dependabot` so it should update this as well in the next run.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
