### PR TITLE
UI Support for Configuring DHCP Subnet Mask

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -67,6 +67,28 @@ function validIP($address)
     return !filter_var($address, FILTER_VALIDATE_IP) === false;
 }
 
+function validSubnetMask($subnetMask)
+{
+    $octets = explode('.', $subnetMask);
+    if (count($octets) != 4) {
+        return false;
+    }
+
+    $subnetBinary = '';
+    foreach ($octets as $octet) {
+        if (!is_numeric($octet) || $octet < 0 || $octet > 255) {
+            return false;
+        }
+        $subnetBinary .= str_pad(decbin($octet), 8, '0', STR_PAD_LEFT);
+    }
+
+    if (strpos($subnetBinary, '01') !== false) {
+        return false;
+    }
+
+    return true;
+}
+
 function validCIDRIP($address)
 {
     // This validation strategy has been taken from ../js/groups-common.js

--- a/scripts/pi-hole/php/savesettings.php
+++ b/scripts/pi-hole/php/savesettings.php
@@ -496,6 +496,12 @@ if (isset($_POST['field'])) {
                     $error .= 'To IP ('.htmlspecialchars($to).') is invalid!<br>';
                 }
 
+                // Validate to Subnet Mask
+                $subnetMask = $_POST['subnetMask'];
+                if (!validSubnetMask($subnetMask)) {
+                    $error .= 'Subnet Mask ('.htmlspecialchars($subnetMask).') is invalid!<br>';
+                }
+
                 // Validate router IP
                 $router = $_POST['router'];
                 if (!validIP($router)) {
@@ -531,7 +537,7 @@ if (isset($_POST['field'])) {
                 }
 
                 if (!strlen($error)) {
-                    pihole_execute('-a enabledhcp '.$from.' '.$to.' '.$router.' '.$leasetime.' '.$domain.' '.$ipv6.' '.$rapidcommit);
+                    pihole_execute('-a enabledhcp '.$from.' '.$to.' '.$subnetMask.' '.$router.' '.$leasetime.' '.$domain.' '.$ipv6.' '.$rapidcommit);
                     $success .= 'The DHCP server has been activated '.htmlspecialchars($type);
                 }
             } else {

--- a/settings.php
+++ b/settings.php
@@ -412,6 +412,11 @@ if ($FTLpid !== 0) {
                         } else {
                             $DHCPend = '';
                         }
+                        if (isset($setupVars['DHCP_SUBNET_MASK'])) {
+                            $DHCPSubnetMask = $setupVars['DHCP_SUBNET_MASK'];
+                        } else {
+                            $DHCPSubnetMask = '255.255.255.0'; // Setting default value here
+                        }
                         if (isset($setupVars['DHCP_ROUTER'])) {
                             $DHCProuter = $setupVars['DHCP_ROUTER'];
                         } else {
@@ -442,6 +447,7 @@ if ($FTLpid !== 0) {
                         $DHCP = false;
                         $DHCPstart = '';
                         $DHCPend = '';
+                        $DHCPsubnetMask = '255.255.255.0';
                         $DHCProuter = '';
 
                         // Try to guess initial settings
@@ -506,7 +512,19 @@ if ($FTLpid !== 0) {
                                             </div>
                                         </div>
                                         <div class="row">
-                                            <div class="col-md-12">
+                                            <div class="col-xs-12 col-sm-6 col-md-12 col-lg-6">
+                                                <label>Subnet Mask</label>
+                                                <div class="form-group">
+                                                    <div class="input-group">
+                                                        <div class="input-group-addon">Subnet</div>
+                                                        <input type="text" class="form-control DHCPgroup" name="subnetMask"
+                                                            autocomplete="off" spellcheck="false" autocapitalize="none"
+                                                            autocorrect="off" value="<?php echo $DHCPSubnetMask; ?>"
+                                                            <?php if (!$DHCP) { ?>disabled<?php } ?>>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="col-xs-12 col-sm-6 col-md-12 col-lg-6">
                                                 <label>Router (gateway) IP address</label>
                                                 <div class="form-group">
                                                     <div class="input-group">


### PR DESCRIPTION
This PR adds the necessary UI elements and logic to support the configuration of the DHCP subnet mask from the Pi-hole admin settings, corresponding to the backend changes made in the `pi-hole/pi-hole` repository.

Users can now specify a subnet mask for the DHCP server directly from the web interface, providing greater flexibility and control over network configurations.

**Dependency**:
This PR is dependent on the changes made in PR [[#5471](https://github.com/pi-hole/pi-hole/pull/5471)] in the `pi-hole/pi-hole` repository. Please ensure that the PR in `pi-hole/pi-hole` is reviewed and merged before merging this one.

I am available for any questions or additional information required during the review.

Thank you for your time and consideration.

---

By submitting this pull request, I confirm the following:

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([git rebase](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

 ---

- [x]    I have read the above and my PR is ready for review. Check this box to confirm
