### PR TITLE
Tweak processing/render time

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -676,12 +676,6 @@ function addAdvancedInfo() {
   const endtime = parseFloat(advancedInfoSource.data("endtime"));
   const totaltime = 1e3 * (endtime - starttime);
 
-  // Hide advanced info if settings level is lower than 2
-  if (settingsLevel < 2) {
-    advancedInfoTarget.hide();
-    return;
-  }
-
   // Show advanced info
   advancedInfoTarget.empty();
 

--- a/scripts/pi-hole/js/search.js
+++ b/scripts/pi-hole/js/search.js
@@ -174,8 +174,6 @@ function eventsource(partial) {
           "using a more specific search term or increase N.<br>";
       }
 
-      result += "<br>Search took " + (1000 * data.took).toFixed(1) + " ms";
-
       ta.append(result);
     })
     .fail(function (data) {

--- a/scripts/pi-hole/js/settings-teleporter.js
+++ b/scripts/pi-hole/js/settings-teleporter.js
@@ -58,12 +58,6 @@ function importZIP() {
         $("#modal-import-success-message").html(text);
       }
 
-      if ("took" in data) {
-        $("#modal-import-info-message").text(
-          "Processing took " + data.took.toFixed(3) + " seconds."
-        );
-      }
-
       $("#modal-import").modal("show");
     })
     .catch(error => {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Tweaks processing/rendering time info

1) Removes processing time from teleporter import modal
2) Removes search duration from adlist search page
3) Always show advanced client info in top right menu

Rationale: I see not much benefit in knowing 1) and 2) as I can't influence the processing time. What do I do if my processing time increases from 4 to 6 ms? It looks like this is forgotten debug output.
3) Is nice advanced info, but it is total unclear that this information is only presented when setting level is "expert". The level selector has no connection to this menu - users wound't expect changes at this place.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
