### PR TITLE
Add `color-scheme: dark` to fix #2554: browser not detecting dark mode

### DIFF
--- a/style/themes/default-dark.css
+++ b/style/themes/default-dark.css
@@ -12,6 +12,11 @@
   --datatable-bgcolor: rgba(64, 76, 88, 0.8);
 }
 
+/* fix #2554: browser not detecting dark mode */
+html {
+  color-scheme: dark;
+}
+
 body {
   background-color: #353c42;
   color: #bec5cb;

--- a/style/themes/default-darker.css
+++ b/style/themes/default-darker.css
@@ -32,6 +32,8 @@ _______|_______/__/ ____ \__\__|___\__\__|___\__\____
 /* User-Agent Style */
 html {
   background-color: #181a1b !important;
+  /* fix #2554: browser not detecting dark mode */
+  color-scheme: dark;
 }
 html,
 body,

--- a/style/themes/high-contrast-dark.css
+++ b/style/themes/high-contrast-dark.css
@@ -36,6 +36,11 @@
   transition: none !important;
 }
 
+/* fix #2554: browser not detecting dark mode */
+html {
+  color-scheme: dark;
+}
+
 body {
   font-size: 15px;
   color: var(--main-text-color);

--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -24,6 +24,8 @@
 /*** General ***/
 html {
   font-size: 17px;
+  /* fix #2554: browser not detecting dark mode */
+  color-scheme: dark;
 }
 
 body {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

fix #2554: browser not detecting that dark mode is already used and attempts to apply force-dark-mode, ruining the site's look

**How does this PR accomplish the above?:**

Add `color-scheme: dark;` to the `html` section of all `.css` files related to dark mode.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
