### PR TITLE
Show Reset Zoom button when zoomed in

### DIFF
--- a/index.lp
+++ b/index.lp
@@ -83,7 +83,8 @@ mg.include('scripts/pi-hole/lua/header_authenticated.lp','r')
         <div class="box" id="queries-over-time">
             <div class="box-header with-border">
                 <h3 class="box-title">Total queries over last 24 hours</h3>
-                <span class="pull-right" data-toggle="tooltip" title="You can zoom this graph by either holding down the [Ctrl] key and using your mouse wheel or by using the &quot;pinch&quot; multi-touch gesture. You can furthermore click and drag to pan the graph."><i class="fa fa-info-circle"></i></span>
+                <button class="btn btn-xs btn-default pull-right" data-sel="zoom-reset-history" style="display:none;"><i class="fas fa-undo"></i>&nbsp;Reset zoom</button>
+                <span class="pull-right" data-sel="zoom-info" data-toggle="tooltip" title="You can zoom this graph by either holding down the [Ctrl] key and using your mouse wheel or by using the &quot;pinch&quot; multi-touch gesture. You can furthermore click and drag to pan the graph."><i class="fa fa-info-circle"></i></span>
             </div>
             <div class="box-body">
                 <div class="chart" style="width: 100%; height: 180px">
@@ -102,7 +103,8 @@ mg.include('scripts/pi-hole/lua/header_authenticated.lp','r')
         <div class="box" id="clients">
             <div class="box-header with-border">
                 <h3 class="box-title">Client activity over last 24 hours</h3>
-                <span class="pull-right" data-toggle="tooltip" title="You can zoom this graph by either holding down the [Ctrl] key and using your mouse wheel or by using the &quot;pinch&quot; multi-touch gesture. You can furthermore click and drag to pan the graph."><i class="fa fa-info-circle"></i></span>
+                <button class="btn btn-xs btn-default pull-right" data-sel="zoom-reset-clients" style="display:none;"><i class="fas fa-undo"></i>&nbsp;Reset zoom</button>
+                <span class="pull-right" data-sel="zoom-info" data-toggle="tooltip" title="You can zoom this graph by either holding down the [Ctrl] key and using your mouse wheel or by using the &quot;pinch&quot; multi-touch gesture. You can furthermore click and drag to pan the graph."><i class="fa fa-info-circle"></i></span>
             </div>
             <div class="box-body">
                 <div class="chart" style="width: 100%; height: 180px">

--- a/index.lp
+++ b/index.lp
@@ -83,8 +83,8 @@ mg.include('scripts/pi-hole/lua/header_authenticated.lp','r')
         <div class="box" id="queries-over-time">
             <div class="box-header with-border">
                 <h3 class="box-title">Total queries over last 24 hours</h3>
-                <button class="btn btn-xs btn-default pull-right" data-sel="zoom-reset-history" style="display:none;"><i class="fas fa-undo"></i>&nbsp;Reset zoom</button>
-                <span class="pull-right" data-sel="zoom-info" data-toggle="tooltip" title="You can zoom this graph by either holding down the [Ctrl] key and using your mouse wheel or by using the &quot;pinch&quot; multi-touch gesture. You can furthermore click and drag to pan the graph."><i class="fa fa-info-circle"></i></span>
+                <button class="btn btn-xs btn-default pull-right zoom-reset" data-sel="reset-history"><i class="fas fa-undo"></i>&nbsp;Reset zoom</button>
+                <span class="pull-right zoom-info" data-toggle="tooltip" title="You can zoom this graph by either holding down the [Ctrl] key and using your mouse wheel or by using the &quot;pinch&quot; multi-touch gesture. You can furthermore click and drag to pan the graph."><i class="fa fa-info-circle"></i></span>
             </div>
             <div class="box-body">
                 <div class="chart" style="width: 100%; height: 180px">
@@ -103,8 +103,8 @@ mg.include('scripts/pi-hole/lua/header_authenticated.lp','r')
         <div class="box" id="clients">
             <div class="box-header with-border">
                 <h3 class="box-title">Client activity over last 24 hours</h3>
-                <button class="btn btn-xs btn-default pull-right" data-sel="zoom-reset-clients" style="display:none;"><i class="fas fa-undo"></i>&nbsp;Reset zoom</button>
-                <span class="pull-right" data-sel="zoom-info" data-toggle="tooltip" title="You can zoom this graph by either holding down the [Ctrl] key and using your mouse wheel or by using the &quot;pinch&quot; multi-touch gesture. You can furthermore click and drag to pan the graph."><i class="fa fa-info-circle"></i></span>
+                <button class="btn btn-xs btn-default pull-right zoom-reset" data-sel="reset-clients"><i class="fas fa-undo"></i>&nbsp;Reset zoom</button>
+                <span class="pull-right zoom-info" data-toggle="tooltip" title="You can zoom this graph by either holding down the [Ctrl] key and using your mouse wheel or by using the &quot;pinch&quot; multi-touch gesture. You can furthermore click and drag to pan the graph."><i class="fa fa-info-circle"></i></span>
             </div>
             <div class="box-body">
                 <div class="chart" style="width: 100%; height: 180px">

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -428,12 +428,12 @@ $(function () {
   updateSummaryData();
 
   // On click of the "Reset zoom" buttons, the closest chart to the button is reset
-  $("[data-sel^='zoom-reset']").on("click", function () {
-    if ($(this).data("sel") === "zoom-reset-clients") clientsChart.resetZoom();
+  $(".zoom-reset").on("click", function () {
+    if ($(this).data("sel") === "reset-clients") clientsChart.resetZoom();
     else timeLineChart.resetZoom();
 
     // Show the closest info icon to the current chart
-    $(this).parent().find("[data-sel='zoom-info']").show();
+    $(this).parent().find(".zoom-info").show();
     // Hide the reset zoom button
     $(this).hide();
   });
@@ -465,14 +465,14 @@ $(function () {
         // current zoom level
         if (chart.getZoomLevel() === 1) {
           // Show the closest info icon to the current chart
-          $(chart.canvas).parent().parent().parent().find("[data-sel='zoom-info']").show();
+          $(chart.canvas).parent().parent().parent().find(".zoom-info").show();
           // Hide the reset zoom button
-          $(chart.canvas).parent().parent().parent().find("[data-sel^='zoom-reset']").hide();
+          $(chart.canvas).parent().parent().parent().find(".zoom-reset").hide();
         } else {
           // Hide the closest info icon to the current chart
-          $(chart.canvas).parent().parent().parent().find("[data-sel='zoom-info']").hide();
+          $(chart.canvas).parent().parent().parent().find(".zoom-info").hide();
           // Show the reset zoom button
-          $(chart.canvas).parent().parent().parent().find("[data-sel^='zoom-reset']").show();
+          $(chart.canvas).parent().parent().parent().find(".zoom-reset").show();
         }
       },
     },

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -427,6 +427,17 @@ $(function () {
   // Pull in data via AJAX
   updateSummaryData();
 
+  // On click of the "Reset zoom" buttons, the closest chart to the button is reset
+  $("[data-sel^='zoom-reset']").on("click", function () {
+    if ($(this).data("sel") === "zoom-reset-clients") clientsChart.resetZoom();
+    else timeLineChart.resetZoom();
+
+    // Show the closest info icon to the current chart
+    $(this).parent().find("[data-sel='zoom-info']").show();
+    // Hide the reset zoom button
+    $(this).hide();
+  });
+
   const zoomPlugin = {
     /* Allow zooming only on the y axis */
     zoom: {
@@ -449,6 +460,20 @@ $(function () {
         chart.options.scales.y.ticks.callback = function (value) {
           return value.toFixed(0);
         };
+
+        // Update the top right info icon and reset zoom button depending on the
+        // current zoom level
+        if (chart.getZoomLevel() === 1) {
+          // Show the closest info icon to the current chart
+          $(chart.canvas).parent().parent().parent().find("[data-sel='zoom-info']").show();
+          // Hide the reset zoom button
+          $(chart.canvas).parent().parent().parent().find("[data-sel^='zoom-reset']").hide();
+        } else {
+          // Hide the closest info icon to the current chart
+          $(chart.canvas).parent().parent().parent().find("[data-sel='zoom-info']").hide();
+          // Show the reset zoom button
+          $(chart.canvas).parent().parent().parent().find("[data-sel^='zoom-reset']").show();
+        }
       },
     },
     /* Allow panning only on the y axis */

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1398,3 +1398,9 @@ table.dataTable tbody > tr > .selected {
     white 4%
   );
 }
+
+/* Dashboard graphics: reset zoom button and info tooltip */
+.zoom-reset {
+  display: none;
+  margin-top: -1px;
+}


### PR DESCRIPTION
# What does this implement/fix?

Show Reset Zoom buttons when zooming in

![ezgif-3-59b44a1c45](https://github.com/pi-hole/web/assets/16748619/ea98daa6-e4b7-49ac-bb8d-47ac466aaf07)

The clients chart was already zoomed in when starting the recording.

Javascript-wise, this may not be the most elegant way, but without the chain of
```
parent().parent().parent()
```
neither `.find()` nor `.closest()` were able to find the elements I was looking for.


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.