### PR TITLE
Fix notification icon and add details for Local DNS/CNAME records

### DIFF
--- a/scripts/pi-hole/js/settings-dns-records.js
+++ b/scripts/pi-hole/js/settings-dns-records.js
@@ -156,7 +156,7 @@ function deleteRecord() {
 
 function delHosts(elem) {
   utils.disableAll();
-  utils.showAlert("info", "", "Deleting DNS record...");
+  utils.showAlert("info", "", "Deleting DNS record...", elem);
   const url = "/api/config/dns/hosts/" + encodeURIComponent(elem);
 
   $.ajax({
@@ -165,7 +165,7 @@ function delHosts(elem) {
   })
     .done(function () {
       utils.enableAll();
-      utils.showAlert("success", "far fa-trash-alt", "Successfully deleted DNS record", "");
+      utils.showAlert("success", "fas fa-trash-alt", "Successfully deleted DNS record", elem);
       $("#hosts-Table").DataTable().ajax.reload(null, false);
     })
     .fail(function (data, exception) {
@@ -183,7 +183,7 @@ function delHosts(elem) {
 
 function delCNAME(elem) {
   utils.disableAll();
-  utils.showAlert("info", "", "Deleting local CNAME record...");
+  utils.showAlert("info", "", "Deleting local CNAME record...", elem);
   const url = "/api/config/dns/cnameRecords/" + encodeURIComponent(elem);
 
   $.ajax({
@@ -192,7 +192,12 @@ function delCNAME(elem) {
   })
     .done(function () {
       utils.enableAll();
-      utils.showAlert("success", "far fa-trash-alt", "Successfully deleted local CNAME record", "");
+      utils.showAlert(
+        "success",
+        "fas fa-trash-alt",
+        "Successfully deleted local CNAME record",
+        elem
+      );
       $("#cnameRecords-Table").DataTable().ajax.reload(null, false);
     })
     .fail(function (data, exception) {
@@ -220,7 +225,7 @@ $(document).ready(function () {
     })
       .done(function () {
         utils.enableAll();
-        utils.showAlert("success", "far fa-plus", "Successfully added DNS record", "");
+        utils.showAlert("success", "fas fa-plus", "Successfully added DNS record", elem);
         $("#hosts-Table").DataTable().ajax.reload(null, false);
       })
       .fail(function (data, exception) {
@@ -244,7 +249,7 @@ $(document).ready(function () {
     })
       .done(function () {
         utils.enableAll();
-        utils.showAlert("success", "far fa-plus", "Successfully added CNAME record", "");
+        utils.showAlert("success", "fas fa-plus", "Successfully added CNAME record", elem);
         $("#cnameRecords-Table").DataTable().ajax.reload(null, false);
       })
       .fail(function (data, exception) {

--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -88,6 +88,7 @@ function showAlert(type, icon, title, message) {
   const options = {
       title: "&nbsp;<strong>" + title + "</strong><br>",
       message: message,
+      icon: icon,
     },
     settings = {
       type: type,
@@ -100,7 +101,7 @@ function showAlert(type, icon, title, message) {
     };
   switch (type) {
     case "info":
-      options.icon = icon !== null && icon.len > 0 ? icon : "far fa-clock";
+      options.icon = icon !== null && icon.len > 0 ? icon : "fas fa-clock";
 
       break;
     case "success":


### PR DESCRIPTION
1) Fixes the icon displayed in the notifications. Before, it always defaulted to `´fa-clock`
2) Re-adds detail info to the notifications for adding/deleting Local DNS/CNAME records. They have been added by https://github.com/pi-hole/web/pull/2786 but where (accidentally) removed by https://github.com/pi-hole/web/pull/2787

![Screenshot at 2023-11-05 21-47-14](https://github.com/pi-hole/web/assets/26622301/f544fbdd-cac2-47bb-a8f3-ba1047ed21c1)
