### PR TITLE
Add DHCP netmask field and nicely format API errors

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -114,6 +114,7 @@ function setConfigValues(topic, key, value) {
 
 function saveSettings() {
   var settings = {};
+  utils.disableAll();
   $("[data-key]").each(function () {
     var key = $(this).data("key");
     var value = $(this).val();
@@ -168,6 +169,7 @@ function saveSettings() {
     contentType: "application/json; charset=utf-8",
   })
     .done(function () {
+      utils.enableAll();
       // Success
       utils.showAlert(
         "success",
@@ -178,7 +180,10 @@ function saveSettings() {
       // Reload page
       location.reload();
     })
-    .fail(function (data) {
+    .fail(function (data, exception) {
+      utils.enableAll();
+      utils.showAlert("error", "", "Error while applying settings", data.responseText);
+      console.log(exception); // eslint-disable-line no-console
       apiFailure(data);
     });
 }

--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -32,7 +32,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                     <div class="col-xs-12 col-sm-6 col-md-12 col-lg-6">
                         <div class="form-group">
                             <div class="input-group">
-                                <div class="input-group-addon">From</div>
+                                <div class="input-group-addon">Start</div>
                                 <input type="text" class="form-control DHCPgroup" id="dhcp.start" data-key="dhcp.start"
                                     autocomplete="off" spellcheck="false" autocapitalize="none"
                                     autocorrect="off" value="">
@@ -42,7 +42,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                     <div class="col-xs-12 col-sm-6 col-md-12 col-lg-6">
                         <div class="form-group">
                             <div class="input-group">
-                                <div class="input-group-addon">To</div>
+                                <div class="input-group-addon">End</div>
                                 <input type="text" class="form-control DHCPgroup" id="dhcp.end" data-key="dhcp.end"
                                     autocomplete="off" spellcheck="false" autocapitalize="none"
                                     autocorrect="off" value="">

--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -60,6 +60,17 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                             </div>
                         </div>
                     </div>
+                    <div class="col-xs-12 col-sm-6 col-md-12 col-lg-6">
+                        <label>Netmask (<code>0.0.0.0</code> = auto)</label>
+                        <div class="form-group">
+                            <div class="input-group">
+                                <div class="input-group-addon">Netmask</div>
+                                <input type="text" class="form-control DHCPgroup" id="dhcp.netmask" data-key="dhcp.netmask"
+                                    autocomplete="off" spellcheck="false" autocapitalize="none"
+                                    autocorrect="off" value="">
+                            </div>
+                        </div>
+                    </div>
                     <div class="col-md-12">
                         <div><input type="checkbox" id="dhcp.ipv6" data-key="dhcp.ipv6" class="DHCPgroup">&nbsp;<label for="dhcp.ipv6"><strong>Enable additional IPv6 support (SLAAC + RA)</strong></label></div>
                         <p>Enable this option to enable IPv6 support for the Pi-hole DHCP server. This will allow the Pi-hole to hand out IPv6 addresses to clients and also provide IPv6 router advertisements (RA) to clients. This option is only useful if the Pi-hole is configured with an IPv6 address.</p>


### PR DESCRIPTION
# What does this implement/fix?

This PR accompanies https://github.com/pi-hole/FTL/pull/1731. It adds a new DHCP netmask field and furthermore improve error displaying for settings changes.

Examples:

![image](https://github.com/pi-hole/web/assets/16748619/2c6c7576-6afc-45b0-a031-4d4f4d41aad4)

![image](https://github.com/pi-hole/web/assets/16748619/8e5adb57-5664-44ac-8b46-46d63ca063eb)


**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.