### PR TITLE
Fix multiple restarts while importing with Teleporter

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -220,7 +220,7 @@ function getCustomDNSEntries()
     return $entries;
 }
 
-function addCustomDNSEntry($ip = '', $domain = '', $reload = '', $json = true)
+function addCustomDNSEntry($ip = '', $domain = '', $reload = '', $json = true, $teleporter = false)
 {
     try {
         if (isset($_REQUEST['ip'])) {
@@ -279,7 +279,8 @@ function addCustomDNSEntry($ip = '', $domain = '', $reload = '', $json = true)
         foreach ($domains as $domain) {
             pihole_execute('-a addcustomdns '.$ip.' '.$domain.' '.$reload);
         }
-        if ($num > 0) {
+        // restart only if not called from teleporter.php as it handles restarts itself
+        if (($num > 0) && (!$teleporter)) {
             pihole_execute('restartdns');
         }
 
@@ -397,7 +398,7 @@ function getCustomCNAMEEntries()
     return $entries;
 }
 
-function addCustomCNAMEEntry($domain = '', $target = '', $reload = '', $json = true)
+function addCustomCNAMEEntry($domain = '', $target = '', $reload = '', $json = true, $teleporter = false)
 {
     try {
         if (isset($_REQUEST['domain'])) {
@@ -460,7 +461,8 @@ function addCustomCNAMEEntry($domain = '', $target = '', $reload = '', $json = t
             pihole_execute('-a addcustomcname '.$d.' '.$target.' '.$reload);
         }
 
-        if ($num > 0) {
+        // restart only if not called from teleporter.php as it handles restarts itself
+        if (($num > 0) && (!$teleporter)) {
             pihole_execute('restartdns');
         }
 

--- a/scripts/pi-hole/php/teleporter.php
+++ b/scripts/pi-hole/php/teleporter.php
@@ -493,6 +493,7 @@ if (isset($_POST['action'])) {
             if (isset($_POST['localdnsrecords']) && $file->getFilename() === 'custom.list') {
                 ob_start();
                 $reload = 'false';
+                $teleporter = true;
                 if ($flushtables) {
                     // Defined in func.php included via auth.php
                     // passing reload="false" will not restart Pi-hole
@@ -502,7 +503,7 @@ if (isset($_POST['action'])) {
                 $localdnsrecords = process_file(file_get_contents($file));
                 foreach ($localdnsrecords as $record) {
                     list($ip, $domain) = explode(' ', $record);
-                    if (addCustomDNSEntry($ip, $domain, $reload, false)) {
+                    if (addCustomDNSEntry($ip, $domain, $reload, false, $teleporter)) {
                         ++$num;
                     }
                 }
@@ -517,6 +518,7 @@ if (isset($_POST['action'])) {
             if (isset($_POST['localcnamerecords']) && $file->getFilename() === '05-pihole-custom-cname.conf') {
                 ob_start();
                 $reload = 'false';
+                $teleporter = true;
                 if ($flushtables) {
                     // Defined in func.php included via auth.php
                     // passing reload="false" will not restart Pi-hole
@@ -534,7 +536,7 @@ if (isset($_POST['action'])) {
                     $domain = implode(',', array_slice($explodedLine, 0, -1));
                     $target = $explodedLine[count($explodedLine) - 1];
 
-                    if (addCustomCNAMEEntry($domain, $target, $reload, false)) {
+                    if (addCustomCNAMEEntry($domain, $target, $reload, false, $teleporter)) {
                         ++$num;
                     }
                 }


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Do not restart FTL for each local DNS record or local CNAME record. This was partly fixed by https://github.com/pi-hole/AdminLTE/pull/1925 but re-introduced with https://github.com/pi-hole/AdminLTE/pull/2410.

Background: we use `addCustomDNSEntry` and `addCustomCNAMEEntry` when adding domains through the web interface but also via Teleporter. We don't want a **reload** for each added item, but a **restart** when added via web but not via Teleporter. Teleporter is handling restarts by itself because it only restarts when everything is imported.

So far, this bug was hiding, but with adding a native `systemd` unit and setting a start limit of 5 within 60 seconds this unveiled the bug.

https://github.com/pi-hole/pi-hole/blob/c7ad7113d70f63b0b4a5460daaf5ada8f10c28f4/advanced/Templates/pihole-FTL.systemd#L14-L16

**How does this PR accomplish the above?:**

Adds a new variable `$teleporter` to the function to signal if it was called from `teleporter.php`.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
