### PR TITLE
Show two decimals on doughnutTooltip if total share shown is less than 1%

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -729,10 +729,17 @@ function doughnutTooltip(tooltipLabel) {
   // to compensate rounding errors we round to one decimal
 
   var label = " " + tooltipLabel.label;
-  // in case the item share is really small it could be rounded to 0.0
-  // we compensate for this
-  var itemPercentage =
-    tooltipLabel.parsed.toFixed(1) === "0.0" ? "< 0.1" : tooltipLabel.parsed.toFixed(1);
+  var itemPercentage;
+
+  // if we only show < 1% percent of all, show each item with two decimals
+  if (percentageTotalShown < 1) {
+    itemPercentage = tooltipLabel.parsed.toFixed(2);
+  } else {
+    // show with one decimal, but in case the item share is really small it could be rounded to 0.0
+    // we compensate for this
+    itemPercentage =
+      tooltipLabel.parsed.toFixed(1) === "0.0" ? "< 0.1" : tooltipLabel.parsed.toFixed(1);
+  }
 
   // even if no doughnut slice is hidden, sometimes percentageTotalShown is slightly less then 100
   // we therefore use 99.9 to decide if slices are hidden (we only show with 0.1 precision)


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

If users hide a big part of the doughnut chart, rounding can lead to "falsely" reported item share and confuse users. See https://github.com/pi-hole/AdminLTE/issues/2500.

To compensate for that, this PR will show two decimal precision of each tooltip item when the total shown percentage is less then 1%

![Screenshot at 2023-01-18 22-00-59](https://user-images.githubusercontent.com/26622301/213296196-9507e1bb-9962-4362-9df4-bae4f6f1519e.png)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
