### PR TITLE
Use class attribute only for styles

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -37,7 +37,7 @@ function setConfigValues(topic, key, value) {
 
   // else: we have a setting we can set
   var escapedKey = key.replaceAll(".", "\\.");
-  var envTitle = $(`.${escapedKey}`);
+  var envTitle = $(`[data-configkeys~='${key}']`);
 
   if (value.flags.advanced && envTitle.find(".advanced-warning").length === 0) {
     envTitle.append(

--- a/settings-api.lp
+++ b/settings-api.lp
@@ -19,7 +19,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="col-md-12 settings-level-1">
                 <div class="box box-warning">
                     <div class="box-header with-border">
-                        <h3 class="box-title webserver.api.excludeDomains webserver.api.excludeClients">Exclusions</h3>
+                        <h3 class="box-title" data-configkeys="webserver.api.excludeDomains webserver.api.excludeClients">Exclusions</h3>
                     </div>
                     <div class="box-body">
                         <div class="row">
@@ -40,7 +40,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="col-md-12 settings-level-0">
                 <div class="box box-warning">
                     <div class="box-header with-border">
-                        <h3 class="box-title webserver.interface.theme webserver.interface.boxed">Theme settings</h3>
+                        <h3 class="box-title" data-configkeys="webserver.interface.theme webserver.interface.boxed">Theme settings</h3>
                     </div>
                     <div class="box-body">
                         <div class="row">
@@ -92,7 +92,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title webserver.api.localAPIauth webserver.api.prettyJSON webserver.api.allow_destructive webserver.api.temp.limit webserver.api.temp.unit">Advanced Settings</h3>
+                <h3 class="box-title" data-configkeys="webserver.api.localAPIauth webserver.api.prettyJSON webserver.api.allow_destructive webserver.api.temp.limit webserver.api.temp.unit">Advanced Settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">

--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -18,7 +18,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-0">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title dhcp.active dhcp.start dhcp.end dhcp.router dhcp.ipv6">DHCP Settings</h3>
+                <h3 class="box-title" data-configkeys="dhcp.active dhcp.start dhcp.end dhcp.router dhcp.ipv6">DHCP Settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -71,7 +71,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title dhcp.domain dhcp.leaseTime dhcp.rapidCommit chdp.multiDNS">Advanced DHCP Settings</h3>
+                <h3 class="box-title" data-configkeys="dhcp.domain dhcp.leaseTime dhcp.rapidCommit dhcp.multiDNS">Advanced DHCP Settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -17,7 +17,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-lg-6">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h1 class="box-title dns.upstreams" id="lblDNSupstreams">Upstream DNS Servers</h1>
+                <h1 class="box-title" data-configkeys="dns.upstreams" id="lblDNSupstreams">Upstream DNS Servers</h1>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -59,7 +59,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning settings-level-1">
             <div class="box-header with-border">
-                <h3 class="box-title dns.revServer.active dns.revServer.cidr dns.revServer.target dns.revServer.domain">Conditional forwarding</h3>
+                <h3 class="box-title" data-configkeys="dns.revServer.active dns.revServer.cidr dns.revServer.target dns.revServer.domain">Conditional forwarding</h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -125,7 +125,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-lg-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h1 class="box-title dns.listeningMode">Interface settings</h1>
+                <h1 class="box-title" data-configkeys="dns.listeningMode">Interface settings</h1>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -166,7 +166,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title dns.domainNeeded dns.bogusPriv dns.dnssec">Advanced DNS settings</h3>
+                <h3 class="box-title" data-configkeys="dns.domainNeeded dns.bogusPriv dns.dnssec">Advanced DNS settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -212,7 +212,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning settings-level-2">
             <div class="box-header with-border">
-                <h3 class="box-title dns.rateLimit.count dns.rateLimit.interval">Rate-limiting</h3>
+                <h3 class="box-title" data-configkeys="dns.rateLimit.count dns.rateLimit.interval">Rate-limiting</h3>
             </div>
             <div class="box-body">
                 <div class="row">

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -29,7 +29,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                     Add new DNS record
                                 </h3>
                                 <div class="box-tools pull-right">
-                                    <button type="button" class="btn btn-box-tool hosts" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                                    <button type="button" class="btn btn-box-tool" data-configkeys="hosts" data-widget="collapse"><i class="fa fa-plus"></i></button>
                                 </div>
                             </div>
                             <!-- /.box-header -->
@@ -37,11 +37,11 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 <div class="row">
                                     <div class="form-group col-md-6">
                                         <label for="domain">Domain:</label>
-                                        <input id="Hdomain" type="url" class="form-control hosts" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Hdomain" type="url" class="form-control" data-configkeys="hosts" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                     <div class="form-group col-md-6">
                                         <label for="target">IP address:</label>
-                                        <input id="Hip" type="text" class="form-control hosts" placeholder="Associated IP address" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Hip" type="text" class="form-control" data-configkeys="hosts" placeholder="Associated IP address" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                 </div>
                             </div>
@@ -51,7 +51,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                             <p>The reason for this is that Pi-hole will not send additional queries upstream when serving <code>CNAME</code> replies. As consequence, if you set a target that isn't already known, the reply to the client may be incomplete. Pi-hole just returns the information it knows at the time of the query. This results in certain limitations for <code>CNAME</code> targets,
                                 for instance, only <i>active</i> DHCP leases work as targets - mere DHCP <i>leases</i> aren't sufficient as they aren't (yet) valid DNS records.</p>
                                 <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this could result in invalid SSL certificate errors when the target server does not serve content for the requested domain.</p>
-                                <button type="button" id="btnAdd-host" class="btn btn-primary pull-right hosts">Add</button>
+                                <button type="button" id="btnAdd-host" class="btn btn-primary pull-right" data-configkeys="hosts">Add</button>
                             </div>
                         </div>
                     </div>
@@ -88,7 +88,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                     Add new CNAME record
                                 </h3>
                                 <div class="box-tools pull-right">
-                                    <button type="button" class="btn btn-box-tool cnameRecords" data-widget="collapse"><i class="fa fa-plus"></i></button>
+                                    <button type="button" class="btn btn-box-tool" data-configkeys="cnameRecords" data-widget="collapse"><i class="fa fa-plus"></i></button>
                                 </div>
                             </div>
                             <!-- /.box-header -->
@@ -96,20 +96,20 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 <div class="row">
                                     <div class="form-group col-md-5">
                                         <label for="domain">Domain:</label>
-                                        <input id="Cdomain" type="url" class="form-control cnameRecords" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Cdomain" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                     <div class="form-group col-md-5">
                                         <label for="target">Target Domain:</label>
-                                        <input id="Ctarget" type="url" class="form-control cnameRecords" placeholder="Associated Target Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Ctarget" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Associated Target Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                     <div class="form-group col-md-2">
                                         <label for="target">TTL (optional):</label>
-                                        <input id="Cttl" type="numeric" class="form-control cnameRecords" placeholder="TTL in seconds" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Cttl" type="numeric" class="form-control" data-configkeys="cnameRecords" placeholder="TTL in seconds" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </div>
                                 </div>
                             </div>
                             <div class="box-footer clearfix">
-                                <button type="button" id="btnAdd-cname" class="btn btn-primary pull-right cnameRecords">Add</button>
+                                <button type="button" id="btnAdd-cname" class="btn btn-primary pull-right" data-configkeys="cnameRecords">Add</button>
                             </div>
                         </div>
                     </div>

--- a/settings-privacy.lp
+++ b/settings-privacy.lp
@@ -19,7 +19,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="col-md-12">
                 <div class="box box-warning">
                     <div class="box-header with-border">
-                        <h3 class="box-title dns.queryLogging">Query Logging</h3>
+                        <h3 class="box-title" data-configkeys="dns.queryLogging">Query Logging</h3>
                     </div>
                     <div class="box-body">
                         <div class="row">
@@ -37,7 +37,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="col-md-12 settings-level-2">
                 <div class="box box-warning">
                     <div class="box-header with-border">
-                        <h3 class="box-title database.DBimport database.DBexport database.maxDBdays database.network.expire">Privacy-related database settings</h3>
+                        <h3 class="box-title" data-configkeys="database.DBimport database.DBexport database.maxDBdays database.network.expire">Privacy-related database settings</h3>
                     </div>
                     <div class="box-body">
                         <div class="row">
@@ -70,7 +70,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title misc.privacylevel">Query Anonymization ("Privacy Level")</h3>
+                <h3 class="box-title" data-configkeys="misc.privacylevel">Query Anonymization ("Privacy Level")</h3>
             </div>
             <div class="box-body">
                 <div class="row">


### PR DESCRIPTION
### What does this PR aim to accomplish?

A recent change was using the `class` attribute from titles to store the config keys and decide if an icon should be set.
The problem is: the config keys are not CSS classes and they contain periods (`.`). This might cause confusion in the future, when we forget why these "classes" were added here.

We should use the `class` attribute only for CSS classes.

### How does this PR accomplish the above?

Adding a `data-configkeys` attribute to store the list of config keys.

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
