### PR TITLE
Adding option to show all results for queryads

### DIFF
--- a/queryads.php
+++ b/queryads.php
@@ -17,7 +17,7 @@ require 'scripts/pi-hole/php/header_authenticated.php';
 <div class="row">
     <div class="col-md-12">
         <div class="box">
-            <div class="box-body">
+            <div class="box-header">
                 <!-- domain-search-block - Single search field mobile/desktop -->
                 <div id="domain-search-block" class="input-group">
                     <input id="domain" type="url" class="form-control" placeholder="Domain to look for (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
@@ -27,7 +27,13 @@ require 'scripts/pi-hole/php/header_authenticated.php';
                         <button type="button" id="btnSearchExact" class="btn btn-default">Search exact match</button>
                     </span>
                 </div>
+            </div>
+            <div class="box-body">
                 <!-- /domain-search-block -->
+                <div id="limitbox-block">
+                    <input type="checkbox" id="show-all">
+                    <label for="show-all"><strong>Show unlimited results.</strong> <br class="hidden-md hidden-lg">This can be very slow if too many domains are returned. <span class="text-red">Use with caution</span>.</label></i>
+                </div>
             </div>
         </div>
     </div>

--- a/scripts/pi-hole/js/queryads.js
+++ b/scripts/pi-hole/js/queryads.js
@@ -6,6 +6,7 @@
  *  Please see LICENSE file for your rights under this license. */
 
 var exact = "";
+var showAll = "";
 
 function quietfilter(ta, data) {
   var lines = data.split("\n");
@@ -22,8 +23,9 @@ function quietfilter(ta, data) {
 function eventsource() {
   var ta = $("#output");
   // process with the current visible domain input field
-  var domain = $("input[id^='domain']:visible").val().trim();
+  var domain = $("input[id^='domain']:visible").val().trim().toLowerCase();
   var q = $("#quiet");
+  var unlimited = $("#show-all").is(":checked");
 
   if (domain.length === 0) {
     return;
@@ -32,14 +34,20 @@ function eventsource() {
   var quiet = false;
   if (q.val() === "yes") {
     quiet = true;
-    exact = "exact";
+    exact = "&exact";
   }
+
+  if (unlimited === true) {
+    showAll = "&showall";
+  }
+
+  var queryURL = "scripts/pi-hole/php/queryads.php?domain=" + domain + exact + showAll;
 
   // IE does not support EventSource - load whole content at once
   if (typeof EventSource !== "function") {
     $.ajax({
       method: "GET",
-      url: "scripts/pi-hole/php/queryads.php?domain=" + domain.toLowerCase() + "&" + exact + "&IE",
+      url: queryURL + "&IE",
       async: false,
     }).done(function (data) {
       ta.show();
@@ -53,9 +61,7 @@ function eventsource() {
     return;
   }
 
-  var source = new EventSource(
-    "scripts/pi-hole/php/queryads.php?domain=" + domain.toLowerCase() + "&" + exact
-  );
+  var source = new EventSource(queryURL);
 
   // Reset and show field
   ta.empty();
@@ -82,8 +88,9 @@ function eventsource() {
     false
   );
 
-  // Reset exact variable
+  // Reset option variables
   exact = "";
+  showAll = "";
 }
 
 // Handle enter key
@@ -100,7 +107,7 @@ $("button[id^='btnSearch']").on("click", function () {
   exact = "";
 
   if (this.id.match("^btnSearchExact")) {
-    exact = "exact";
+    exact = "&exact";
   }
 
   eventsource();

--- a/scripts/pi-hole/js/queryads.js
+++ b/scripts/pi-hole/js/queryads.js
@@ -8,33 +8,14 @@
 var exact = "";
 var showAll = "";
 
-function quietfilter(ta, data) {
-  var lines = data.split("\n");
-  for (var i = 0; i < lines.length; i++) {
-    if (lines[i].indexOf("results") !== -1 && lines[i].indexOf("0 results") === -1) {
-      var shortstring = lines[i].replace("::: /etc/pihole/", "");
-      // Remove "(x results)"
-      shortstring = shortstring.replace(/\(.*/, "");
-      ta.append(shortstring + "\n");
-    }
-  }
-}
-
 function eventsource() {
   var ta = $("#output");
   // process with the current visible domain input field
   var domain = $("input[id^='domain']:visible").val().trim().toLowerCase();
-  var q = $("#quiet");
   var unlimited = $("#show-all").is(":checked");
 
   if (domain.length === 0) {
     return;
-  }
-
-  var quiet = false;
-  if (q.val() === "yes") {
-    quiet = true;
-    exact = "&exact";
   }
 
   if (unlimited === true) {
@@ -52,11 +33,7 @@ function eventsource() {
     }).done(function (data) {
       ta.show();
       ta.empty();
-      if (!quiet) {
-        ta.append(data);
-      } else {
-        quietfilter(ta, data);
-      }
+      ta.append(data);
     });
     return;
   }
@@ -70,11 +47,7 @@ function eventsource() {
   source.addEventListener(
     "message",
     function (e) {
-      if (!quiet) {
-        ta.append(e.data);
-      } else {
-        quietfilter(ta, e.data);
-      }
+      ta.append(e.data);
     },
     false
   );

--- a/scripts/pi-hole/php/queryads.php
+++ b/scripts/pi-hole/php/queryads.php
@@ -25,10 +25,12 @@ header('Cache-Control: no-cache');
 function echoEvent($datatext)
 {
     if (!isset($_GET['IE'])) {
-        echo 'data:'.implode("\ndata:", explode("\n", $datatext))."\n\n";
+        $txt = 'data:'.implode("\ndata:", explode("\n", $datatext))."\n\n";
     } else {
-        echo $datatext;
+        $txt = $datatext;
     }
+
+    echo str_replace('This can be overridden using the -all option', 'Select the checkbox to remove the limitation', $txt);
 }
 
 // Test if domain is set
@@ -47,15 +49,16 @@ if (isset($_GET['domain'])) {
     exit;
 }
 
+$options = '';
 if (isset($_GET['exact'])) {
-    $exact = '-exact';
-} elseif (isset($_GET['bp'])) {
-    $exact = '-bp';
-} else {
-    $exact = '';
+    $options .= ' -exact';
 }
 
-$proc = popen('sudo pihole -q -adlist '.$url.' '.$exact, 'r');
+if (isset($_GET['showall'])) {
+    $options .= ' -all';
+}
+
+$proc = popen('sudo pihole -q -adlist '.$url.$options, 'r');
 while (!feof($proc)) {
     echoEvent(fread($proc, 4096));
 }

--- a/scripts/pi-hole/php/queryads.php
+++ b/scripts/pi-hole/php/queryads.php
@@ -58,7 +58,7 @@ if (isset($_GET['showall'])) {
     $options .= ' -all';
 }
 
-$proc = popen('sudo pihole -q -adlist '.$url.$options, 'r');
+$proc = popen('sudo pihole -q '.$url.$options, 'r');
 while (!feof($proc)) {
     echoEvent(fread($proc, 4096));
 }

--- a/scripts/pi-hole/php/queryads.php
+++ b/scripts/pi-hole/php/queryads.php
@@ -22,7 +22,7 @@ ob_implicit_flush(true);
 header('Content-Type: text/event-stream');
 header('Cache-Control: no-cache');
 
-function echoEvent($datatext)
+function echoEvent($datatext, $url = '')
 {
     if (!isset($_GET['IE'])) {
         $txt = 'data:'.implode("\ndata:", explode("\n", $datatext))."\n\n";
@@ -30,7 +30,10 @@ function echoEvent($datatext)
         $txt = $datatext;
     }
 
-    echo str_replace('This can be overridden using the -all option', 'Select the checkbox to remove the limitation', $txt);
+    $txt = str_replace('This can be overridden using the -all option', 'Select the checkbox to remove the limitation', $txt);
+    $txt = str_replace($url, '<strong class="text-blue">'.$url.'</strong>', $txt);
+
+    echo $txt;
 }
 
 // Test if domain is set
@@ -39,7 +42,7 @@ if (isset($_GET['domain'])) {
     // Convert domain name to IDNA ASCII form for international domains
     $url = convertUnicodeToIDNA($_GET['domain']);
     if (!validDomain($url)) {
-        echoEvent(htmlentities($url).' is an invalid domain!');
+        echoEvent(htmlentities($url).' is an invalid domain!', $url);
 
         exit;
     }
@@ -60,5 +63,5 @@ if (isset($_GET['showall'])) {
 
 $proc = popen('sudo pihole -q '.$url.$options, 'r');
 while (!feof($proc)) {
-    echoEvent(fread($proc, 4096));
+    echoEvent(fread($proc, 4096), $url);
 }

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -530,11 +530,10 @@ td.details-control {
     margin: 5px 0;
   }
   #domain-search-block .input-group-btn {
-    margin: 5px 0;
-    text-align: center;
+    display: inline-block;
   }
   #domain-search-block .input-group-btn button {
-    margin: 0 2px;
+    margin: 0 5px 0 0;
     border-radius: 3px;
   }
 }


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix #2486 

Allow unlimited results on the **_Tools > Search Adlists_** page.
Also change the message when more than 100 domains are returned.

### How does this PR accomplish the above?

Adding code and a checkbox to allow unlimited results.

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
