### PR TITLE
Nicely format error toasts

### DIFF
--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -111,6 +111,20 @@ function showAlert(type, icon, title, message) {
       options.title = "&nbsp;<strong>Error, something went wrong!</strong><br>";
       settings.delay *= 2;
 
+      // If the message is an API object, nicely format the error message
+      // Try to parse message as JSON
+      try {
+        var data = JSON.parse(message);
+        console.log(data); // eslint-disable-line no-console
+        if (data.error !== undefined) {
+          options.title = "&nbsp;<strong>" + data.error.message + "</strong><br>";
+
+          if (data.error.hint !== null) options.message = data.error.hint;
+        }
+      } catch {
+        // Do nothing
+      }
+
       break;
     default:
       // Case not handled, do nothing


### PR DESCRIPTION
# What does this implement/fix?

As we standardized how error responses coming from FTL look like, we can easily add parsing into the web interface to make it a bit more human-friendly.

Previously:
![development-v6](https://github.com/pi-hole/web/assets/16748619/8676b22d-6777-4807-9747-4a0f982e6b6b)

Now:
![this branch](https://github.com/pi-hole/web/assets/16748619/e996f38b-9cd1-41f3-9379-95b1e8bf42a6)


**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.