### PR TITLE
Fix the graphics time range when MAXLOGAGE is different than 24h

### DIFF
--- a/api_FTL.php
+++ b/api_FTL.php
@@ -64,16 +64,13 @@ if ((isset($_GET['summary']) || isset($_GET['summaryRaw']) || !count($_GET)) && 
 }
 
 if (isset($_GET['getMaxlogage']) && $auth) {
-    $return = callFTLAPI('maxlogage');
-    if (array_key_exists('FTLnotrunning', $return)) {
+    $maxlogage = getMaxlogage();
+
+    if ($maxlogage < 0) {
+        // FTL is offline
         $data = array('FTLnotrunning' => true);
     } else {
-        // Convert seconds to hours and rounds to one decimal place.
-        $ret = round(intval($return[0]) / 3600, 1);
-        // Return 24h if value is 0, empty, null or non numeric.
-        $ret = $ret ?: 24;
-
-        $data = array_merge($data, array('maxlogage' => $ret));
+        $data = array_merge($data, array('maxlogage' => $maxlogage));
     }
 }
 

--- a/api_FTL.php
+++ b/api_FTL.php
@@ -75,16 +75,26 @@ if (isset($_GET['getMaxlogage']) && $auth) {
 }
 
 if (isset($_GET['overTimeData10mins']) && $auth) {
+    $maxlogage = getMaxlogage();
+
     $return = callFTLAPI('overTime');
-    if (array_key_exists('FTLnotrunning', $return)) {
+    if (array_key_exists('FTLnotrunning', $return) || $maxlogage < 0) {
         $data = array('FTLnotrunning' => true);
     } else {
         $domains_over_time = array();
         $ads_over_time = array();
+
+        // Use current time and maxlogage to limit the time range
+        $time_end = time();
+        $time_start = $time_end - ($maxlogage * 3600);
+
         foreach ($return as $line) {
             $tmp = explode(' ', $line);
-            $domains_over_time[intval($tmp[0])] = intval($tmp[1]);
-            $ads_over_time[intval($tmp[0])] = intval($tmp[2]);
+            $timeslot = intval($tmp[0]);
+            if ($timeslot >= $time_start && $timeslot <= $time_end) {
+                $domains_over_time[$timeslot] = intval($tmp[1]);
+                $ads_over_time[$timeslot] = intval($tmp[2]);
+            }
         }
 
         $result = array(
@@ -398,16 +408,25 @@ if (isset($_GET['getClientNames']) && $auth) {
 }
 
 if (isset($_GET['overTimeDataClients']) && $auth) {
-    $return = callFTLAPI('ClientsoverTime');
+    $maxlogage = getMaxlogage();
 
-    if (array_key_exists('FTLnotrunning', $return)) {
+    $return = callFTLAPI('ClientsoverTime');
+    if (array_key_exists('FTLnotrunning', $return) || $maxlogage < 0) {
         $data = array('FTLnotrunning' => true);
     } else {
         $over_time = array();
+
+        // Use current time and maxlogage to limit the time range
+        $time_end = time();
+        $time_start = $time_end - ($maxlogage * 3600);
+
         foreach ($return as $line) {
             $tmp = explode(' ', $line);
             for ($i = 0; $i < count($tmp) - 1; ++$i) {
-                $over_time[intval($tmp[0])][$i] = floatval($tmp[$i + 1]);
+                $timeslot = intval($tmp[0]);
+                if ($timeslot >= $time_start && $timeslot <= $time_end) {
+                    $over_time[$timeslot][$i] = floatval($tmp[$i + 1]);
+                }
             }
         }
         $result = array('over_time' => $over_time);

--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -641,6 +641,24 @@ function getGateway()
     return $ret;
 }
 
+// Returns the maxlogage used by FTL
+function getMaxlogage()
+{
+    $api_return = callFTLAPI('maxlogage');
+
+    if (array_key_exists('FTLnotrunning', $api_return)) {
+        // FTL is offline. Return "-1"
+        $maxlogage = -1;
+    } else {
+        // Convert seconds to hours and rounds to one decimal place.
+        $maxlogage = round(intval($api_return[0]) / 3600, 1);
+        // Return 24h if value is 0, empty, null or non numeric.
+        $maxlogage = $maxlogage ?: 24;
+    }
+
+    return $maxlogage;
+}
+
 // Try to convert possible IDNA domain to Unicode
 function convertIDNAToUnicode($IDNA)
 {


### PR DESCRIPTION
### What does this PR aim to accomplish?:

Fix https://github.com/pi-hole/AdminLTE/issues/2584



Screenshot showing the issue:
![image](https://user-images.githubusercontent.com/1385443/234419010-ea946ccc-d2e9-4887-900a-18f71c05b4d8.png)

**How does this PR accomplish the above?:**

The PHP code now take into account the current time and the value from MAXLOGAGE option to limit the values received from the API.
Now, it only accepts values on the expected time range and ignores data outside the range.
This prevents empty timeslots from showing on the graphics.

![image](https://user-images.githubusercontent.com/1385443/234419197-1ed66f24-ace5-486f-b643-0d2be78d50b2.png)


**Link documentation PRs if any are needed to support this PR:**

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
