### PR TITLE
Do not show extra N/A when no ABP-style domains are in a list

### DIFF
--- a/scripts/pi-hole/js/groups-adlists.js
+++ b/scripts/pi-hole/js/groups-adlists.js
@@ -85,7 +85,7 @@ function format(data) {
       : "N/A") +
     (data.abp_entries !== null && parseInt(data.abp_entries, 10) > 0 && numbers === true
       ? " (out of which " + parseInt(data.abp_entries, 10).toLocaleString() + " are in ABP-style)"
-      : "N/A") +
+      : "") +
     '</td></tr><tr class="dataTables-child"' +
     "><td>Number of non-domains on this list:&nbsp;&nbsp;</td>" +
     "<td>" +


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug reported on [Discourse](https://discourse.pi-hole.net/t/blocklist-statistics-always-includes-n-a-with-number-of-entries-on-this-list/65690)

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.