### PR TITLE
Move dhcp.domain -> dns.domain

### DIFF
--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -71,21 +71,11 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-1">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title" data-configkeys="dhcp.domain dhcp.leaseTime dhcp.rapidCommit dhcp.multiDNS">Advanced DHCP Settings</h3>
+                <h3 class="box-title" data-configkeys="dhcp.leaseTime dhcp.rapidCommit dhcp.multiDNS">Advanced DHCP Settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">
-                    <div class="col-md-6">
-                        <label>Pi-hole domain name</label>
-                        <div class="form-group">
-                            <div class="input-group">
-                                <div class="input-group-addon">Domain</div>
-                                <input type="text" class="form-control DHCPgroup" id="dhcp.domain" data-key="dhcp.domain" value="">
-                            </div>
-                        </div>
-                        <p>The DNS domains for the DHCP server. If no domain is specified, then any DHCP hostname with a domain part (i.e., with a period) will be disallowed. If a domain is specified, then hostnames with a domain parts matching the domain here are allowed. In addition, when a suffix is set then hostnames without a domain part have the suffix added as an optional domain part.</p>
-                    </div>
-                    <div class="col-md-6">
+                    <div class="col-md-12">
                         <label>DHCP lease time</label>
                         <div class="form-group">
                             <div class="input-group">

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -166,7 +166,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title" data-configkeys="dns.domain dns.domainNeeded dns.bogusPriv dns.dnssec">Advanced DNS settings</h3>
+                <h3 class="box-title" data-configkeys="dns.domain dns.expandHosts">DNS domain settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">
@@ -175,11 +175,25 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                         <div class="form-group">
                             <div class="input-group">
                                 <div class="input-group-addon">Domain</div>
-                                <input type="text" class="form-control DHCPgroup" id="dns.domain" data-key="dns.domain" value="">
+                                <input type="text" class="form-control" id="dns.domain" data-key="dns.domain" value="">
                             </div>
                         </div>
                         <p>The DNS domains for your Pi-hole. If no domain is specified and you are using Pi-hole's DHCP server, then any hostnames with a domain part (i.e., with a period) will be disallowed. If a domain is specified, then hostnames with a domain parts matching the domain here are allowed. In addition, when a suffix is set then hostnames without a domain part have the suffix added as an optional domain part.</p>
+                        <div>
+                            <input type="checkbox" id="dns.expandHosts" data-key="dns.expandHosts" title="domain-needed">
+                            <label for="dns.expandHosts"><strong>Expand hostnames</strong></label>
+                            <p>If set, the domain is added to simple names (without a period) in /etc/hosts in the same way as for DHCP-derived names.</p>
+                        </div>
                     </div>
+                </div>
+            </div>
+        </div>
+        <div class="box box-warning">
+            <div class="box-header with-border">
+                <h3 class="box-title" data-configkeys="dns.domainNeeded dns.bogusPriv dns.dnssec">Advanced DNS settings</h3>
+            </div>
+            <div class="box-body">
+                <div class="row">
                     <div class="col-lg-12">
                         <div>
                             <input type="checkbox" id="dns.domainNeeded" data-key="dns.domainNeeded" title="domain-needed">

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -166,10 +166,20 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
         </div>
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title" data-configkeys="dns.domainNeeded dns.bogusPriv dns.dnssec">Advanced DNS settings</h3>
+                <h3 class="box-title" data-configkeys="dns.domain dns.domainNeeded dns.bogusPriv dns.dnssec">Advanced DNS settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">
+                    <div class="col-md-12">
+                        <label>Pi-hole domain name</label>
+                        <div class="form-group">
+                            <div class="input-group">
+                                <div class="input-group-addon">Domain</div>
+                                <input type="text" class="form-control DHCPgroup" id="dns.domain" data-key="dns.domain" value="">
+                            </div>
+                        </div>
+                        <p>The DNS domains for your Pi-hole. If no domain is specified and you are using Pi-hole's DHCP server, then any hostnames with a domain part (i.e., with a period) will be disallowed. If a domain is specified, then hostnames with a domain parts matching the domain here are allowed. In addition, when a suffix is set then hostnames without a domain part have the suffix added as an optional domain part.</p>
+                    </div>
                     <div class="col-lg-12">
                         <div>
                             <input type="checkbox" id="dns.domainNeeded" data-key="dns.domainNeeded" title="domain-needed">
@@ -190,8 +200,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 with "no such domain" rather than being forwarded upstream. The set
                                 of prefixes affected is the list given in <a href="https://tools.ietf.org/html/rfc6303">RFC6303</a>.</p>
                                 <p><strong>Important</strong>: Enabling these two options may increase your privacy,
-                                but may also prevent you from being able to access
-                                local hostnames if the Pi-hole is not used as DHCP server.</p>
+                                but may also prevent you from being able to access. Make sure you have set up conditional forwarding in this case.</p>
                         </div>
                         <br>
                         <div>


### PR DESCRIPTION
# What does this implement/fix?

This PR accompanies https://github.com/pi-hole/FTL/pull/1739. It furthermore adds a new setting `dns.expandHosts` which is strongly related to `dns.domain`. Previously, this setting was only reachable via "All settings".

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.