### PR TITLE
Tweak DHCP setting page

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -506,6 +506,11 @@ if ($FTLpid !== 0) {
                                             </div>
                                         </div>
                                     </div>
+                                    <div class="box-footer clearfix">
+                                        <input type="hidden" name="field" value="DHCP">
+                                        <input type="hidden" name="token" value="<?php echo $token; ?>">
+                                        <button type="submit" class="btn btn-primary pull-right">Save</button>
+                                    </div>
                                 </div>
                             </div>
                             <!-- Advanced DHCP Settings Box -->
@@ -558,10 +563,14 @@ if (!$DHCP) { ?> disabled<?php } ?>
                                             </div>
                                         </div>
                                     </div>
+                                    <div class="box-footer clearfix">
+                                        <input type="hidden" name="field" value="DHCP">
+                                        <input type="hidden" name="token" value="<?php echo $token; ?>">
+                                        <button type="submit" class="btn btn-primary pull-right">Save</button>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-
                         <!-- DHCP Leases Box -->
                         <div class="row">
                             <?php
@@ -700,13 +709,12 @@ readStaticLeasesFile();
                                                     given, the IP address will still be generated dynamically and the
                                                     specified host name will be used. If the host name is omitted, only
                                                     a static lease will be added.</p>
+                                                <p><b>Note</b>: All changes to the static DHCP assignments need a <b>full Pi-hole restart</b>
+                                                    to take effect.</p>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
-                                <input type="hidden" name="field" value="DHCP">
-                                <input type="hidden" name="token" value="<?php echo $token; ?>">
-                                <button type="submit" class="btn btn-primary pull-right">Save</button>
                             </div>
                         </div>
                     </form>


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

1) Adds a note that all changes to the static DHCP assignments need a full restart. Fixes https://github.com/pi-hole/AdminLTE/issues/2546

2) Moves the 'Save' button from the end of the table upwards. The button is responsible for saving the DHCP settings but not the static assignments. This was confusion to users: https://discourse.pi-hole.net/t/change-location-or-behavior-of-save-button-on-dhcp-settings-page-to-reduce-confusion/56678


**How does this PR accomplish the above?:**

I did not find a good place for a single 'Save' button (including nice placement on mobile) as it applies to both "DHCP Settings" and "Advanced DHCP Settings". So I just doubled the button for each box.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
