### PR TITLE
Fix query logs "all time" option

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -7,8 +7,8 @@
 
 /* global moment:false, utils:false */
 
-const beginningOfTime = 1262304000; // Jan 01 2010, 00:00
-const endOfTime = 2147483647; // Jan 19, 2038, 03:14
+const beginningOfTime = 1262304000000; // Jan 01 2010, 00:00
+const endOfTime = 2147483647000; // Jan 19, 2038, 03:14
 var from = beginningOfTime;
 var until = endOfTime;
 


### PR DESCRIPTION
# What does this implement/fix?

See title. When you click on "All Time", you will get on branch ...

`development-v6`:
![Screenshot from 2023-11-12 21-18-00](https://github.com/pi-hole/web/assets/16748619/1559ad8d-fa92-402b-865a-7be1e33eebaf)

this branch:
![Screenshot from 2023-11-12 21-17-49](https://github.com/pi-hole/web/assets/16748619/9b59db4c-36ce-4c73-9330-4dca273655ca)

The fix is simply mutiplying the current constants by 1000 because [Javascript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now) thinks milliseconds are a good unit for timestamps...

This issue was first reported on Discourse

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.