### PR TITLE
Fix multi-deletion of DHCP leases

### DIFF
--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -154,7 +154,7 @@ function deleteMessage() {
 function delMsg(id) {
   id = parseInt(id, 10);
   utils.disableAll();
-  toasts[id] = utils.showAlert("info", "", "Deleting message...", null, null);
+  toasts[id] = utils.showAlert("info", "", "Deleting message...", "ID: " + id, null);
 
   $.ajax({
     url: "/api/info/messages/" + id,
@@ -167,7 +167,7 @@ function delMsg(id) {
           "success",
           "far fa-trash-alt",
           "Successfully deleted message",
-          "",
+          "ID: " + id,
           toasts[id]
         );
         table.row(id).remove();

--- a/scripts/pi-hole/js/messages.js
+++ b/scripts/pi-hole/js/messages.js
@@ -98,13 +98,10 @@ $(function () {
         className: "btn-sm datatable-bt deleteSelected",
         action: function () {
           // For each ".selected" row ...
-          var ids = [];
           $("tr.selected").each(function () {
-            // ... add the row identified by "data-id".
-            ids.push(parseInt($(this).attr("data-id"), 10));
+            // ... delete the row identified by "data-id".
+            delMsg($(this).attr("data-id"));
           });
-          // Delete all selected rows at once
-          delMsg(ids);
         },
       },
     ],

--- a/scripts/pi-hole/js/settings-dhcp.js
+++ b/scripts/pi-hole/js/settings-dhcp.js
@@ -163,7 +163,7 @@ function deleteLease() {
 
 function delLease(ip) {
   utils.disableAll();
-  utils.showAlert("info", "", "Deleting lease...");
+  const toast = utils.showAlert("info", "", "Deleting lease...", ip, null);
 
   $.ajax({
     url: "/api/dhcp/leases/" + encodeURIComponent(ip),
@@ -172,10 +172,10 @@ function delLease(ip) {
     .done(function (response) {
       utils.enableAll();
       if (response === undefined) {
-        utils.showAlert("success", "far fa-trash-alt", "Successfully deleted lease", "");
+        utils.showAlert("success", "far fa-trash-alt", "Successfully deleted lease", ip, toast);
         dhcpLeaesTable.ajax.reload(null, false);
       } else {
-        utils.showAlert("error", "", "Error while deleting lease: " + ip, response.lease);
+        utils.showAlert("error", "", "Error while deleting lease: " + ip, response.lease, toast);
       }
 
       // Clear selection after deletion
@@ -184,7 +184,7 @@ function delLease(ip) {
     })
     .fail(function (jqXHR, exception) {
       utils.enableAll();
-      utils.showAlert("error", "", "Error while deleting lease: " + ip, jqXHR.responseText);
+      utils.showAlert("error", "", "Error while deleting lease: " + ip, jqXHR.responseText, toast);
       console.log(exception); // eslint-disable-line no-console
     });
 }

--- a/scripts/pi-hole/js/settings-dhcp.js
+++ b/scripts/pi-hole/js/settings-dhcp.js
@@ -7,7 +7,8 @@
 
 /* global utils:false, setConfigValues: false, apiFailure: false */
 
-var dhcpLeaesTable = null;
+var dhcpLeaesTable = null,
+  toasts = {};
 
 // DHCP leases tooltips
 $(function () {
@@ -163,7 +164,7 @@ function deleteLease() {
 
 function delLease(ip) {
   utils.disableAll();
-  const toast = utils.showAlert("info", "", "Deleting lease...", ip, null);
+  toasts[ip] = utils.showAlert("info", "", "Deleting lease...", ip, null);
 
   $.ajax({
     url: "/api/dhcp/leases/" + encodeURIComponent(ip),
@@ -172,10 +173,22 @@ function delLease(ip) {
     .done(function (response) {
       utils.enableAll();
       if (response === undefined) {
-        utils.showAlert("success", "far fa-trash-alt", "Successfully deleted lease", ip, toast);
+        utils.showAlert(
+          "success",
+          "far fa-trash-alt",
+          "Successfully deleted lease",
+          ip,
+          toasts[ip]
+        );
         dhcpLeaesTable.ajax.reload(null, false);
       } else {
-        utils.showAlert("error", "", "Error while deleting lease: " + ip, response.lease, toast);
+        utils.showAlert(
+          "error",
+          "",
+          "Error while deleting lease: " + ip,
+          response.lease,
+          toasts[ip]
+        );
       }
 
       // Clear selection after deletion
@@ -184,7 +197,13 @@ function delLease(ip) {
     })
     .fail(function (jqXHR, exception) {
       utils.enableAll();
-      utils.showAlert("error", "", "Error while deleting lease: " + ip, jqXHR.responseText, toast);
+      utils.showAlert(
+        "error",
+        "",
+        "Error while deleting lease: " + ip,
+        jqXHR.responseText,
+        toasts[ip]
+      );
       console.log(exception); // eslint-disable-line no-console
     });
 }

--- a/scripts/pi-hole/js/settings-dhcp.js
+++ b/scripts/pi-hole/js/settings-dhcp.js
@@ -115,13 +115,10 @@ $(function () {
         className: "btn-sm datatable-bt deleteSelected",
         action: function () {
           // For each ".selected" row ...
-          var ids = [];
           $("tr.selected").each(function () {
-            // ... add the row identified by "data-id".
-            ids.push(parseInt($(this).attr("data-id"), 10));
+            // ... delete the row identified by "data-id".
+            delLease($(this).attr("data-id"));
           });
-          // Delete all selected rows at once
-          delLease(ids);
         },
       },
     ],
@@ -161,17 +158,7 @@ $(function () {
 
 function deleteLease() {
   // Passes the button data-del-id attribute as IP
-  var ips = [$(this).attr("data-del-ip")];
-
-  // Check input validity
-  if (!Array.isArray(ips)) return;
-
-  // Exploit prevention: Return early for non-numeric IDs
-  for (var ip in ips) {
-    if (Object.hasOwnProperty.call(ips, ip)) {
-      delLease(ips);
-    }
-  }
+  delLease($(this).attr("data-del-ip"));
 }
 
 function delLease(ip) {
@@ -179,7 +166,7 @@ function delLease(ip) {
   utils.showAlert("info", "", "Deleting lease...");
 
   $.ajax({
-    url: "/api/dhcp/leases/" + ip,
+    url: "/api/dhcp/leases/" + encodeURIComponent(ip),
     method: "DELETE",
   })
     .done(function (response) {

--- a/scripts/pi-hole/js/settings-dns-records.js
+++ b/scripts/pi-hole/js/settings-dns-records.js
@@ -141,19 +141,8 @@ $(function () {
 });
 
 function deleteRecord() {
-  // Get the tags
-  var tags = [$(this).attr("data-tag")];
-  var types = [$(this).attr("data-type")];
-  // Check input validity
-  if (!Array.isArray(tags)) return;
-
-  // Exploit prevention: Return early for non-numeric IDs
-  for (var tag in tags) {
-    if (Object.hasOwnProperty.call(tags, tag)) {
-      if (types[0] === "hosts") delHosts(tags);
-      else delCNAME(tags);
-    }
-  }
+  if ($(this).attr("data-type") === "hosts") delHosts($(this).attr("data-tag"));
+  else delCNAME($(this).attr("data-tag"));
 }
 
 function delHosts(elem) {

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -84,7 +84,7 @@ function padNumber(num) {
 }
 
 var showAlertBox = null;
-function showAlert(type, icon, title, message) {
+function showAlert(type, icon, title, message, toast) {
   const options = {
       title: "&nbsp;<strong>" + escapeHtml(title) + "</strong><br>",
       message: escapeHtml(message),
@@ -138,16 +138,28 @@ function showAlert(type, icon, title, message) {
       return;
   }
 
-  if (type === "info") {
-    // Create a new notification for info boxes
-    showAlertBox = $.notify(options, settings);
-  } else if (showAlertBox !== null) {
-    // Update existing notification for other boxes (if available)
-    showAlertBox.update(options);
-    showAlertBox.update(settings);
+  if (toast === undefined) {
+    if (type === "info") {
+      // Create a new notification for info boxes
+      showAlertBox = $.notify(options, settings);
+      return showAlertBox;
+    } else if (showAlertBox !== null) {
+      // Update existing notification for other boxes (if available)
+      showAlertBox.update(options);
+      showAlertBox.update(settings);
+      return showAlertBox;
+    } else {
+      // Create a new notification for other boxes if no previous info box exists
+      return $.notify(options, settings);
+    }
+  } else if (toast === null) {
+    // Always create a new toast
+    return $.notify(options, settings);
   } else {
-    // Create a new notification for other boxes if no previous info box exists
-    $.notify(options, settings);
+    // Update existing toast
+    toast.update(options);
+    toast.update(settings);
+    return toast;
   }
 }
 


### PR DESCRIPTION
# What does this implement/fix?

IP lease deletion incorrectly utilized `parseInt(..., 10)` which truncated, e.g., `127.0.0.1` to `127` which was then sent to the API. This PR also adds a further improvement to `toast` handling where an existing toast can be memorized by the caller to update exactly this one single toast later on with either success or error. This is only relevant for mass-events and can later trivially be extended to other places where this is meaningful.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.