### PR TITLE
Move comment about CNAME limitations to the CNAME box

### DIFF
--- a/scripts/pi-hole/js/settings-dns-records.js
+++ b/scripts/pi-hole/js/settings-dns-records.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Precord see LICENSE file for your rights under this license. */
 
-/* global utils: false, apiFailure:false */
+/* global utils: false, apiFailure:false, setConfigValues: false */
 
 function hostsDomain(data) {
   // Split record in format IP NAME1 [NAME2 [NAME3 [NAME...]]]
@@ -58,12 +58,11 @@ function populateDataTable(endpoint) {
   $.ajax({
     url: `/api/config/dns/${endpoint}?detailed=true`,
   }).done(function (data) {
-    setByEnv = data.config.dns[endpoint].flags.env_var;
+    // Set the title icons if needed
+    setConfigValues("dns", "dns", data.config.dns);
 
-    if (setByEnv) {
-      $(`#title-${endpoint}`).append(
-        `<span class="env-warning">&nbsp;&nbsp;<i class="fas fa-lock text-orange env-warning" title="Settings overwritten by an environmental variable are read-only"></i></span>`
-      );
+    // disable input fields if set by env var
+    if (data.config.dns[endpoint].flags.env_var) {
       $(`.${endpoint}`).prop("disabled", true);
     }
   });

--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiFailure:false */
+/* global utils:false, apiFailure:false*/
 
 $(function () {
   // Handle hiding of alerts

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -46,11 +46,8 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 </div>
                             </div>
                             <div class="box-footer clearfix">
-                            <strong>Note:</strong>
-                            <p>The target of a <code>CNAME</code> must be a domain that the Pi-hole already has in its cache or is authoritative for. This is a universal limitation of <code>CNAME</code> records.</p>
-                            <p>The reason for this is that Pi-hole will not send additional queries upstream when serving <code>CNAME</code> replies. As consequence, if you set a target that isn't already known, the reply to the client may be incomplete. Pi-hole just returns the information it knows at the time of the query. This results in certain limitations for <code>CNAME</code> targets,
-                                for instance, only <i>active</i> DHCP leases work as targets - mere DHCP <i>leases</i> aren't sufficient as they aren't (yet) valid DNS records.</p>
-                                <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this could result in invalid SSL certificate errors when the target server does not serve content for the requested domain.</p>
+                                <strong>Note:</strong>
+                                <p>Adding/removing local DNS records will flush the cache but does not require a restart of the DNS server.</p>
                                 <button type="button" id="btnAdd-host" class="btn btn-primary pull-right" data-configkeys="hosts">Add</button>
                             </div>
                         </div>
@@ -109,6 +106,12 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 </div>
                             </div>
                             <div class="box-footer clearfix">
+                                <strong>Note:</strong>
+                                <p>The target of a <code>CNAME</code> must be a domain that the Pi-hole already has in its cache or is authoritative for. This is a universal limitation of <code>CNAME</code> records.</p>
+                                <p>The reason for this is that Pi-hole will not send additional queries upstream when serving <code>CNAME</code> replies. As consequence, if you set a target that isn't already known, the reply to the client may be incomplete. Pi-hole just returns the information it knows at the time of the query. This results in certain limitations for <code>CNAME</code> targets,
+                                for instance, only <i>active</i> DHCP leases work as targets - mere DHCP <i>leases</i> aren't sufficient as they aren't (yet) valid DNS records.</p>
+                                <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this could result in invalid SSL certificate errors when the target server does not serve content for the requested domain.</p>
+                                <p>Adding/removing local CNAME records will restart the DNS server.</p>
                                 <button type="button" id="btnAdd-cname" class="btn btn-primary pull-right" data-configkeys="cnameRecords">Add</button>
                             </div>
                         </div>

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -17,7 +17,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box">
             <div class="box-header with-border">
-                <h3 class="box-title" id="title-hosts">Local DNS records<span class="restart-warning">&nbsp;&nbsp;<i class="fas fa-redo text-orange" title="Setting requires FTL restart on change"></i></span></h3>
+                <h3 class="box-title" id="title-hosts" data-configkeys="dns.hosts">Local DNS records</h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -73,7 +73,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box">
             <div class="box-header with-border">
-                <h3 class="box-title" id="title-cnameRecords">Local CNAME records records<span class="restart-warning">&nbsp;&nbsp;<i class="fas fa-redo text-orange" title="Setting requires FTL restart on change"></i></span></h3>
+                <h3 class="box-title" id="title-cnameRecords" data-configkeys="dns.cnameRecords">Local CNAME records records</h3>
             </div>
             <div class="box-body">
                 <div class="row">


### PR DESCRIPTION
# What does this implement/fix?

The comment about CNAME limitations is currently in the wrong box. This is fixed by this PR- We furthermore add a hint that restarting the DNS server is not needed for local DNS record changes (this will be true as of https://github.com/pi-hole/FTL/pull/1732) but is needed (and automagically done) for CNAMEs.

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.