### PR TITLE
Fix z-index of .dropdown-toggle

### DIFF
--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -514,7 +514,7 @@ p.login-box-msg,
 }
 
 .dropdown-toggle {
-  z-index: 1050;
+  z-index: 1000;
 }
 
 .main-header li.user-header {


### PR DESCRIPTION
A recent fix seemed to improve this but by going a bit further it seems to resolve the problem where the dropdown-toggle buttons would appear over alert messages.

Signed-off-by: infinitytec <infinitytec@users.noreply.github.com>

## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

This PR fixes some z-index issues with the .dropdown-toggle buttons that causes them to appear over pop-up alerts in the LCARS theme.

It is difficult to get a screenshot due to the brief visibility of the alert.

**How does this PR accomplish the above?:**

I further adjusted the z-index like was done in #2405 

**Link documentation PRs if any are needed to support this PR:**

None.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
