### PR TITLE
Revert "Fix login page rediction"

### DIFF
--- a/scripts/pi-hole/js/login.js
+++ b/scripts/pi-hole/js/login.js
@@ -33,11 +33,6 @@ function redirect() {
     }
   }
 
-  // Ensure the target ends in "/" if there is no query string
-  if (target.indexOf("?") === -1 && target.slice(-1) !== "/") {
-    target += "/";
-  }
-
   // Redirect to target
   window.location.replace(target);
 }


### PR DESCRIPTION
Reverts pi-hole/AdminLTE#2655

This code is not needed any longer since https://github.com/pi-hole/FTL/pull/1601 has been merged. Further testing has revealed that it can even be harmful. Example: When logging out on any other page than the dashboard, re-login leads to an error 404 because there should be no trailing slash.