### PR TITLE
Add word break for clients column to avoid horizontal scrollbar (v6)

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -92,6 +92,11 @@ td.lookatme {
   white-space: pre-wrap;
 }
 
+/* Client column */
+#all-queries td:nth-of-type(5) {
+  word-break: break-all;
+}
+
 /* Allow Info String to wrap (useful while filtering entries on small screen) */
 #all-queries_info {
   white-space: unset;


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix #2837 

### How does this PR accomplish the above?

Allowing word break when the client name is too long.

Note: This is the v6 version of PR-2838

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
