### PR TITLE
Fix AJAX JSON data

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -119,10 +119,11 @@ function piholeChange(action, duration) {
   $.ajax({
     url: "/api/dns/blocking",
     method: "POST",
-    data: JSON.stringify({
+    dataType: "json",
+    data: {
       blocking: action === "enable",
       timer: parseInt(duration, 10) > 0 ? parseInt(duration, 10) : null,
-    }),
+    },
   })
     .done(function (data) {
       if (data.blocking === action + "d") {

--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -516,7 +516,7 @@ function addAdlist(event) {
     url: "/api/lists",
     method: "post",
     dataType: "json",
-    data: JSON.stringify({ address: address, comment: comment, type: type }),
+    data: { address: address, comment: comment, type: type },
     success: function () {
       utils.enableAll();
       utils.showAlert("success", "fas fa-plus", "Successfully added " + type + "list", address);
@@ -582,12 +582,12 @@ function editAdlist() {
     url: "/api/lists/" + encodeURIComponent(addressDecoded),
     method: "put",
     dataType: "json",
-    data: JSON.stringify({
+    data: {
       groups: groups,
       comment: comment,
       enabled: enabled,
       type: type,
-    }),
+    },
     success: function () {
       utils.enableAll();
       utils.showAlert(

--- a/scripts/pi-hole/js/groups-clients.js
+++ b/scripts/pi-hole/js/groups-clients.js
@@ -440,7 +440,7 @@ function addClient() {
     url: "/api/clients",
     method: "post",
     dataType: "json",
-    data: JSON.stringify({ client: ip, comment: comment }),
+    data: { client: ip, comment: comment },
     success: function () {
       utils.enableAll();
       utils.showAlert("success", "fas fa-plus", "Successfully added client", ip);
@@ -495,12 +495,12 @@ function editClient() {
     url: "/api/clients/" + encodeURIComponent(clientDecoded),
     method: "put",
     dataType: "json",
-    data: JSON.stringify({
+    data: {
       client: client,
       groups: groups,
       comment: comment,
       enabled: enabled,
-    }),
+    },
     success: function () {
       utils.enableAll();
       utils.showAlert(

--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -527,12 +527,12 @@ function addDomain() {
     url: "/api/domains/" + type + "/" + kind,
     method: "post",
     dataType: "json",
-    data: JSON.stringify({
+    data: {
       domain: domain,
       comment: comment,
       type: type,
       kind: kind,
-    }),
+    },
     success: function () {
       utils.enableAll();
       utils.showAlert("success", "fas fa-plus", "Successfully added domain", domain);
@@ -609,13 +609,13 @@ function editDomain() {
     url: "/api/domains/" + newTypestr + "/" + encodeURIComponent(domainDecoded),
     method: "put",
     dataType: "json",
-    data: JSON.stringify({
+    data: {
       groups: groups,
       comment: comment,
       enabled: enabled,
       type: oldType,
       kind: oldKind,
-    }),
+    },
     success: function () {
       utils.enableAll();
       utils.showAlert(

--- a/scripts/pi-hole/js/groups.js
+++ b/scripts/pi-hole/js/groups.js
@@ -294,11 +294,11 @@ function addGroup() {
     url: "/api/groups",
     method: "post",
     dataType: "json",
-    data: JSON.stringify({
+    data: {
       name: name,
       comment: comment,
       enabled: true,
-    }),
+    },
     success: function () {
       utils.enableAll();
       utils.showAlert("success", "fas fa-plus", "Successfully added group", name);
@@ -360,11 +360,11 @@ function editGroup() {
     url: "/api/groups/" + oldName,
     method: "put",
     dataType: "json",
-    data: JSON.stringify({
+    data: {
       name: name,
       comment: comment,
       enabled: enabled,
-    }),
+    },
     success: function () {
       utils.enableAll();
       utils.showAlert("success", "fas fa-pencil-alt", "Successfully " + done + " group", oldName);

--- a/scripts/pi-hole/js/login.js
+++ b/scripts/pi-hole/js/login.js
@@ -60,7 +60,8 @@ function doLogin(password) {
   $.ajax({
     url: "/api/auth",
     method: "POST",
-    data: JSON.stringify({ password: password, totp: parseInt($("#totp").val(), 10) }),
+    dataType: "json",
+    data: { password: password, totp: parseInt($("#totp").val(), 10) },
   })
     .done(function () {
       wrongPassword(false, true);

--- a/scripts/pi-hole/js/settings-api.js
+++ b/scripts/pi-hole/js/settings-api.js
@@ -318,7 +318,8 @@ function setTOTPSecret(secret) {
   $.ajax({
     url: "/api/config",
     type: "PATCH",
-    data: JSON.stringify({ config: { webserver: { api: { totp_secret: secret } } } }),
+    dataType: "json",
+    data: { config: { webserver: { api: { totp_secret: secret } } } },
     contentType: "application/json",
   })
     .done(function () {

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -137,7 +137,8 @@ function saveSettings() {
   $.ajax({
     url: "/api/config",
     method: "PATCH",
-    data: JSON.stringify({ config: settings }),
+    dataType: "json",
+    data: { config: settings },
     contentType: "application/json; charset=utf-8",
   })
     .done(function () {

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -315,12 +315,12 @@ function addFromQueryLog(domain, list) {
       url: "/api/domains/" + list + "/exact",
       method: "post",
       dataType: "json",
-      data: JSON.stringify({
+      data: {
         domain: domain,
         comment: "Added from Query Log",
         type: list,
         kind: "exact",
-      }),
+      },
       success: function (response) {
         alProcessing.hide();
         if ("domains" in response && response.domains.length > 0) {


### PR DESCRIPTION
# What does this implement/fix?

Following

http://api.jquery.com/jquery.ajax/

we should not pass a `string` but the `PlainObject` to `AJAX.data`. If we pass a string, it needs to be correctly encoded (`application/x-www-form-urlencoded`) which the output of `JSON.stringify()` is not.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.