### PR TITLE
Fixing the FTL information on settings page after a FTL restart

### DIFF
--- a/scripts/pi-hole/js/restartdns.js
+++ b/scripts/pi-hole/js/restartdns.js
@@ -1,0 +1,39 @@
+/* Pi-hole: A black hole for Internet advertisements
+ *  (c) 2017 Pi-hole, LLC (https://pi-hole.net)
+ *  Network-wide ad blocking via your own hardware.
+ *
+ *  This file is copyright under the latest version of the EUPL.
+ *  Please see LICENSE file for your rights under this license. */
+
+var timeleft = 60;
+var status = -1;
+var reloadMsg =
+  "FTL was restarted: <a href='settings.php' class='btn btn-sm btn-primary'>Reload FTL details.</a>";
+var warningMsg = "FTL was not able to reload after " + timeleft + " seconds.";
+var counterMsg = "FTL is reloading: ";
+
+var reloadTimer = setInterval(function () {
+  $.getJSON("api.php?dns-port", function (data) {
+    if ("FTLnotrunning" in data) {
+      return;
+    }
+
+    status = data["dns-port"];
+  });
+
+  if (timeleft <= 0 || status >= 0) {
+    clearInterval(reloadTimer);
+    if (status < 0) {
+      // FTL was not restarted in 60 seconds. Show warning message
+      document.getElementById("restart-countdown").innerHTML = warningMsg;
+    } else {
+      // FTL restartd.
+      document.getElementById("restart-countdown").innerHTML = reloadMsg;
+    }
+  } else {
+    document.getElementById("restart-countdown").innerHTML =
+      counterMsg + timeleft + " seconds remaining...";
+  }
+
+  timeleft -= 1;
+}, 1000);

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -693,12 +693,8 @@ function convertUnicodeToIDNA($unicode)
 }
 
 // Return PID of FTL (used in settings.php)
-function pidofFTL($add_delay = false)
+function pidofFTL()
 {
-    if ($add_delay) {
-        usleep(100000);
-    }
-
     return shell_exec('pidof pihole-FTL');
 }
 

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -693,8 +693,12 @@ function convertUnicodeToIDNA($unicode)
 }
 
 // Return PID of FTL (used in settings.php)
-function pidofFTL()
+function pidofFTL($add_delay = false)
 {
+    if ($add_delay) {
+        usleep(100000);
+    }
+
     return shell_exec('pidof pihole-FTL');
 }
 

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -197,6 +197,7 @@ $DNSserverslist = readDNSserversList();
 
 $error = '';
 $success = '';
+$FTLrestarted = false;
 
 if (isset($_POST['field'])) {
     // Handle CSRF
@@ -445,6 +446,7 @@ if (isset($_POST['field'])) {
 
         case 'restartdns':
             pihole_execute('-a restartdns');
+            $FTLrestarted = true;
             $success = 'The DNS server has been restarted';
 
             break;
@@ -554,6 +556,7 @@ if (isset($_POST['field'])) {
 
                 if ($privacylevel > $level) {
                     pihole_execute('-a restartdns');
+                    $FTLrestarted = true;
                     $success .= 'The privacy level has been decreased and the DNS resolver has been restarted';
                 } elseif ($privacylevel < $level) {
                     $success .= 'The privacy level has been increased';

--- a/settings.php
+++ b/settings.php
@@ -241,7 +241,7 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array('sysadmin', 'dns', 'piho
                                     <div class="row">
                                         <div class="col-lg-12">
                                             <?php
-                                            $FTLpid = intval(pidofFTL());
+                                            $FTLpid = intval(pidofFTL($FTLrestarted));
 if ($FTLpid !== 0) {
     $FTLversion = exec('/usr/bin/pihole-FTL version'); ?>
                                             <table class="table table-striped table-bordered nowrap">

--- a/settings.php
+++ b/settings.php
@@ -240,10 +240,13 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array('sysadmin', 'dns', 'piho
                                 <div class="box-body">
                                     <div class="row">
                                         <div class="col-lg-12">
-                                            <?php
-                                            $FTLpid = intval(pidofFTL($FTLrestarted));
+<?php
+// Try to get FTL PID
+$FTLpid = intval(pidofFTL());
+
 if ($FTLpid !== 0) {
-    $FTLversion = exec('/usr/bin/pihole-FTL version'); ?>
+    $FTLversion = exec('/usr/bin/pihole-FTL version');
+    ?>
                                             <table class="table table-striped table-bordered nowrap">
                                                 <tbody>
                                                     <tr>
@@ -256,20 +259,19 @@ if ($FTLpid !== 0) {
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">Time FTL started:</th>
-                                                        <td><?php print_r(get_FTL_data($FTLpid, 'lstart'));
-    echo ' '.$timezone; ?></td>
+                                                        <td><?php echo get_FTL_data($FTLpid, 'lstart').' '.$timezone; ?></td>
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">User / Group:</th>
-                                                        <td><?php print_r(get_FTL_data($FTLpid, 'euser')); ?> / <?php print_r(get_FTL_data($FTLpid, 'egroup')); ?></td>
+                                                        <td><?php echo get_FTL_data($FTLpid, 'euser').' / '.get_FTL_data($FTLpid, 'egroup'); ?></td>
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">Total CPU utilization:</th>
-                                                        <td><?php print_r(get_FTL_data($FTLpid, '%cpu')); ?>%</td>
+                                                        <td><?php echo get_FTL_data($FTLpid, '%cpu'); ?>%</td>
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">Memory utilization:</th>
-                                                        <td><?php print_r(get_FTL_data($FTLpid, '%mem')); ?>%</td>
+                                                        <td><?php echo get_FTL_data($FTLpid, '%mem'); ?>%</td>
                                                     </tr>
                                                     <tr>
                                                         <th scope="row">
@@ -298,10 +300,20 @@ if ($FTLpid !== 0) {
                                                 </tbody>
                                             </table>
                                             See also our <a href="https://docs.pi-hole.net/ftldns/dns-cache/" rel="noopener" target="_blank">DNS cache documentation</a>.
-                                            <?php
-} else { ?>
+<?php
+} elseif ($FTLrestarted) {
+    // Show a countdown and a message if FTL was restarted
+    ?>
+                                            <div id="restart-countdown"></div>
+                                            <script src="<?php echo fileversion('scripts/pi-hole/js/restartdns.js'); ?>"></script>
+<?php
+} else {
+    // Show a message if FTL is offline
+    ?>
                                             <div>The FTL service is offline!</div>
-                                            <?php } ?>
+<?php
+}
+?>
                                         </div>
                                     </div>
                                 </div>


### PR DESCRIPTION
### What does this PR aim to accomplish?

This PR tries to fix a behavior affecting some installations (docker and bare metal) where the web interface button "Restart DNS resolver" causes an apparent error, while restarting FTL.

This topic from Discourse shows the problem on a bare metal install:
https://discourse.pi-hole.net/t/restart-dns-resolver-is-killing-new-ftl/60693

The real issue:
FTL is restarted, but in some cases the PHP page is reloaded before FTL is completely restarted. 
The page uses the function `pidofFTL()` to read the PID, but the value is not found and _"FTL is offline"_ message is shown.

A few milliseconds after that, FTL finishes the restart process, but in some cases the restart could take seconds to finish.

Screen capture showing the behavior:
![restart_FTL_issue](https://user-images.githubusercontent.com/1385443/214122562-14986b4a-151f-436d-9c16-3afd8c14f611.gif)


### How does this PR accomplish the above?

Adding a new message and a countdown to wait for FTL to restart.

### Link documentation PRs if any are needed to support this PR

none

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
