### PR TITLE
Use the `setupVars.conf` option `TEMPERATUREUNIT`, plus slight rearrangement of settings page

### DIFF
--- a/api.php
+++ b/api.php
@@ -75,6 +75,17 @@ if (isset($_GET['enable']) && $auth) {
     $data = array_merge($data, $current);
     $data = array_merge($data, $latest);
     $data = array_merge($data, $branches);
+} elseif (isset($_GET['setTempUnit'])) {
+    $unit = strtolower($_GET['setTempUnit']);
+    if ($unit == 'c' || $unit == 'f' || $unit == 'k') {
+        pihole_execute('-a -'.$unit);
+        $result = 'success';
+    } else {
+        // invalid unit
+        $result = 'error';
+    }
+
+    $data = array_merge($data, array('result' => $result));
 } elseif (isset($_GET['list'])) {
     if (!$auth) {
         exit('Not authorized!');

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -160,10 +160,6 @@ function initCheckboxRadioStyle() {
 
 function initCPUtemp() {
   function setCPUtemp(unit) {
-    if (localStorage) {
-      localStorage.setItem("tempunit", tempunit);
-    }
-
     var temperature = parseFloat($("#rawtemp").text());
     var displaytemp = $("#tempdisplay");
     if (!isNaN(temperature)) {
@@ -185,11 +181,8 @@ function initCPUtemp() {
     }
   }
 
-  // Read from local storage, initialize if needed
-  var tempunit = localStorage ? localStorage.getItem("tempunit") : null;
-  if (tempunit === null) {
-    tempunit = "C";
-  }
+  // Read the temperature unit from HTML code
+  var tempunit = $("#tempunit").text();
 
   setCPUtemp(tempunit);
 
@@ -200,6 +193,15 @@ function initCPUtemp() {
     tempunitSelector.on("change", function () {
       tempunit = $(this).val();
       setCPUtemp(tempunit);
+
+      // store the selected value on setupVars.conf
+      $.getJSON("api.php?setTempUnit=" + tempunit + "&token=" + token, function (data) {
+        if ("result" in data && data.result == "success") {
+          utils.showAlert("success", "", "Temperature unit set to " + tempunit, "");
+        } else {
+          utils.showAlert("error", "", "", "Temperature unit not set");
+        }
+      });
     });
   }
 }

--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -181,8 +181,31 @@ function initCPUtemp() {
     }
   }
 
+  function setSetupvarsTempUnit(unit, showmsg = true) {
+    var token = encodeURIComponent($("#token").text());
+    $.getJSON("api.php?setTempUnit=" + unit + "&token=" + token, function (data) {
+      if (showmsg === true) {
+        if ("result" in data && data.result === "success") {
+          utils.showAlert("success", "", "Temperature unit set to " + unit, "");
+        } else {
+          utils.showAlert("error", "", "", "Temperature unit not set");
+        }
+      }
+    });
+  }
+
   // Read the temperature unit from HTML code
   var tempunit = $("#tempunit").text();
+  if (!tempunit) {
+    // if no value was set in setupVars.conf, tries to retrieve the old config from localstorage
+    tempunit = localStorage ? localStorage.getItem("tempunit") : null;
+    if (tempunit === null) {
+      tempunit = "C";
+    } else {
+      // if some value was found on localstorage, set the value in setupVars.conf
+      setSetupvarsTempUnit(tempunit, false);
+    }
+  }
 
   setCPUtemp(tempunit);
 
@@ -195,13 +218,7 @@ function initCPUtemp() {
       setCPUtemp(tempunit);
 
       // store the selected value on setupVars.conf
-      $.getJSON("api.php?setTempUnit=" + tempunit + "&token=" + token, function (data) {
-        if ("result" in data && data.result == "success") {
-          utils.showAlert("success", "", "Temperature unit set to " + tempunit, "");
-        } else {
-          utils.showAlert("error", "", "", "Temperature unit not set");
-        }
-      });
+      setSetupvarsTempUnit(tempunit);
     });
   }
 }

--- a/scripts/pi-hole/php/header_authenticated.php
+++ b/scripts/pi-hole/php/header_authenticated.php
@@ -98,7 +98,22 @@ function getTemperature()
         $limit = null;
     }
 
-    return array($celsius, $limit);
+    // Get user-defined temperature limit if set
+    if (isset($setupVars['TEMPERATUREUNIT'])) {
+        switch (strtoupper($setupVars['TEMPERATUREUNIT'])) {
+            case 'F':
+            case 'K':
+                $unit = strtoupper($setupVars['TEMPERATUREUNIT']);
+                break;
+
+            default:
+                $unit = 'C';
+        }
+    } else {
+        $unit = 'C';
+    }
+
+    return array($celsius, $limit, $unit);
 }
 
 check_cors();
@@ -113,7 +128,7 @@ $token = $_SESSION['token'];
 $maxlifetime = ini_get('session.gc_maxlifetime');
 
 // Get temperature
-list($celsius, $temperaturelimit) = getTemperature();
+list($celsius, $temperaturelimit, $temperatureunit) = getTemperature();
 
 // Get CPU load
 $loaddata = sys_getloadavg();

--- a/scripts/pi-hole/php/header_authenticated.php
+++ b/scripts/pi-hole/php/header_authenticated.php
@@ -110,7 +110,8 @@ function getTemperature()
                 $unit = 'C';
         }
     } else {
-        $unit = 'C';
+        // no value is set in setupVars.conf
+        $unit = '';
     }
 
     return array($celsius, $limit, $unit);

--- a/scripts/pi-hole/php/sidebar.php
+++ b/scripts/pi-hole/php/sidebar.php
@@ -57,6 +57,7 @@
                         }
                         echo '<span id="temperature"><i class="fa fa-w fa-fire '.$tempcolor.'" style="width: 1em !important"></i> ';
                         echo 'Temp:&nbsp;<span id="rawtemp" hidden>'.$celsius.'</span>';
+                        echo '<span id="tempunit" hidden>'.$temperatureunit.'</span>';
                         echo '<span id="tempdisplay"></span></span>';
                     }
                     ?>

--- a/settings.php
+++ b/settings.php
@@ -196,7 +196,7 @@ if (isset($setupVars['API_QUERY_LOG_SHOW'])) {
 ?>
 
 <?php
-if (isset($_GET['tab']) && in_array($_GET['tab'], array('sysadmin', 'dns', 'piholedhcp', 'api', 'privacy', 'teleporter'))) {
+if (isset($_GET['tab']) && in_array($_GET['tab'], array('sysadmin', 'dns', 'piholedhcp', 'web', 'api', 'privacy', 'teleporter'))) {
     $tab = $_GET['tab'];
 } else {
     $tab = 'sysadmin';
@@ -215,8 +215,11 @@ if (isset($_GET['tab']) && in_array($_GET['tab'], array('sysadmin', 'dns', 'piho
                 <li role="presentation"<?php if ($tab === 'piholedhcp') { ?> class="active"<?php } ?>>
                     <a href="#piholedhcp" aria-controls="piholedhcp" aria-expanded="<?php echo $tab === 'piholedhcp' ? 'true' : 'false'; ?>" role="tab" data-toggle="tab">DHCP</a>
                 </li>
+                <li role="presentation"<?php if ($tab === 'web') { ?> class="active"<?php } ?>>
+                    <a href="#web" aria-controls="web" aria-expanded="<?php echo $tab === 'web' ? 'true' : 'false'; ?>" role="tab" data-toggle="tab">Web interface</a>
+                </li>
                 <li role="presentation"<?php if ($tab === 'api') { ?> class="active"<?php } ?>>
-                    <a href="#api" aria-controls="api" aria-expanded="<?php echo $tab === 'api' ? 'true' : 'false'; ?>" role="tab" data-toggle="tab">API / Web interface</a>
+                    <a href="#api" aria-controls="api" aria-expanded="<?php echo $tab === 'api' ? 'true' : 'false'; ?>" role="tab" data-toggle="tab">API</a>
                 </li>
                 <li role="presentation"<?php if ($tab === 'privacy') { ?> class="active"<?php } ?>>
                     <a href="#privacy" aria-controls="privacy" aria-expanded="<?php echo $tab === 'privacy' ? 'true' : 'false'; ?>" role="tab" data-toggle="tab">Privacy</a>
@@ -1026,10 +1029,162 @@ if (isset($piholeFTLConf['RATE_LIMIT'])) {
                         </div>
                     </form>
                 </div>
-                <!-- ######################################################### API and Web ######################################################### -->
-                <div id="api" class="tab-pane fade<?php if ($tab === 'api') { ?> in active<?php } ?>">
+                <!-- ######################################################## Web Interface ######################################################## -->
+                <div id="web" class="tab-pane fade<?php if ($tab === 'web') { ?> in active<?php } ?>">
                     <div class="row">
                         <div class="col-md-6">
+                            <form role="form" method="post">
+                                <div class="box box-warning">
+                                    <div class="box-header with-border">
+                                        <h3 class="box-title">Theme and Layout</h3>
+                                    </div>
+                                    <div class="box-body">
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <?php theme_selection(); ?>
+                                            </div>
+                                        </div>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div>
+                                                    <input type="checkbox" name="boxedlayout" id="boxedlayout" value="yes" <?php if ($boxedlayout) { ?>checked<?php } ?>>
+                                                    <label for="boxedlayout"><strong>Use boxed layout (for large screens)</strong></label>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <input type="hidden" name="field" value="webUI">
+                                        <input type="hidden" name="token" value="<?php echo $token; ?>">
+                                    </div>
+                                    <div class="box-footer clearfix">
+                                        <button type="submit" class="btn btn-primary pull-right">Save</button>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                        <div class="col-md-6">
+                            <div class="box box-warning">
+                                <div class="box-header with-border">
+                                    <h3 class="box-title">Interface settings (auto saved)</h3>
+                                </div>
+                                <div class="box-body">
+
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <h4>Global Settings</h4>
+                                        </div>
+                                    </div>
+
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="icheck-default">
+                                                <label for="tempunit-selector"><strong>CPU Temperature Unit:</strong> </label>
+                                                <select id="tempunit-selector">
+                                                    <option value="C">Celsius</option>
+                                                    <option value="K">Kelvin</option>
+                                                    <option value="F">Fahrenheit</option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <hr class="faint-border">
+
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <h4>Per Browser Settings</h4>
+                                        </div>
+                                    </div>
+
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div class="icheck-default">
+                                                <label for="iCheckStyle"><strong>Checkbox and radio buttons: </strong> </label>
+                                                <select id="iCheckStyle">
+                                                    <option>default</option>
+                                                    <option>primary</option>
+                                                    <option>success</option>
+                                                    <option>info</option>
+                                                    <option>warning</option>
+                                                    <option>danger</option>
+                                                    <option>turquoise</option>
+                                                    <option>emerland</option>
+                                                    <option>peterriver</option>
+                                                    <option>amethyst</option>
+                                                    <option>wetasphalt</option>
+                                                    <option>greensea</option>
+                                                    <option>nephritis</option>
+                                                    <option>belizehole</option>
+                                                    <option>wisteria</option>
+                                                    <option>midnightblue</option>
+                                                    <option>sunflower</option>
+                                                    <option>carrot</option>
+                                                    <option>alizarin</option>
+                                                    <option>clouds</option>
+                                                    <option>concrete</option>
+                                                    <option>orange</option>
+                                                    <option>pumpkin</option>
+                                                    <option>pomegranate</option>
+                                                    <option>silver</option>
+                                                    <option>asbestos</option>
+
+                                                    <option>material-red</option>
+                                                    <option>material-pink</option>
+                                                    <option>material-purple</option>
+                                                    <option>material-deeppurple</option>
+                                                    <option>material-indigo</option>
+                                                    <option>material-blue</option>
+                                                    <option>material-lightblue</option>
+                                                    <option>material-cyan</option>
+                                                    <option>material-teal</option>
+                                                    <option>material-green</option>
+                                                    <option>material-lightgreen</option>
+                                                    <option>material-lime</option>
+                                                    <option>material-yellow</option>
+                                                    <option>material-amber</option>
+                                                    <option>material-orange</option>
+                                                    <option>material-deeporange</option>
+                                                    <option>material-brown</option>
+                                                    <option>material-grey</option>
+                                                    <option>material-bluegrey</option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div>
+                                                <input type="checkbox" name="bargraphs" id="bargraphs" value="yes">
+                                                <label for="bargraphs"><strong>Use new Bar charts on dashboard</strong></label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div>
+                                                <input type="checkbox" name="colorfulQueryLog" id="colorfulQueryLog" value="no">
+                                                <label for="colorfulQueryLog"><strong>Colorful Query Log</strong></label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="row">
+                                        <div class="col-md-12">
+                                            <div>
+                                                <input type="checkbox" name="hideNonfatalDnsmasqWarnings" id="hideNonfatalDnsmasqWarnings" value="no">
+                                                <label for="hideNonfatalDnsmasqWarnings"><strong>Hide non-fatal <code>dnsmasq</code> warnings (warnings listed <a target="_blank" href="https://docs.pi-hole.net/ftldns/dnsmasq_warn">here</a>)</strong></label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- ############################################################# API ############################################################# -->
+                <div id="api" class="tab-pane fade<?php if ($tab === 'api') { ?> in active<?php } ?>">
+                    <div class="row">
+                        <div class="col-md-12">
                             <form role="form" method="post">
                                 <div class="box box-warning">
                                     <div class="box-header with-border">
@@ -1109,138 +1264,9 @@ if (isset($piholeFTLConf['RATE_LIMIT'])) {
                                 </div>
                             </div>
                         </div>
-                        <div class="col-md-6">
-                            <form role="form" method="post">
-                                <div class="box box-warning">
-                                    <div class="box-header with-border">
-                                        <h3 class="box-title">Web interface settings</h3>
-                                    </div>
-                                    <div class="box-body">
-                                        <div class="row">
-                                            <div class="col-md-12">
-                                                <h4>Interface appearance</h4>
-                                                <?php theme_selection(); ?>
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-md-12">
-                                                <div>
-                                                    <input type="checkbox" name="boxedlayout" id="boxedlayout" value="yes" <?php if ($boxedlayout) { ?>checked<?php } ?>>
-                                                    <label for="boxedlayout"><strong>Use boxed layout (for large screens)</strong></label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="row">
-                                            <div class="col-md-12">
-                                                <div class="icheck-default">
-                                                    <label for="tempunit-selector"><strong>CPU Temperature Unit:</strong> </label>
-                                                    <select id="tempunit-selector">
-                                                        <option value="C">Celsius</option>
-                                                        <option value="K">Kelvin</option>
-                                                        <option value="F">Fahrenheit</option>
-                                                    </select>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <input type="hidden" name="field" value="webUI">
-                                        <input type="hidden" name="token" value="<?php echo $token; ?>">
-                                    </div>
-                                    <div class="box-footer clearfix">
-                                        <button type="submit" class="btn btn-primary pull-right">Save</button>
-                                    </div>
-                                </div>
-                            </form>
-                        </div>
-                        <div class="col-md-6">
-                            <div class="box box-warning">
-                                <div class="box-header with-border">
-                                    <h3 class="box-title">Per-browser settings (auto saved)</h3>
-                                </div>
-                                <div class="box-body">
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <p>Checkbox and radio buttons</p>
-                                        </div>
-                                        <div class="col-md-6">
-                                            <select id="iCheckStyle">
-                                                <option>default</option>
-                                                <option>primary</option>
-                                                <option>success</option>
-                                                <option>info</option>
-                                                <option>warning</option>
-                                                <option>danger</option>
-                                                <option>turquoise</option>
-                                                <option>emerland</option>
-                                                <option>peterriver</option>
-                                                <option>amethyst</option>
-                                                <option>wetasphalt</option>
-                                                <option>greensea</option>
-                                                <option>nephritis</option>
-                                                <option>belizehole</option>
-                                                <option>wisteria</option>
-                                                <option>midnightblue</option>
-                                                <option>sunflower</option>
-                                                <option>carrot</option>
-                                                <option>alizarin</option>
-                                                <option>clouds</option>
-                                                <option>concrete</option>
-                                                <option>orange</option>
-                                                <option>pumpkin</option>
-                                                <option>pomegranate</option>
-                                                <option>silver</option>
-                                                <option>asbestos</option>
-
-                                                <option>material-red</option>
-                                                <option>material-pink</option>
-                                                <option>material-purple</option>
-                                                <option>material-deeppurple</option>
-                                                <option>material-indigo</option>
-                                                <option>material-blue</option>
-                                                <option>material-lightblue</option>
-                                                <option>material-cyan</option>
-                                                <option>material-teal</option>
-                                                <option>material-green</option>
-                                                <option>material-lightgreen</option>
-                                                <option>material-lime</option>
-                                                <option>material-yellow</option>
-                                                <option>material-amber</option>
-                                                <option>material-orange</option>
-                                                <option>material-deeporange</option>
-                                                <option>material-brown</option>
-                                                <option>material-grey</option>
-                                                <option>material-bluegrey</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="col-md-12">
-                                            <div>
-                                                <input type="checkbox" name="bargraphs" id="bargraphs" value="yes">
-                                                <label for="bargraphs"><strong>Use new Bar charts on dashboard</strong></label>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="col-md-12">
-                                            <div>
-                                                <input type="checkbox" name="colorfulQueryLog" id="colorfulQueryLog" value="no">
-                                                <label for="colorfulQueryLog"><strong>Colorful Query Log</strong></label>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="col-md-12">
-                                            <div>
-                                                <input type="checkbox" name="hideNonfatalDnsmasqWarnings" id="hideNonfatalDnsmasqWarnings" value="no">
-                                                <label for="hideNonfatalDnsmasqWarnings"><strong>Hide non-fatal <code>dnsmasq</code> warnings (warnings listed <a target="_blank" href="https://docs.pi-hole.net/ftldns/dnsmasq_warn">here</a>)</strong></label>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
                     </div>
                 </div>
+
                 <!-- ######################################################### Privacy (may be expanded further later on) ######################################################### -->
                 <?php
                 // Get privacy level from piholeFTL config array

--- a/settings.php
+++ b/settings.php
@@ -1130,6 +1130,18 @@ if (isset($piholeFTLConf['RATE_LIMIT'])) {
                                                 </div>
                                             </div>
                                         </div>
+                                        <div class="row">
+                                            <div class="col-md-12">
+                                                <div class="icheck-default">
+                                                    <label for="tempunit-selector"><strong>CPU Temperature Unit:</strong> </label>
+                                                    <select id="tempunit-selector">
+                                                        <option value="C">Celsius</option>
+                                                        <option value="K">Kelvin</option>
+                                                        <option value="F">Fahrenheit</option>
+                                                    </select>
+                                                </div>
+                                            </div>
+                                        </div>
                                         <input type="hidden" name="field" value="webUI">
                                         <input type="hidden" name="token" value="<?php echo $token; ?>">
                                     </div>
@@ -1197,18 +1209,6 @@ if (isset($piholeFTLConf['RATE_LIMIT'])) {
                                                 <option>material-brown</option>
                                                 <option>material-grey</option>
                                                 <option>material-bluegrey</option>
-                                            </select>
-                                        </div>
-                                    </div>
-                                    <div class="row">
-                                        <div class="col-md-6">
-                                            <p>CPU Temperature Unit</p>
-                                        </div>
-                                        <div class="col-md-6">
-                                            <select id="tempunit-selector">
-                                                <option value="C">Celsius</option>
-                                                <option value="K">Kelvin</option>
-                                                <option value="F">Fahrenheit</option>
                                             </select>
                                         </div>
                                     </div>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1042,3 +1042,7 @@ table.dataTable tbody > tr > .selected {
   left: 50%;
   translate: -50% -50%;
 }
+
+.faint-border {
+  border-color: rgba(127, 127, 127, 0.1);
+}


### PR DESCRIPTION
## What does this PR aim to accomplish?

Allow the selection of temperature unit shown on the web interface via `setupVars.conf`, like other interfaces (PADD/chronometer) already do.

Currently the web interface always defaults to "C" (Celcius). The user must manually select the unit on Setting page for every device/browser used.

Note:
The suggest code here will use a global unit and remove the ability to use different units on each device (which was probably never the desired behavior).

## How does this PR accomplish the above?

Changing the code to use a new behavior:
- if the option `TEMPERATUREUNIT` is set in `setupVars.conf` file, the value will be used.
- if there is no unit set in `setupVars.conf`, but the browser has an old value set on `locastorage`, the `localstorage` value will be used and stored in `setupVars.conf` file.
- if there is no unit set in `setupVars.conf` or `localstorage`, "C" will be used as default value.

Also:
- The temperature unit will be set GLOBALLY and not per browser.
- changing the value on the web interface WILL CHANGE `setupVars.conf`.


## Link documentation PRs if any are needed to support this PR:

The [TEMPERATUREUNIT description](https://github.com/pi-hole/docker-pi-hole/#optional-variables) on docker-pi-hole repository will need to be updated to reflect the new behavior

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
