### PR TITLE
Fix TOTP input field not being shown when enabled

### DIFF
--- a/scripts/pi-hole/js/login.js
+++ b/scripts/pi-hole/js/login.js
@@ -111,10 +111,16 @@ $(function () {
   // Check if we need to login at all
   $.ajax({
     url: "/api/auth",
-  }).done(function (data) {
-    if (data.session.valid === true) redirect();
-    if (data.session.totp === true) $("#totp_input").removeClass("hidden");
-  });
+  })
+    .done(function (data) {
+      // If we are already logged in, redirect to dashboard
+      if (data.session.valid === true) redirect();
+    })
+    .fail(function (xhr) {
+      const session = xhr.responseJSON.session;
+      // If TOPT is enabled, show the input field
+      if (session.totp === true) $("#totp_input").removeClass("hidden");
+    });
 
   // Get information about HTTPS port and DNS status
   $.ajax({


### PR DESCRIPTION
# What does this implement/fix?

See title, the issue is that `401 Unauthorized` is not handled in `.done()` but in `.fail()`

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.