### PR TITLE
Fix the size of the "key icon" on the login page

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -582,7 +582,9 @@ td.details-control {
 }
 
 .form-control-feedback {
-  right: 12px;
+  right: 0.5em;
+  width: 16px;
+  height: 100%;
 }
 
 .loginpage-logo {

--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -344,11 +344,6 @@ p.login-box-msg,
   box-shadow: none;
 }
 
-.form-control-feedback {
-  right: 0.4em;
-  height: 32px;
-}
-
 .has-error.login-box-msg::before,
 .has-error.login-box-msg::after {
   content: "ACCESS DENIED";


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix the size of this MEGA icon:

![image](https://github.com/pi-hole/AdminLTE/assets/1385443/c6b5b242-789a-4cd6-b562-d44b0df6a1d8)

**Note:**
The issue appeared after we updated the font-awesome javascript file.

### How does this PR accomplish the above?

Adjusting the CSS.

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
