### PR TITLE
Restore Teleporter functionality

### DIFF
--- a/scripts/pi-hole/js/settings-teleporter.js
+++ b/scripts/pi-hole/js/settings-teleporter.js
@@ -86,7 +86,7 @@ $("#GETTeleporter").on("click", function () {
       // eslint-disable-next-line compat/compat
       var url = window.URL.createObjectURL(data);
       a.href = url;
-      a.download = xhr.getResponseHeader("Content-Disposition").split("filename=")[1];
+      a.download = xhr.getResponseHeader("Content-Disposition").match(/filename="([^"]*)"/)[1];
       document.body.append(a);
       a.click();
       a.remove();

--- a/scripts/pi-hole/js/settings-teleporter.js
+++ b/scripts/pi-hole/js/settings-teleporter.js
@@ -81,12 +81,12 @@ $("#GETTeleporter").on("click", function () {
     xhrFields: {
       responseType: "blob",
     },
-    success: function (data) {
+    success: function (data, status, xhr) {
       var a = document.createElement("a");
       // eslint-disable-next-line compat/compat
       var url = window.URL.createObjectURL(data);
       a.href = url;
-      a.download = "teleporter.zip";
+      a.download = xhr.getResponseHeader("Content-Disposition").split("filename=")[1];
       document.body.append(a);
       a.click();
       a.remove();

--- a/scripts/pi-hole/js/settings-teleporter.js
+++ b/scripts/pi-hole/js/settings-teleporter.js
@@ -33,6 +33,7 @@ function importZIP() {
   fetch("/api/teleporter", {
     method: "POST",
     body: formData,
+    headers: { "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr("content") },
   })
     .then(response => response.json())
     .then(data => {
@@ -70,3 +71,27 @@ function importZIP() {
       console.error(error); // eslint-disable-line no-console
     });
 }
+
+// Inspired by https://stackoverflow.com/a/59576416/2087442
+$("#GETTeleporter").on("click", function () {
+  $.ajax({
+    url: "/api/teleporter",
+    headers: { "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr("content") },
+    method: "GET",
+    xhrFields: {
+      responseType: "blob",
+    },
+    success: function (data) {
+      var a = document.createElement("a");
+      // eslint-disable-next-line compat/compat
+      var url = window.URL.createObjectURL(data);
+      a.href = url;
+      a.download = "teleporter.zip";
+      document.body.append(a);
+      a.click();
+      a.remove();
+      // eslint-disable-next-line compat/compat
+      window.URL.revokeObjectURL(url);
+    },
+  });
+});

--- a/settings-teleporter.lp
+++ b/settings-teleporter.lp
@@ -23,7 +23,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                 <p>Warning: This archive contains sensitive information about your Pi-hole installation, e.g. the API token and the 2FA-TOTP secret (if enabled). Please be careful with this file and do not share it with anyone even if they claim to help you.</p>
                 <? if not is_secure then ?><p class='text-danger'>Warning: You are currently not using an end-to-end encryption. This means that your API token and 2FA-TOTP secret will be transmitted in plain text. We recommend to use HTTPS when exporting your configuration.</p><? end ?>
                 <div class="pull-right">
-                    <a class="btn btn-app btn-success" href="/api/teleporter" target="_blank">
+                    <a class="btn btn-app btn-success" id="GETTeleporter" target="_blank">
                         <i class="fa fa-save"></i><br>Export
                     </a>
                 </div>


### PR DESCRIPTION
# What does this implement/fix?

Restore Teleporter functionality. Concerning compatibility, https://caniuse.com/url tells us it can be used in any sufficiently recent browser except IE and Opera Mini. If you have a better approach, I'd love to see it.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.