### PR TITLE
Do not return 'false' if IDNA<->UNICODE conversion fails

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -640,7 +640,7 @@ function getGateway()
 }
 
 // Try to convert possible IDNA domain to Unicode
-function convertIDNAToUnicode($unicode)
+function convertIDNAToUnicode($IDNA)
 {
     if (extension_loaded('intl')) {
         // we try the UTS #46 standard first
@@ -652,32 +652,42 @@ function convertIDNAToUnicode($unicode)
             // to ensure sparkasse-gießen.de is not converted into
             // sparkass-giessen.de but into xn--sparkasse-gieen-2ib.de
             // as mandated by the UTS #46 standard
-            $unicode = idn_to_utf8($unicode, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+            $unicode = idn_to_utf8($IDNA, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
         } elseif (defined('INTL_IDNA_VARIANT_2003')) {
             // If conversion failed, try with the (deprecated!) IDNA 2003 variant
             // We have to check for its existence as support of this variant is
             // scheduled for removal with PHP 8.0
             // see https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003
-            $unicode = idn_to_utf8($unicode, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
+            $unicode = idn_to_utf8($IDNA, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
         }
     }
 
-    return $unicode;
+    // if the conversion failed (e.g. domain to long) return the original domain
+    if ($unicode == false) {
+        return $IDNA;
+    } else {
+        return $unicode;
+    }
 }
 
 // Convert a given (unicode) domain to IDNA ASCII
-function convertUnicodeToIDNA($IDNA)
+function convertUnicodeToIDNA($unicode)
 {
     if (extension_loaded('intl')) {
         // Be prepared that this may fail and see our comments about convertIDNAToUnicode()
         if (defined('INTL_IDNA_VARIANT_UTS46')) {
-            $IDNA = idn_to_ascii($IDNA, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
+            $IDNA = idn_to_ascii($unicode, IDNA_NONTRANSITIONAL_TO_ASCII, INTL_IDNA_VARIANT_UTS46);
         } elseif (defined('INTL_IDNA_VARIANT_2003')) {
-            $IDNA = idn_to_ascii($IDNA, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
+            $IDNA = idn_to_ascii($unicode, IDNA_DEFAULT, INTL_IDNA_VARIANT_2003);
         }
     }
 
-    return $IDNA;
+    // if the conversion failed (e.g. domain to long) return the original domain
+    if ($IDNA == false) {
+        return $unicode;
+    } else {
+        return $IDNA;
+    }
 }
 
 // Return PID of FTL (used in settings.php)

--- a/scripts/pi-hole/php/groups.php
+++ b/scripts/pi-hole/php/groups.php
@@ -510,14 +510,11 @@ if ($_POST['action'] == 'get_groups') {
             $res['groups'] = $groups;
             if ($res['type'] === LISTTYPE_WHITELIST || $res['type'] === LISTTYPE_BLACKLIST) {
                 // Convert domain name to international form
-                // Skip this for the root zone `.`
-                if ($res['domain'] != '.') {
-                    $utf8_domain = convertIDNAToUnicode($res['domain']);
+                $utf8_domain = convertIDNAToUnicode($res['domain']);
 
-                    // if domain and international form are different, show both
-                    if ($res['domain'] !== $utf8_domain) {
-                        $res['domain'] = $utf8_domain.' ('.$res['domain'].')';
-                    }
+                // if domain and international form are different, show both
+                if ($res['domain'] !== $utf8_domain) {
+                    $res['domain'] = $utf8_domain.' ('.$res['domain'].')';
                 }
             }
             // Prevent domain and comment fields from returning any arbitrary javascript code which could be executed on the browser.
@@ -600,10 +597,7 @@ if ($_POST['action'] == 'get_groups') {
                 // If not adding a RegEx....
                 $input = $domain;
                 // Convert domain name to IDNA ASCII form for international domains
-                // Skip this for the root zone `.`
-                if ($domain != '.') {
-                    $domain = convertUnicodeToIDNA($domain);
-                }
+                $domain = convertUnicodeToIDNA($domain);
                 // convert the domain lower case and check whether it is valid
                 $domain = strtolower($domain);
                 $msg = '';


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When we try `IDNA` to unicode conversion (or vice versa) the functions fails if the entered string is not a valid domain (e.g. to  long).

https://github.com/pi-hole/AdminLTE/blob/ad2d43869e9ad97cc3a8c5afc6fefec0e142a972/scripts/pi-hole/php/func.php#L629-L666

However, we usually immediately check the returned string right after conversion for validity and return a meaningful error message.

https://github.com/pi-hole/AdminLTE/blob/ad2d43869e9ad97cc3a8c5afc6fefec0e142a972/scripts/pi-hole/php/func.php#L13-L43

The issue occurs, when the conversion fails and no domain is entering `validDomain()`: it will always fail with the first (negative) matching test ("invalid characters") even if the reason is another one (e.g. too long domain). 
(This can be simply tested by trying to add a blacklist entry with one label >63 chars)

This PR mitigates the issue by checking if the conversion failed and returning the **non-converted** string. 

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
