### PR TITLE
Fix "Save & Apply" button

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1116,6 +1116,7 @@ table.dataTable tbody > tr > .selected {
   position: fixed;
   bottom: 2%;
   right: 2%;
+  z-index: 10;
 }
 
 .settings-level-0 {


### PR DESCRIPTION
### What does this PR aim to accomplish?

Depending on the screen size and the selected theme, the floating **_Save & Apply_** button (Settings page) will be behind other elements, making difficult or impossible to click on it.

![image](https://github.com/pi-hole/AdminLTE/assets/1385443/9ec7f90f-0d68-4ed0-9ffe-1af603783ed6)
---
![image](https://github.com/pi-hole/AdminLTE/assets/1385443/69504f27-dae2-4755-a97d-f7cd66ca9639)
---
![image](https://github.com/pi-hole/AdminLTE/assets/1385443/812fbd2e-366b-47b4-a7ae-ac246ae854ee)

### How does this PR accomplish the above?

Using a higher _z-index_ for the button will fix it.

### Link documentation PRs if any are needed to support this PR:

none

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
