### PR TITLE
Show active instead of clients-ever-seen on the dashboard

### DIFF
--- a/index.lp
+++ b/index.lp
@@ -22,8 +22,8 @@ mg.include('scripts/pi-hole/lua/header_authenticated.lp','r')
             <div class="icon">
                 <i class="fas fa-globe-americas"></i>
             </div>
-            <a href="network.lp" class="small-box-footer" title="">
-                <span id="total_clients">-</span> active clients <i class="fa fa-arrow-circle-right"></i>
+            <a href="network.lp" class="small-box-footer" title="" id="total_clients">
+                <span id="active_clients">-</span> active clients <i class="fa fa-arrow-circle-right"></i>
             </a>
         </div>
     </div>

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -384,7 +384,10 @@ function updateSummaryData(runOnce) {
   $.getJSON("/api/stats/summary", function (data) {
     var intl = new Intl.NumberFormat();
     glowIfChanged($("span#dns_queries"), intl.format(parseInt(data.queries.total, 10)));
-    glowIfChanged($("span#total_clients"), intl.format(parseInt(data.clients.total, 10)));
+    let clientsString = intl.format(parseInt(data.clients.active, 10));
+    if (data.clients.active !== data.clients.total)
+      clientsString += " / " + intl.format(parseInt(data.clients.total, 10));
+    glowIfChanged($("span#total_clients"), clientsString);
     glowIfChanged($("span#blocked_queries"), intl.format(parseFloat(data.queries.blocked)));
     glowIfChanged(
       $("span#percent_blocked"),

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -384,10 +384,11 @@ function updateSummaryData(runOnce) {
   $.getJSON("/api/stats/summary", function (data) {
     var intl = new Intl.NumberFormat();
     glowIfChanged($("span#dns_queries"), intl.format(parseInt(data.queries.total, 10)));
-    let clientsString = intl.format(parseInt(data.clients.active, 10));
-    if (data.clients.active !== data.clients.total)
-      clientsString += " / " + intl.format(parseInt(data.clients.total, 10));
-    glowIfChanged($("span#total_clients"), clientsString);
+    glowIfChanged($("span#active_clients"), intl.format(parseInt(data.clients.active, 10)));
+    $("a#total_clients").attr(
+      "title",
+      intl.format(parseInt(data.clients.total, 10)) + " total clients"
+    );
     glowIfChanged($("span#blocked_queries"), intl.format(parseFloat(data.queries.blocked)));
     glowIfChanged(
       $("span#percent_blocked"),


### PR DESCRIPTION
# What does this implement/fix?

Show *active* clients instead of *clients-ever-seen* on the dashboard:
![Screenshot from 2023-10-21 18-45-55](https://github.com/pi-hole/web/assets/16748619/1d57b999-ef6d-4bae-945b-5614472789c6)

When the two numbers are different, show both
![image](https://github.com/pi-hole/web/assets/16748619/459cc0f4-9c9a-4de8-837a-032d640a4d48)

This PR depends on the corresponding FTL branch being checked out: https://github.com/pi-hole/FTL/pull/1688

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.