### PR TITLE
Show indication on settings causing a restart

### DIFF
--- a/scripts/pi-hole/js/settings-advanced.js
+++ b/scripts/pi-hole/js/settings-advanced.js
@@ -46,6 +46,9 @@ function generateRow(topic, key, value) {
     (value.flags.advanced
       ? '&nbsp;&nbsp;<i class="fas fa-cogs text-yellow" title="Expert-level setting"></i>'
       : "") +
+    (value.flags.restart_dnsmasq
+      ? '&nbsp;&nbsp;<i class="fas fa-redo text-red" title="Setting requires FTL restart on change"></i>'
+      : "") +
     "</h3>" +
     "<p>" +
     utils.escapeHtml(value.description).replace("\n", "<br>") +

--- a/scripts/pi-hole/js/settings-system.js
+++ b/scripts/pi-hole/js/settings-system.js
@@ -280,7 +280,7 @@ $("#loggingButton").confirm({
     "Are you sure you want to switch query logging mode?<br><br>" +
     "<strong>This will restart the DNS server.</strong><br>" +
     "As consequence of this action, your DNS cache will be cleared and you may temporarily loose your internet connection.<br>" +
-    "Furthermore, you will be logged out of the web interface.",
+    "Furthermore, you may be logged out of the web interface.",
   title: "Confirmation required",
   confirm: function () {
     const data = {};


### PR DESCRIPTION
# What does this implement/fix?

Add red redo-icon on advanced settings page for settings requiring a restart of FTL

![image](https://github.com/pi-hole/web/assets/16748619/5ac5bffe-6f7b-430e-9da3-c4ce10f15f40)

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.