### PR TITLE
Insert icheck CSS right after bootstrap file.

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -143,7 +143,7 @@ function initCheckboxRadioStyle() {
   }
 
   var boxsheet = $('<link href="' + getCheckboxURL(chkboxStyle) + '" rel="stylesheet" />');
-  boxsheet.appendTo("head");
+  boxsheet.insertAfter($("link[href*='style/vendor/bootstrap/css/bootstrap.min.css']"));
 
   applyCheckboxRadioStyle(chkboxStyle);
 

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -779,29 +779,33 @@ li:not(.menu-open) .treeview-menu .warning-count {
 }
 
 /* Domains table: filter by type - smaller icheck */
-body:not(.lcars) .filter_types [class*="icheck-"] > label {
+body:not([class*="lcars"]) .filter_types [class*="icheck-"] > label {
   padding-left: 1.5em !important;
   line-height: 1.2em;
   min-height: 1.2em;
 }
-body:not(.lcars)
+body:not([class*="lcars"])
   .filter_types
   [class*="icheck-"]
   > input:first-child
   + input[type="hidden"]
   + label::before,
-body:not(.lcars) .filter_types [class*="icheck-"] > input:first-child + label::before {
+body:not([class*="lcars"]) .filter_types [class*="icheck-"] > input:first-child + label::before {
   width: 1.2em;
   height: 1.2em;
   margin-left: -1.55em;
 }
-body:not(.lcars)
+body:not([class*="lcars"])
   .filter_types
   [class*="icheck-"]
   > input:first-child:checked
   + input[type="hidden"]
   + label::after,
-body:not(.lcars) .filter_types [class*="icheck-"] > input:first-child:checked + label::after {
+body:not([class*="lcars"])
+  .filter_types
+  [class*="icheck-"]
+  > input:first-child:checked
+  + label::after {
   width: 0.35em;
   height: 0.7em;
   top: -0.2em;


### PR DESCRIPTION
### What issues does this PR aim to fix?

Note: this PR is aimed to fix issues identified during the tests of the new [LCARS Picard theme](https://github.com/pi-hole/web/pull/2709).

In CSS, the order of files matters.

The current code inserts `icheck` CSS in the end of `<HEAD>` tag (after all theme files). `icheck` CSS file uses a few `!important` rules.

If a theme needs to change something related to `icheck` elements, a higher selector specificity is needed (in addition to `!important` rules).

Another issue is the use of `body:not(.lcars)`. This selector doesn't work for the new theme, but it should.

### How does this PR fix the issues?

Changing where we insert this CSS file.
Replacing the `body:not(.lcars)` selector with `body:not([class*="lcars"])`.

These changes will reduce the need of complex selectors or hacks to achieve a higher specificity.

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
