### PR TITLE
Fix HTTPS link on login page

### DIFF
--- a/login.lp
+++ b/login.lp
@@ -8,15 +8,6 @@
 --]]
 
 mg.include('scripts/pi-hole/lua/header.lp','r')
-
--- Build HTTPS upgrade link if HTTP is used
-https_link = ""
-if not is_secure then
-    https_link = "https://pi.hole" .. mg.request_info.request_uri
-    if mg.request_info.query_string then
-        https_link = https_link .. "?" .. mg.request_info.query_string
-    end
-end
 ?>
 <body class="hold-transition layout-boxed login-page">
 <div class="box login-box" id="login-box">
@@ -41,7 +32,7 @@ end
                             <h3 class="box-title has-error control-label"><i class="fa fa-fw fa-triangle-exclamation"></i>&nbsp;&nbsp;Insecure network connection&nbsp;&nbsp;<i class="fa fa-fw fa-triangle-exclamation"></i></h3>
                         </div>
                         <div class="box-body">
-                            <p>Consider upgrading to <a href="<?=https_link?>">HTTPS</a> (end-to-end encryption)</p>
+                            <p>Consider upgrading to <a href="#" id="https-link">HTTPS</a> (end-to-end encryption)</p>
                         </div>
                     </div>
                 </div>

--- a/scripts/pi-hole/js/login.js
+++ b/scripts/pi-hole/js/login.js
@@ -117,4 +117,10 @@ $(function () {
 
   // Clear TOTP field
   $("#totp").val("");
+
+  // Generate HTTPS redirection link (only used if not already HTTPS)
+  if (location.protocol !== "https:") {
+    const url = "https:" + location.href.substring(location.protocol.length);
+    $("#https-link").attr("href", url);
+  }
 });


### PR DESCRIPTION
# What does this implement/fix?

Fix https://github.com/pi-hole/AdminLTE/issues/2724

Do not hard-code `pi.hole` as hostname but instead build a dynamic HTTPS URL using Javascript to ensure we use the exact same URL the user used to get there (may even be an IP address with a custom port)

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.