### PR TITLE
Fix broken multi-delete of adlists

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -359,7 +359,7 @@ function initTable() {
             var ids = [];
             $("tr.selected").each(function () {
               // ... add the row identified by "data-id".
-              ids.push($(this).attr("data-id"), 10);
+              ids.push($(this).attr("data-id"));
             });
             // Delete all selected rows at once
             delItems(ids);


### PR DESCRIPTION
# What does this implement/fix?

Multi-delete (select on the left and click the gray trash button) of adlists is broken in the current `development-v6` branch. Deleting individual adlists by the red trash button is not affected by this bug.

The issue seems to come from an insufficient removal of previous code parts when migrating from v5.x code. There used to be a `parseInt(x, 10)` code here, the `,10` has been forgotten to be removed.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.