### PR TITLE
Fix the gravity output to use the ${OVER} sequence

### DIFF
--- a/scripts/pi-hole/js/gravity.js
+++ b/scripts/pi-hole/js/gravity.js
@@ -47,9 +47,18 @@ function eventsource() {
               // Enqueue the next data chunk into our target stream
               controller.enqueue(value);
               var string = new TextDecoder().decode(value);
-              // Remove ${OVER} from the string
-              string = string.replaceAll("\r[K", "\n");
-              ta.append(string);
+
+              // If a Carriage Return is found ...
+              if (string.indexOf("\r") === -1) {
+                ta.append(string);
+              } else {
+                // ... remove the last line from the output ...
+                ta.text(ta.text().substring(0, ta.text().lastIndexOf("\n")) + "\n");
+                // ... and append the new text to the end of the output,
+                // without ${OVER} ("CR + ESC[K") or Carriage Return.
+                ta.append(string.replaceAll("\r[K", "").replaceAll("\r", ""));
+              }
+
               if (string.indexOf("Pi-hole blocking is") !== -1) {
                 alSuccess.show();
               }

--- a/scripts/pi-hole/js/gravity.js
+++ b/scripts/pi-hole/js/gravity.js
@@ -38,6 +38,7 @@ function eventsource() {
             return reader.read().then(({ done, value }) => {
               // When no more data needs to be consumed, close the stream
               if (done) {
+                ta.append("Done.");
                 controller.close();
                 alInfo.hide();
                 $("#gravityBtn").prop("disabled", false);


### PR DESCRIPTION
### What does this PR aim to accomplish?:

The "OVER" sequence `CR + ESC[K` is not working as expected.

The current code is just replacing the "OVER" sequence with a newline and printing the text after the previous line.

Also, the FTL `gravity_parseList()` function is sending only a Carriage Return (`\r`) instead of the full OVER sequence, because the web interface is not a terminal. This prints one very long line with the text of all Progress lines contatenated.
```
  [i] Processed 1% of downloaded list  [i] Processed 2% of downloaded list  [i] Processed 3% of downloaded list ...
```
![progress_wrong](https://github.com/pi-hole/AdminLTE/assets/1385443/df7107ed-f8e6-4cc4-b3f2-d749ebb07a6e)

### How does this PR accomplish the above?:

The new code fixes this:
When "OVER" is found, the last line on the screen is REPLACED by the new text (like it was in v5).

![progress_fixed](https://github.com/pi-hole/AdminLTE/assets/1385443/a4375403-2223-47c7-80b1-2e6c9abf2e3b)

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
