### PR TITLE
Always point "Pi-hole" top bar link to `pihole.webhome`

### DIFF
--- a/scripts/pi-hole/lua/header_authenticated.lp
+++ b/scripts/pi-hole/lua/header_authenticated.lp
@@ -34,7 +34,7 @@ mg.include('header.lp','r')
 <div class="wrapper">
     <header class="main-header">
         <!-- Logo -->
-        <a href="index.lp" class="logo">
+        <a href="<?=pihole.webhome()?>" class="logo">
             <!-- mini logo for sidebar mini 50x50 pixels -->
             <span class="logo-mini">P<strong>h</strong></span>
             <!-- logo for regular state and mobile devices -->


### PR DESCRIPTION
### What does this PR aim to accomplish?

The "Pi-hole " link on the top bar was using a relative URL pointing to `index.lp` page.

![image](https://github.com/pi-hole/web/assets/1385443/652d4c41-893c-4daa-ada3-c2b7228a8aab)

This was an issue when accessing one of the Settings pages, because the link was pointing to `/admin/settings/index.lp`, which is an invalid address.

### How does this PR accomplish the above?

Replacing the `index.lp` with `pihole.webhome()`.

This will assure the link is always pointing to the web interface home.

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
