### PR TITLE
Conditional HTTPS hint on login page

### DIFF
--- a/login.lp
+++ b/login.lp
@@ -26,8 +26,8 @@ mg.include('scripts/pi-hole/lua/header.lp','r')
                 <div class="text-center form-group has-error" id="dns-failure-label" style="display: none;">
                     <label>DNS Server failure detected, log in to see Pi-hole diagnosis messages</label>
                 </div>
-                <div class="text-center form-group has-error" id="dns-failure-label" style="display: <? if is_secure then ?>none<? else ?>block<? end ?>;">
-                    <div class="box box-danger" id="insecure-box">
+                <div class="text-center form-group has-error" id="insecure-box" style="display: none;">
+                    <div class="box box-danger">
                         <div class="box-header with-border pointer no-user-select">
                             <h3 class="box-title has-error control-label"><i class="fa fa-fw fa-triangle-exclamation"></i>&nbsp;&nbsp;Insecure network connection&nbsp;&nbsp;<i class="fa fa-fw fa-triangle-exclamation"></i></h3>
                         </div>

--- a/scripts/pi-hole/js/login.js
+++ b/scripts/pi-hole/js/login.js
@@ -109,23 +109,27 @@ $(function () {
   // Check if we need to login at all
   $.ajax({
     url: "/api/auth",
-  })
-    .done(function (data) {
-      if (data.session.valid === true) redirect();
-      if (data.session.totp === true) $("#totp_input").removeClass("hidden");
-      if (data.dns === false) showDNSfailure();
-    })
-    .always(function (data) {
-      // Generate HTTPS redirection link (only used if not already HTTPS)
-      if (location.protocol !== "https:" && data.responseJSON.https_port !== 0) {
-        let url = "https://" + location.hostname;
-        if (data.responseJSON.https_port !== 443) url += ":" + data.responseJSON.https_port;
-        url += location.pathname + location.search + location.hash;
+  }).done(function (data) {
+    if (data.session.valid === true) redirect();
+    if (data.session.totp === true) $("#totp_input").removeClass("hidden");
+  });
 
-        $("#https-link").attr("href", url);
-        $("#insecure-box").show();
-      }
-    });
+  // Get imformation about HTTPS port and DNS status
+  $.ajax({
+    url: "/api/info/login",
+  }).done(function (data) {
+    if (data.dns === false) showDNSfailure();
+
+    // Generate HTTPS redirection link (only used if not already HTTPS)
+    if (location.protocol !== "https:" && data.https_port !== 0) {
+      let url = "https://" + location.hostname;
+      if (data.https_port !== 443) url += ":" + data.https_port;
+      url += location.pathname + location.search + location.hash;
+
+      $("#https-link").attr("href", url);
+      $("#insecure-box").show();
+    }
+  });
 
   // Clear TOTP field
   $("#totp").val("");

--- a/scripts/pi-hole/js/login.js
+++ b/scripts/pi-hole/js/login.js
@@ -109,18 +109,24 @@ $(function () {
   // Check if we need to login at all
   $.ajax({
     url: "/api/auth",
-  }).done(function (data) {
-    if (data.session.valid === true) redirect();
-    if (data.session.totp === true) $("#totp_input").removeClass("hidden");
-    if (data.dns === false) showDNSfailure();
-  });
+  })
+    .done(function (data) {
+      if (data.session.valid === true) redirect();
+      if (data.session.totp === true) $("#totp_input").removeClass("hidden");
+      if (data.dns === false) showDNSfailure();
+    })
+    .always(function (data) {
+      // Generate HTTPS redirection link (only used if not already HTTPS)
+      if (location.protocol !== "https:" && data.responseJSON.https_port !== 0) {
+        let url = "https://" + location.hostname;
+        if (data.responseJSON.https_port !== 443) url += ":" + data.responseJSON.https_port;
+        url += location.pathname + location.search + location.hash;
+
+        $("#https-link").attr("href", url);
+        $("#insecure-box").show();
+      }
+    });
 
   // Clear TOTP field
   $("#totp").val("");
-
-  // Generate HTTPS redirection link (only used if not already HTTPS)
-  if (location.protocol !== "https:") {
-    const url = "https:" + location.href.substring(location.protocol.length);
-    $("#https-link").attr("href", url);
-  }
 });

--- a/scripts/pi-hole/js/login.js
+++ b/scripts/pi-hole/js/login.js
@@ -114,7 +114,7 @@ $(function () {
     if (data.session.totp === true) $("#totp_input").removeClass("hidden");
   });
 
-  // Get imformation about HTTPS port and DNS status
+  // Get information about HTTPS port and DNS status
   $.ajax({
     url: "/api/info/login",
   }).done(function (data) {


### PR DESCRIPTION
# What does this implement/fix?

Show HTTPS hint on login page only when HTTPS is actually served. If it is served on a port != 443, add this port as well to the link

Depends on FTL in https://github.com/pi-hole/FTL/pull/1653

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.