### PR TITLE
temp.limit needs to be data-type="integer"

### DIFF
--- a/settings-api.lp
+++ b/settings-api.lp
@@ -123,7 +123,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 <label for="webserver.api.temp.limit"><strong>Temperature limit for "hot":</strong></label>
                             </div>
                             <div class="col-md-6">
-                                <input type="number" id="webserver.api.temp.limit" data-key="webserver.api.temp.limit">
+                                <input type="number" data-type="integer" id="webserver.api.temp.limit" data-key="webserver.api.temp.limit">
                             </div>
                         </div>
                         <div class="row">


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fix the input field of the temp limit from `/settings/api`. The data-type was missing and the corresponding js did not convert the input to integer.

https://github.com/pi-hole/web/blob/1a359449d86306649d17081039fbf238a527b765/scripts/pi-hole/js/settings.js#L110-L113

Missing this, errors were generated and the new limit was not saved.

```
023-10-27 12:51:06.960 [282154/T282165] ERR: /api/config: webserver.api.temp.limit invalid: not a number
2023-10-27 12:51:06.961 [282154/T282165] INFO: No config changes detected
2023-10-27 12:51:14.810 [282154/T282166] ERR: /api/config: webserver.api.temp.limit invalid: not a number
2023-10-27 12:51:14.811 [282154/T282166] INFO: No config changes detected
2023-10-27 12:52:07.074 [282154/T282167] INFO: Writing config file
2023-10-27 12:52:28.312 [282154/T282168] ERR: /api/config: webserver.api.temp.limit invalid: not a number
2023-10-27 12:52:28.313 [282154/T282168] INFO: No config changes detected

```

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
