### PR TITLE
Expose docker tag information using the API

### DIFF
--- a/api.php
+++ b/api.php
@@ -71,6 +71,13 @@ if (isset($_GET['enable']) && $auth) {
     $branches = array('core_branch' => $core_branch,
         'web_branch' => $web_branch,
         'FTL_branch' => $FTL_branch, );
+    if (isset($versions['DOCKER_VERSION'])) {
+        // Docker info is available only inside containers
+        $updates['docker_update'] = $docker_update;
+        $current['docker_current'] = $docker_current;
+        $latest['docker_latest'] = $docker_latest;
+    }
+
     $data = array_merge($data, $updates);
     $data = array_merge($data, $current);
     $data = array_merge($data, $latest);


### PR DESCRIPTION
### What does this PR aim to accomplish?

Docker tag information is available since the introduction of `versions` file.
The docker info is shown by `pihole -v` and the web interface footer, but it was never added to the `versions` API endpoint.

### How does this PR accomplish the above?

Adding the information to the API (only inside containers).

The new API response will look like this:
```json
{
  "core_update": false,
  "web_update": false,
  "FTL_update": false,
  "docker_update": false,
  "core_current": "v5.16.2",
  "web_current": "v5.19",
  "FTL_current": "v5.22",
  "docker_current": "2023.03.1",
  "core_latest": "v5.16.2",
  "web_latest": "v5.19",
  "FTL_latest": "v5.22",
  "docker_latest": "2023.03.1",
  "core_branch": "master",
  "web_branch": "master",
  "FTL_branch": "master"
}
```

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
