### PR TITLE
Fix NaN error message when FTL is offline or Web interface session expired

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -678,7 +678,6 @@ function updateSummaryData(runOnce) {
       updateTopLists();
     }
 
-    var formatter = new Intl.NumberFormat();
     //Element name might have a different name to the property of the API so we split it at |
     [
       "ads_blocked_today|queries_blocked_today",
@@ -691,9 +690,17 @@ function updateSummaryData(runOnce) {
       var apiName = apiElName[0];
       var elName = apiElName[1];
       var $todayElement = elName ? $("span#" + elName) : $("span#" + apiName);
-      // Round to one decimal place and format locale-aware
-      var text = formatter.format(Math.round(data[apiName] * 10) / 10);
-      var textData = idx === 2 && data[apiName] !== "to" ? text + "%" : text;
+
+      var textData = data[apiName];
+      if (!FTLoffline) {
+        // Only format as number if FTL is online
+        var formatter = new Intl.NumberFormat();
+
+        // Round to one decimal place and format locale-aware
+        var text = formatter.format(Math.round(data[apiName] * 10) / 10);
+        textData = idx === 2 && data[apiName] !== "to" ? text + "%" : text;
+      }
+
       if ($todayElement.text() !== textData && $todayElement.text() !== textData + "%") {
         $todayElement.addClass("glow");
         $todayElement.text(textData);


### PR DESCRIPTION
### What does this PR aim to accomplish?

Since [commit b7c0fcb1](https://github.com/pi-hole/AdminLTE/commit/b7c0fcb131e64121b8fed673a89a4daf6b1cbe68) the function formats the numbers to respect locale differences and round to one decimal place.

The problem is the function is trying to format the output even when FTL is offline and the [values are not numbers](https://github.com/pi-hole/AdminLTE/blob/b29a423b9553654f113bcdc8a82296eb6e4613d7/scripts/pi-hole/js/index.js#L660-L663). 
This shows `NaN` error on the boxes:

![image](https://user-images.githubusercontent.com/1385443/225987886-886e9938-b944-4f8e-aa62-c58206deb4bd.png)


### How does this PR accomplish the above?

Only formating the values if FTL is online.

The fixed output will show the expected message:

![image](https://user-images.githubusercontent.com/1385443/225988294-cc4ef6ef-2e48-407c-818c-a152103770e0.png)


### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
