### PR TITLE
Move settings level selector into sidebar

### DIFF
--- a/scripts/pi-hole/lua/settings_header.lp
+++ b/scripts/pi-hole/lua/settings_header.lp
@@ -1,14 +1,4 @@
 <!-- Title -->
 <div class="page-header flex-header">
     <h1><?= PageTitle ?></h1>
-<?
-if scriptname ~= 'settings/all' then
-    -- Show the level selector, except in All Settings page
-?>
-    <div class="settings-selector">
-        Settings level: <select id="settings-level" class="form-control input-sm"></select>
-    </div>
-<?
-end
-?>
 </div>

--- a/scripts/pi-hole/lua/sidebar.lp
+++ b/scripts/pi-hole/lua/sidebar.lp
@@ -133,6 +133,11 @@
                         </span>
                     </a>
                     <ul class="treeview-menu">
+                        <li>
+                            <div class="settings-selector">
+                                Settings level: <select id="settings-level" class="form-control input-sm"></select>
+                            </div>
+                        </li>
                         <li class="<? if scriptname == 'settings/system' then ?> active<? end ?>">
                             <a href="<?=webhome?>settings/system">
                                 <i class="fa-fw menu-icon fa-solid fa-circle-info"></i> <span>System</span>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -892,9 +892,8 @@ body:not(.lcars) .filter_types [class*="icheck-"] > input:first-child:checked + 
 
 /* Global settings level selector container */
 .settings-selector {
-  padding: 14px 0 0;
+  padding: 2px 2px 0 16px;
   order: 2;
-  font-size: 18px;
 }
 
 /* Global settings level selector */


### PR DESCRIPTION
# What does this implement/fix?

Move settings level selector into the sidebar instead of the settings page header

![Screenshot from 2023-11-02 06-15-06](https://github.com/pi-hole/web/assets/16748619/441d6f64-dbe0-44d9-b703-3efda7006139)

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.