### PR TITLE
Group search results by adlist

### DIFF
--- a/scripts/pi-hole/js/search.js
+++ b/scripts/pi-hole/js/search.js
@@ -34,80 +34,103 @@ function eventsource(partial) {
 
       const res = data.search;
       var result = "";
-      if (res.domains.length > 0) {
-        result =
-          "Found " +
-          res.domains.length +
-          " domain(s) <em>" +
-          verb +
-          "</em> matching '<strong class='text-blue'>" +
-          utils.escapeHtml(q) +
-          "</strong>':<br><br>";
-        for (const domain of res.domains) {
-          result +=
-            "  - <a href='groups-domains.lp?domainid=" +
-            domain.id +
-            "' target='_blank'><strong class='text-green'>" +
-            utils.escapeHtml(domain.domain) +
-            "</strong></a><br>    " +
-            domain.kind +
-            " " +
-            domain.type +
-            " domain<br>    added " +
-            utils.renderTimestamp(domain.date_added, "display") +
-            "<br>    last modified " +
-            utils.renderTimestamp(domain.date_modified, "display") +
-            "<br>    " +
-            (domain.enabled ? "enabled" : "disabled") +
-            ", used in " +
-            domain.groups.length +
-            " group" +
-            (domain.groups.length === 1 ? "" : "s") +
-            (domain.comment !== null && domain.comment.length > 0
-              ? '<br>    comment: "' + utils.escapeHtml(domain.comment) + '"'
-              : "<br>    no comment") +
-            ")<br><br>";
-        }
+      const numDomains = res.domains.length;
+      result =
+        "Found " +
+        numDomains +
+        " domain" +
+        (numDomains !== 1 ? "s" : "") +
+        " <em>" +
+        verb +
+        "</em> matching '<strong class='text-blue'>" +
+        utils.escapeHtml(q) +
+        "</strong>'" +
+        (numDomains > 0 ? ":" : ".") +
+        "<br><br>";
+      for (const domain of res.domains) {
+        result +=
+          "  - <a href='groups-domains.lp?domainid=" +
+          domain.id +
+          "' target='_blank'><strong class='text-green'>" +
+          utils.escapeHtml(domain.domain) +
+          "</strong></a><br>    " +
+          domain.kind +
+          " " +
+          domain.type +
+          " domain<br>    added:         " +
+          utils.renderTimestamp(domain.date_added, "display") +
+          "<br>    last modified: " +
+          utils.renderTimestamp(domain.date_modified, "display") +
+          "<br>    " +
+          (domain.enabled ? "enabled" : "disabled") +
+          ", used in " +
+          domain.groups.length +
+          " group" +
+          (domain.groups.length === 1 ? "" : "s") +
+          (domain.comment !== null && domain.comment.length > 0
+            ? '<br>    comment: "' + utils.escapeHtml(domain.comment) + '"'
+            : "<br>    no comment") +
+          "<br><br>";
       }
 
-      if (res.gravity.length > 0) {
-        result =
-          "Found " +
-          res.gravity.length +
-          " adlists <em>" +
-          verb +
-          "</em> matching '<strong class='text-blue'>" +
-          utils.escapeHtml(q) +
-          "</strong>':<br><br>";
-        for (const adlist of res.gravity) {
-          result +=
-            "  - <strong class='text-green'>" +
-            utils.escapeHtml(adlist.domain) +
-            "</strong>" +
-            "<br>    <a href='groups-adlists.lp?adlistid=" +
-            adlist.id +
-            "' target='_blank'>" +
-            utils.escapeHtml(adlist.address) +
-            "</a><br>    added " +
-            utils.renderTimestamp(adlist.date_added, "display") +
-            "<br>    last modified " +
-            utils.renderTimestamp(adlist.date_modified, "display") +
-            "<br>    last updated " +
-            utils.renderTimestamp(adlist.date_updated, "display") +
-            " (" +
-            adlist.number.toLocaleString() +
-            " domains)" +
-            "<br>    " +
-            (adlist.enabled ? "enabled" : "disabled") +
-            ", used in " +
-            adlist.groups.length +
-            " group" +
-            (adlist.groups.length === 1 ? "" : "s") +
-            (adlist.comment !== null && adlist.comment.length > 0
-              ? '<br>    comment: "' + utils.escapeHtml(adlist.comment) + '"'
-              : "<br>    no comment") +
-            "<br><br>";
+      // Group results in res.gravity by res.gravity[].address
+      var grouped = {};
+      for (const adlist of res.gravity) {
+        if (grouped[adlist.address] === undefined) {
+          grouped[adlist.address] = [];
         }
+
+        grouped[adlist.address].push(adlist);
+      }
+
+      const numAdlists = Object.keys(grouped).length;
+
+      result +=
+        "Found " +
+        numAdlists +
+        " adlist" +
+        (numAdlists !== 1 ? "s" : "") +
+        " <em>" +
+        verb +
+        "</em> matching '<strong class='text-blue'>" +
+        utils.escapeHtml(q) +
+        "</strong>'" +
+        (numAdlists > 0 ? ":" : ".") +
+        "<br><br>";
+      for (const address of Object.keys(grouped)) {
+        const adlist = grouped[address][0];
+        result +=
+          "  - <a href='groups-adlists.lp?adlistid=" +
+          adlist.id +
+          "' target='_blank'>" +
+          utils.escapeHtml(address) +
+          "</a><br>    added:         " +
+          utils.renderTimestamp(adlist.date_added, "display") +
+          "<br>    last modified: " +
+          utils.renderTimestamp(adlist.date_modified, "display") +
+          "<br>    last updated:  " +
+          utils.renderTimestamp(adlist.date_updated, "display") +
+          " (" +
+          adlist.number.toLocaleString() +
+          " domains)" +
+          "<br>    " +
+          (adlist.enabled ? "enabled" : "disabled") +
+          ", used in " +
+          adlist.groups.length +
+          " group" +
+          (adlist.groups.length === 1 ? "" : "s") +
+          (adlist.comment !== null && adlist.comment.length > 0
+            ? '<br>    comment: "' + utils.escapeHtml(adlist.comment) + '"'
+            : "<br>    no comment") +
+          "<br>";
+        for (const adlists of grouped[address]) {
+          result +=
+            "    - <strong class='text-green'>" +
+            utils.escapeHtml(adlists.domain) +
+            "</strong><br>";
+        }
+
+        result += "<br>";
       }
 
       result += "Search took " + (1000 * data.took).toFixed(1) + " ms";


### PR DESCRIPTION
# What does this implement/fix?

Previously, matches were sorted by domain, possibly duplicating additional information about the containing adlist:
![Screenshot from 2023-07-24 18-37-59](https://github.com/pi-hole/AdminLTE/assets/16748619/0b447c75-a5df-41a1-8ecd-f3238f438df0)

The new way of displaying this is by grouping domains by their containing adlist and show the additional information only once:
![Screenshot from 2023-07-24 18-38-06](https://github.com/pi-hole/AdminLTE/assets/16748619/3e7b013f-7af0-49df-83a2-6bbb2c6a79d2)


**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.