### PR TITLE
Shorten animation delay

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -14,8 +14,8 @@ var queryTypePieChart, forwardDestinationPieChart;
 // Register the ChartDeferred plugin to all charts:
 Chart.register(ChartDeferred);
 Chart.defaults.set("plugins.deferred", {
-  yOffset: "50%",
-  delay: 500,
+  yOffset: "20%",
+  delay: 300,
 });
 
 // Functions to update data in page

--- a/scripts/pi-hole/js/settings-system.js
+++ b/scripts/pi-hole/js/settings-system.js
@@ -15,8 +15,8 @@ var cacheSize = 0,
 // Register the ChartDeferred plugin to all charts:
 Chart.register(ChartDeferred);
 Chart.defaults.set("plugins.deferred", {
-  yOffset: "50%",
-  delay: 500,
+  yOffset: "20%",
+  delay: 300,
 });
 
 function updateCachePie(data) {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Startup animation of the charts is delayed until the reach the viewport. This PR reduces the fraction of the chart that needs to be within the viewport before the animation triggers. Also the delay is reduced. 
This should prevent seeing 50% empty charts before the animation starts, but keeping the viewport delay.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
