### PR TITLE
Change old `-a -p` parameters to `setpassword`

### DIFF
--- a/login.lp
+++ b/login.lp
@@ -80,7 +80,7 @@ mg.include('scripts/pi-hole/lua/header.lp','r')
                                     a new password (or explicitly disable the password by setting an empty password)
                                     using the command
                                 </p>
-                                <pre>sudo pihole -a -p</pre>
+                                <pre>sudo pihole setpassword</pre>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix the issue reported on Discourse:
https://discourse.pi-hole.net/t/password-help-for-beta-6-0-gives-the-wrong-instruction/65484

### How does this PR accomplish the above?

Changing the command on the page.

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
