### PR TITLE
db_queries.php: use the same color scheme from Dashboard

### DIFF
--- a/db_queries.php
+++ b/db_queries.php
@@ -85,7 +85,7 @@ require 'scripts/pi-hole/php/header_authenticated.php';
         <div class="small-box bg-aqua no-user-select">
             <div class="inner">
                 <h3 class="statistic" id="dns_queries">---</h3>
-                <p>Queries Total</p>
+                <p>Total Queries</p>
             </div>
             <div class="icon">
                 <i class="fas fa-globe-americas"></i>
@@ -124,7 +124,7 @@ require 'scripts/pi-hole/php/header_authenticated.php';
         <div class="small-box bg-yellow no-user-select">
             <div class="inner">
                 <h3 class="statistic" id="queries_percentage_today">---</h3>
-                <p>Queries Blocked</p>
+                <p>Percentage Blocked</p>
             </div>
             <div class="icon">
                 <i class="fas fa-chart-pie"></i>

--- a/db_queries.php
+++ b/db_queries.php
@@ -84,6 +84,19 @@ require 'scripts/pi-hole/php/header_authenticated.php';
         <!-- small box -->
         <div class="small-box bg-aqua no-user-select">
             <div class="inner">
+                <h3 class="statistic" id="dns_queries">---</h3>
+                <p>Queries Total</p>
+            </div>
+            <div class="icon">
+                <i class="fas fa-globe-americas"></i>
+            </div>
+        </div>
+    </div>
+    <!-- ./col -->
+    <div class="col-lg-3 col-xs-12">
+        <!-- small box -->
+        <div class="small-box bg-red no-user-select">
+            <div class="inner">
                 <h3 class="statistic" id="queries_blocked_exact">---</h3>
                 <p>Queries Blocked</p>
             </div>
@@ -95,26 +108,13 @@ require 'scripts/pi-hole/php/header_authenticated.php';
     <!-- ./col -->
     <div class="col-lg-3 col-xs-12">
         <!-- small box -->
-        <div class="small-box bg-aqua no-user-select">
+        <div class="small-box bg-red no-user-select">
             <div class="inner">
                 <h3 class="statistic" id="queries_wildcard_blocked">---</h3>
                 <p>Queries Blocked (Wildcards)</p>
             </div>
             <div class="icon">
                 <i class="fas fa-hand-paper"></i>
-            </div>
-        </div>
-    </div>
-    <!-- ./col -->
-    <div class="col-lg-3 col-xs-12">
-        <!-- small box -->
-        <div class="small-box bg-green no-user-select">
-            <div class="inner">
-                <h3 class="statistic" id="dns_queries">---</h3>
-                <p>Queries Total</p>
-            </div>
-            <div class="icon">
-                <i class="fas fa-globe-americas"></i>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## What does this PR aim to accomplish?

Use a single color scheme and similar order for both pages (dashboard and db_queries):
- Blue (aqua) for `Total queries`;
- Red for `Queries blocked`;
- Yellow for `Percentage Blocked`;

_Dashboard colors:_
![dashboard](https://user-images.githubusercontent.com/1385443/215308716-491db6b5-c924-434e-8ac3-106c1bb7b27e.gif)

_Long-term data > Query log (`db_queries.php`):_
![db_queries_same_colors](https://user-images.githubusercontent.com/1385443/215309002-b0f725ac-8291-454e-b1ce-408b8d0473c0.gif)

## How does this PR accomplish the above?

Replacing the colors on `db_queries.php` page.

## Link documentation PRs if any are needed to support this PR

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
