### PR TITLE
Mark variables set by environment variable as read only in the web interface

### DIFF
--- a/scripts/pi-hole/js/settings-advanced.js
+++ b/scripts/pi-hole/js/settings-advanced.js
@@ -41,10 +41,16 @@ function generateRow(topic, key, value) {
     '<h3 class="box-title">' +
     key +
     (value.modified
-      ? '&nbsp;&nbsp;<i class="far fa-edit text-light-blue" title="Modified"></i>'
+      ? '&nbsp;&nbsp;<i class="far fa-edit text-light-blue" title="Modified from default"></i>'
       : "") +
     (value.flags.advanced
       ? '&nbsp;&nbsp;<i class="fas fa-cogs text-yellow" title="Expert-level setting"></i>'
+      : "") +
+    (value.flags.restart_dnsmasq
+      ? '&nbsp;&nbsp;<i class="fas fa-redo text-orange" title="Setting requires FTL restart on change"></i>'
+      : "") +
+    (value.flags.env_var
+      ? '&nbsp;&nbsp;<i class="fas fa-times-circle text-red" title="Setting overwritten by an environmental variable are read-only"></i>'
       : "") +
     "</h3>" +
     "<p>" +
@@ -84,6 +90,11 @@ function generateRow(topic, key, value) {
     }
   }
 
+  let extraAttributes = "";
+  if (value.flags.env_var) {
+    extraAttributes = " disabled";
+  }
+
   switch (value.type) {
     case "IPv4 address":
     case "IPv6 address":
@@ -95,7 +106,9 @@ function generateRow(topic, key, value) {
         value.value +
         '" data-key="' +
         key +
-        '"> ' +
+        '"' +
+        extraAttributes +
+        "> " +
         defaultValueHint +
         addAllowedValues(value.allowed) +
         "</div>";
@@ -111,7 +124,9 @@ function generateRow(topic, key, value) {
         key +
         '-checkbox" data-key="' +
         key +
-        '"><label for="' +
+        '"' +
+        extraAttributes +
+        '><label for="' +
         key +
         '-checkbox">Enabled ' +
         defaultValueHint +
@@ -129,7 +144,9 @@ function generateRow(topic, key, value) {
         value.value +
         '" data-key="' +
         key +
-        '" data-type="float"> ' +
+        '" data-type="float"' +
+        extraAttributes +
+        "> " +
         defaultValueHint +
         "</div>";
 
@@ -144,7 +161,9 @@ function generateRow(topic, key, value) {
         value.value +
         '" data-key="' +
         key +
-        '" data-type="integer"> ' +
+        '" data-type="integer"' +
+        extraAttributes +
+        "> " +
         defaultValueHint +
         "</div>";
 
@@ -159,7 +178,9 @@ function generateRow(topic, key, value) {
         value.value +
         '" data-key="' +
         key +
-        '" data-type="integer"> ' +
+        '" data-type="integer"' +
+        extraAttributes +
+        "> " +
         defaultValueHint +
         "</div>";
 
@@ -174,7 +195,9 @@ function generateRow(topic, key, value) {
         value.value +
         '" data-key="' +
         key +
-        '" data-type="integer"> ' +
+        '" data-type="integer"' +
+        extraAttributes +
+        "> " +
         defaultValueHint +
         "</div>";
 
@@ -187,7 +210,9 @@ function generateRow(topic, key, value) {
         '<div class="col-sm-7">' +
         '<textarea class="form-control" data-key="' +
         key +
-        '">' +
+        '"' +
+        extraAttributes +
+        ">" +
         value.value.join("\n") +
         "</textarea> " +
         defaultValueHint +
@@ -204,7 +229,9 @@ function generateRow(topic, key, value) {
         '<div class="col-sm-8">' +
         '<select class="form-control" data-key="' +
         key +
-        '">';
+        '"' +
+        extraAttributes +
+        ">";
       value.allowed.forEach(function (option) {
         box +=
           '<option value="' +
@@ -234,7 +261,9 @@ function generateRow(topic, key, value) {
         value.value +
         '" data-key="' +
         key +
-        '"> ' +
+        '"' +
+        extraAttributes +
+        "> " +
         defaultValueHint +
         addAllowedValues(value.allowed) +
         "</div>";

--- a/scripts/pi-hole/js/settings-advanced.js
+++ b/scripts/pi-hole/js/settings-advanced.js
@@ -50,7 +50,7 @@ function generateRow(topic, key, value) {
       ? '&nbsp;&nbsp;<i class="fas fa-redo text-orange" title="Setting requires FTL restart on change"></i>'
       : "") +
     (value.flags.env_var
-      ? '&nbsp;&nbsp;<i class="fas fa-times-circle text-red" title="Setting overwritten by an environmental variable are read-only"></i>'
+      ? '&nbsp;&nbsp;<i class="fas fa-lock text-orange" title="Settings overwritten by an environmental variable are read-only"></i>'
       : "") +
     "</h3>" +
     "<p>" +

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -18,6 +18,12 @@ function removeFromArray(arr, what) {
 }
 
 function fillDNSupstreams(value, servers) {
+  var disabledStr = "";
+  if (value.flags.env_var === true) {
+    $("#DNSupstreamsTextfield").prop("disabled", true);
+    disabledStr = 'disabled="Disabled"';
+  }
+
   var i = 0;
   var customServers = value.value.length;
   servers.forEach(element => {
@@ -30,21 +36,21 @@ function fillDNSupstreams(value, servers) {
       // Loop over available addresses (up to 2)
       for (let index = 0; index < 2; index++) {
         if (address.length > index) {
-          row +=
-            '<td title="' +
-            address[index] +
-            '"><div><input type="checkbox" id="DNSupstreams-' +
-            i +
-            '"';
+          var checkedStr = "";
           if (
             value.value.includes(address[index]) ||
             value.value.includes(address[index] + "#53")
           ) {
-            row += " checked";
+            checkedStr = "checked";
             customServers--;
           }
 
-          row += '><label for="DNSupstreams-' + i++ + '"></label></div></td>';
+          row += `<td title="${address[index]}">
+                    <div>
+                      <input type="checkbox" id="DNSupstreams-${i}" ${disabledStr} ${checkedStr}>
+                      <label for="DNSupstreams-${i++}"></label>
+                    </div>
+                  </td>`;
         } else {
           row += "<td></td>";
         }

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -37,10 +37,26 @@ function setConfigValues(topic, key, value) {
 
   // else: we have a setting we can set
   var escapedKey = key.replaceAll(".", "\\.");
+  var envTitle = $(`.${escapedKey}`);
+
+  if (value.flags.advanced) {
+    if (envTitle.find(".advanced-warning").length === 0) {
+      envTitle.append(
+        `<span class="advanced-warning">&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced level setting"></i></span>`
+      );
+    }
+  }
+
+  if (value.flags.restart_dnsmasq) {
+    if (envTitle.find(".restart-warning").length === 0) {
+      envTitle.append(
+        `<span class="restart-warning">&nbsp;&nbsp;<i class="fas fa-redo text-orange" title="Setting requires FTL restart on change"></i></span>`
+      );
+    }
+  }
 
   if (value.flags.env_var) {
     // If this setting has been set by environment variable, display a padlock in the section title
-    var envTitle = $(`.${escapedKey}`);
     if (envTitle.find(".env-warning").length === 0) {
       envTitle.append(
         `<span class="env-warning">&nbsp;&nbsp;<i class="fas fa-lock text-orange env-warning" title="Settings overwritten by an environmental variable are read-only"></i></span>`

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -37,6 +37,19 @@ function setConfigValues(topic, key, value) {
 
   // else: we have a setting we can set
   var escapedKey = key.replaceAll(".", "\\.");
+
+  if (value.flags.env_var) {
+    // If this setting has been set by environment variable, display a padlock in the section title
+    var envTitle = $(`.${escapedKey}`);
+    if (envTitle.find(".env-warning").length === 0) {
+      envTitle.append(
+        `<span class="env-warning">&nbsp;&nbsp;<i class="fas fa-lock text-orange env-warning" title="Settings overwritten by an environmental variable are read-only"></i></span>`
+      );
+    }
+
+    $(`#${escapedKey}`).prop("disabled", "disabled");
+  }
+
   switch (value.type) {
     case "enum (unsigned integer)": // fallthrough
     case "enum (string)": {
@@ -44,6 +57,7 @@ function setConfigValues(topic, key, value) {
       $("#" + escapedKey + " option").remove();
       // Add allowed select items (if available)
       value.allowed.forEach(function (allowedValue) {
+        $("#" + escapedKey + "-" + allowedValue.item).prop("disabled", value.flags.env_var);
         var newopt = $("<option></option>")
           .attr("value", allowedValue.item)
           .text(allowedValue.description);
@@ -70,7 +84,6 @@ function setConfigValues(topic, key, value) {
     case "string array": {
       // Set input field values from array (if available)
       $("#" + escapedKey).val(value.value.join("\n"));
-
       break;
     }
 

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -39,20 +39,16 @@ function setConfigValues(topic, key, value) {
   var escapedKey = key.replaceAll(".", "\\.");
   var envTitle = $(`.${escapedKey}`);
 
-  if (value.flags.advanced) {
-    if (envTitle.find(".advanced-warning").length === 0) {
-      envTitle.append(
-        `<span class="advanced-warning">&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced level setting"></i></span>`
-      );
-    }
+  if (value.flags.advanced && envTitle.find(".advanced-warning").length === 0) {
+    envTitle.append(
+      `<span class="advanced-warning">&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced level setting"></i></span>`
+    );
   }
 
-  if (value.flags.restart_dnsmasq) {
-    if (envTitle.find(".restart-warning").length === 0) {
-      envTitle.append(
-        `<span class="restart-warning">&nbsp;&nbsp;<i class="fas fa-redo text-orange" title="Setting requires FTL restart on change"></i></span>`
-      );
-    }
+  if (value.flags.restart_dnsmasq && envTitle.find(".restart-warning").length === 0) {
+    envTitle.append(
+      `<span class="restart-warning">&nbsp;&nbsp;<i class="fas fa-redo text-orange" title="Setting requires FTL restart on change"></i></span>`
+    );
   }
 
   if (value.flags.env_var) {

--- a/settings-api.lp
+++ b/settings-api.lp
@@ -19,7 +19,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="col-md-12 settings-level-1">
                 <div class="box box-warning">
                     <div class="box-header with-border">
-                        <h3 class="box-title">Exclusions</h3>
+                        <h3 class="box-title webserver.api.excludeDomains webserver.api.excludeClients">Exclusions</h3>
                     </div>
                     <div class="box-body">
                         <div class="row">
@@ -40,7 +40,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="col-md-12 settings-level-0">
                 <div class="box box-warning">
                     <div class="box-header with-border">
-                        <h3 class="box-title">Theme settings</h3>
+                        <h3 class="box-title webserver.interface.theme webserver.interface.boxed">Theme settings</h3>
                     </div>
                     <div class="box-body">
                         <div class="row">
@@ -65,7 +65,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                 </div>
             </div>
         </div>
-    </div><!--
+    </div><!-- TODO: Why is this commented out?
     <div class="col-md-6">
         <div class="box box-warning">
             <div class="box-header with-border">
@@ -92,7 +92,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title">Advanced Settings</h3>
+                <h3 class="box-title webserver.api.localAPIauth webserver.api.prettyJSON webserver.api.allow_destructive webserver.api.temp.limit webserver.api.temp.unit">Advanced Settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">

--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -18,7 +18,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-0">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title">DHCP Settings</h3>
+                <h3 class="box-title dhcp.active dhcp.start dhcp.end dhcp.router dhcp.ipv6">DHCP Settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -71,7 +71,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title">Advanced DHCP Settings</h3>
+                <h3 class="box-title dhcp.domain dhcp.leaseTime dhcp.rapidCommit chdp.multiDNS">Advanced DHCP Settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">

--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -146,7 +146,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-12 settings-level-2">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title">Static DHCP configuration&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h3>
+                <h3 class="box-title">Static DHCP configuration</h3>
             </div>
             <div class="box-body">
                 <div class="row">

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -17,7 +17,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-lg-6">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h1 class="box-title">Upstream DNS Servers</h1>
+                <h1 class="box-title dns.upstreams" id="lblDNSupstreams">Upstream DNS Servers</h1>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -59,7 +59,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning settings-level-1">
             <div class="box-header with-border">
-                <h3 class="box-title">Conditional forwarding&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h3>
+                <h3 class="box-title dns.revServer.active dns.revServer.cidr dns.revServer.target dns.revServer.domain">Conditional forwarding&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -125,7 +125,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-lg-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h1 class="box-title">Interface settings&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h1>
+                <h1 class="box-title dns.listeningMode">Interface settings&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h1>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -166,7 +166,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title">Advanced DNS settings</h3>
+                <h3 class="box-title dns.domainNeeded dns.bogusPriv dns.dnssec">Advanced DNS settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -212,7 +212,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning settings-level-2">
             <div class="box-header with-border">
-                <h3 class="box-title">Rate-limiting&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h3>
+                <h3 class="box-title dns.rateLimit.count dns.rateLimit.interval">Rate-limiting&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h3>
             </div>
             <div class="box-body">
                 <div class="row">

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -59,7 +59,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning settings-level-1">
             <div class="box-header with-border">
-                <h3 class="box-title dns.revServer.active dns.revServer.cidr dns.revServer.target dns.revServer.domain">Conditional forwarding&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h3>
+                <h3 class="box-title dns.revServer.active dns.revServer.cidr dns.revServer.target dns.revServer.domain">Conditional forwarding</h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -125,7 +125,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-lg-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h1 class="box-title dns.listeningMode">Interface settings&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h1>
+                <h1 class="box-title dns.listeningMode">Interface settings</h1>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -212,7 +212,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning settings-level-2">
             <div class="box-header with-border">
-                <h3 class="box-title dns.rateLimit.count dns.rateLimit.interval">Rate-limiting&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h3>
+                <h3 class="box-title dns.rateLimit.count dns.rateLimit.interval">Rate-limiting</h3>
             </div>
             <div class="box-body">
                 <div class="row">

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -17,7 +17,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box">
             <div class="box-header with-border">
-                <h3 class="box-title">Local DNS records</h3>
+                <h3 class="box-title" id="title-hosts">Local DNS records<span class="restart-warning">&nbsp;&nbsp;<i class="fas fa-redo text-orange" title="Setting requires FTL restart on change"></i></span></h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -29,7 +29,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                     Add new DNS record
                                 </h3>
                                 <div class="box-tools pull-right">
-                                    <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                                    <button type="button" class="btn btn-box-tool hosts" data-widget="collapse"><i class="fa fa-plus"></i></button>
                                 </div>
                             </div>
                             <!-- /.box-header -->
@@ -37,11 +37,11 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 <div class="row">
                                     <div class="form-group col-md-6">
                                         <label for="domain">Domain:</label>
-                                        <input id="Hdomain" type="url" class="form-control" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Hdomain" type="url" class="form-control hosts" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                     <div class="form-group col-md-6">
                                         <label for="target">IP address:</label>
-                                        <input id="Hip" type="text" class="form-control" placeholder="Associated IP address" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Hip" type="text" class="form-control hosts" placeholder="Associated IP address" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                 </div>
                             </div>
@@ -51,14 +51,14 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                             <p>The reason for this is that Pi-hole will not send additional queries upstream when serving <code>CNAME</code> replies. As consequence, if you set a target that isn't already known, the reply to the client may be incomplete. Pi-hole just returns the information it knows at the time of the query. This results in certain limitations for <code>CNAME</code> targets,
                                 for instance, only <i>active</i> DHCP leases work as targets - mere DHCP <i>leases</i> aren't sufficient as they aren't (yet) valid DNS records.</p>
                                 <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this could result in invalid SSL certificate errors when the target server does not serve content for the requested domain.</p>
-                                <button type="button" id="btnAdd-host" class="btn btn-primary pull-right">Add</button>
+                                <button type="button" id="btnAdd-host" class="btn btn-primary pull-right hosts">Add</button>
                             </div>
                         </div>
                     </div>
                     <div class="col-md-12">
                         <h3 class="box-title">List of local DNS records</h3>
                             <!-- /.box-header -->
-                        <table id="dnsRecordsTable" class="table table-striped table-bordered" width="100%">
+                        <table id="hosts-Table" class="table table-striped table-bordered" width="100%">
                             <thead>
                             <tr>
                                 <th>Domain</th>
@@ -76,7 +76,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box">
             <div class="box-header with-border">
-                <h3 class="box-title">Local CNAME records records</h3>
+                <h3 class="box-title" id="title-cnameRecords">Local CNAME records records<span class="restart-warning">&nbsp;&nbsp;<i class="fas fa-redo text-orange" title="Setting requires FTL restart on change"></i></span></h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -88,7 +88,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                     Add new CNAME record
                                 </h3>
                                 <div class="box-tools pull-right">
-                                    <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                                    <button type="button" class="btn btn-box-tool cnameRecords" data-widget="collapse"><i class="fa fa-plus"></i></button>
                                 </div>
                             </div>
                             <!-- /.box-header -->
@@ -96,27 +96,27 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 <div class="row">
                                     <div class="form-group col-md-5">
                                         <label for="domain">Domain:</label>
-                                        <input id="Cdomain" type="url" class="form-control" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Cdomain" type="url" class="form-control cnameRecords" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                     <div class="form-group col-md-5">
                                         <label for="target">Target Domain:</label>
-                                        <input id="Ctarget" type="url" class="form-control" placeholder="Associated Target Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Ctarget" type="url" class="form-control cnameRecords" placeholder="Associated Target Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                     <div class="form-group col-md-2">
                                         <label for="target">TTL (optional):</label>
-                                        <input id="Cttl" type="numeric" class="form-control" placeholder="TTL in seconds" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Cttl" type="numeric" class="form-control cnameRecords" placeholder="TTL in seconds" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                 </div>
                             </div>
                             <div class="box-footer clearfix">
-                                <button type="button" id="btnAdd-cname" class="btn btn-primary pull-right">Add</button>
+                                <button type="button" id="btnAdd-cname" class="btn btn-primary pull-right cnameRecords">Add</button>
                             </div>
                         </div>
                     </div>
                     <div class="col-md-12">
                         <h3 class="box-title">List of local CNAME records</h3>
                             <!-- /.box-header -->
-                        <table id="customCNAMETable" class="table table-striped table-bordered" width="100%">
+                        <table id="cnameRecords-Table" class="table table-striped table-bordered" width="100%">
                             <thead>
                             <tr>
                                 <th>Domain</th>

--- a/settings-privacy.lp
+++ b/settings-privacy.lp
@@ -19,7 +19,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="col-md-12">
                 <div class="box box-warning">
                     <div class="box-header with-border">
-                        <h3 class="box-title">Query Logging</h3>
+                        <h3 class="box-title dns.queryLogging">Query Logging</h3>
                     </div>
                     <div class="box-body">
                         <div class="row">
@@ -37,7 +37,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="col-md-12 settings-level-2">
                 <div class="box box-warning">
                     <div class="box-header with-border">
-                        <h3 class="box-title">Privacy-related database settings</h3>
+                        <h3 class="box-title database.DBimport database.DBexport database.maxDBdays database.network.expire">Privacy-related database settings</h3>
                     </div>
                     <div class="box-body">
                         <div class="row">
@@ -70,7 +70,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title">Query Anonymization ("Privacy Level")</h3>
+                <h3 class="box-title misc.privacylevel">Query Anonymization ("Privacy Level")</h3>
             </div>
             <div class="box-body">
                 <div class="row">

--- a/settings-system.lp
+++ b/settings-system.lp
@@ -282,7 +282,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-12 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title">Actions<span id="actions-title"></span>&nbsp;&nbsp;<i class="fas fa-wrench" title="This is an advanced-level setting"></i></h3>
+                <h3 class="box-title">Actions<span id="actions-title"></span></h3>
             </div>
             <div class="box-body">
                 <div class="row">


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

If a config item is already set by environment variable (this making it read-only) - then we disable the input on the web interface to prevent confusion.

![image](https://github.com/pi-hole/web/assets/1998970/f2787c2a-d18f-455d-a240-30c83f748b9b)


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_