### PR TITLE
Prevent multi-login due to slow password hashing

### DIFF
--- a/scripts/pi-hole/js/login.js
+++ b/scripts/pi-hole/js/login.js
@@ -5,6 +5,8 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
+/* global utils:false */
+
 function getParams() {
   var GETDict = {};
   window.location.search
@@ -102,6 +104,7 @@ function wrongPassword(isError = false, isSuccess = false, data = null) {
 
 function doLogin(password) {
   wrongPassword(false, false, null);
+  utils.disableAll();
   $.ajax({
     url: "/api/auth",
     method: "POST",
@@ -115,6 +118,7 @@ function doLogin(password) {
     })
     .fail(function (data) {
       wrongPassword(true, false, data);
+      utils.enableAll();
     });
 }
 


### PR DESCRIPTION
# What does this implement/fix?

There is currently no limit on how often you can submit the password until you are finally logged in. This is most noticeable on **very** low-end hardware, such as an emulated `armv7` target in the following example:
![ezgif-4-dc8726674d](https://github.com/pi-hole/web/assets/16748619/fa2bcfa2-2a46-4dbf-9aed-940867708534)


After this PR, multiple logins during password validation are prevented:
![ezgif-4-94b945a31e](https://github.com/pi-hole/web/assets/16748619/a8a423c8-fb29-4cc2-af01-8a7f0690a1c9)



**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.