### PR TITLE
Do not load `default-light.css` file when using Auto theme, if dark mode is preferred

### DIFF
--- a/style/themes/default-auto.css
+++ b/style/themes/default-auto.css
@@ -1,6 +1,6 @@
 /* Code courtesy of https://blog.jim-nielsen.com/2019/conditional-syntax-highlighting-in-dark-mode-with-css-imports/ */
 
-/* Assume light mode by default */
-@import "default-light.css" screen and (prefers-color-scheme: light);
-/* Supersede dark mode when applicable */
+/* Import light mode if color-scheme is different than dark (even not set) */
+@import "default-light.css" screen and not (prefers-color-scheme: dark);
+/* Import dark mode when applicable */
 @import "default-dark.css" screen and (prefers-color-scheme: dark);

--- a/style/themes/default-auto.css
+++ b/style/themes/default-auto.css
@@ -1,6 +1,6 @@
 /* Code courtesy of https://blog.jim-nielsen.com/2019/conditional-syntax-highlighting-in-dark-mode-with-css-imports/ */
 
 /* Assume light mode by default */
-@import "default-light.css" screen;
+@import "default-light.css" screen and (prefers-color-scheme: light);
 /* Supersede dark mode when applicable */
 @import "default-dark.css" screen and (prefers-color-scheme: dark);


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix #2763 

When the **Pi-hole auto** theme is used and the user preference is dark mode, the current code is loading both themes (first light, then dark). 

Most styles are overridden by dark theme, but due to small differences between these themes some elements are retaining Light styles on the Dark theme.

### How does this PR accomplish the above?

This PR considers a color scheme preference is always set. The light theme is loaded only when the preference is Light mode (when no preference is set, Light is the default).

Only dark file is loaded when dark mode is selected on the browser.


### Link documentation PRs if any are needed to support this PR:

none

### NOTE:

The previous code always loads the light theme and **when dark mode is selected** it also loads the dark theme, at the same time.

That code was based on an [article](https://blog.jim-nielsen.com/2019/conditional-syntax-highlighting-in-dark-mode-with-css-imports/) and it wasn't using `(prefers-color-scheme: light)`. The author's assumption was based on an older specification, when there were 3 possible values to this media feature: `no-preference | light | dark`.

> `@media (prefers-color-scheme: dark)` is still pretty new, which is why I don’t use `@media (prefers-color-scheme: light)` for the first `@import`.

In practice only 2 values are used by browsers: `light | dark`.

`light` is used as default, even when no value is set.
`no-preference` value was [deprecated](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme#browser_compatibility).

> This feature, like the other `prefers-*` features, previously had a `no-preference` value to indicate an author not expressing an active preference. However, user agents converged on expressing the "default" behavior as a light preference, and never matching `no-preference`.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
