### PR TITLE
Use row background colors in Query Log table

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -85,6 +85,7 @@ function parseQueryStatus(data) {
     buttontext,
     icon = null,
     colorClass = false,
+    blocked = false,
     isCNAME = false;
   switch (data.status) {
     case "GRAVITY":
@@ -93,6 +94,7 @@ function parseQueryStatus(data) {
       fieldtext = "Blocked (gravity)";
       buttontext =
         '<button type="button" class="btn btn-default btn-sm text-green btn-whitelist"><i class="fas fa-check"></i> Allow</button>';
+      blocked = true;
       break;
     case "FORWARDED":
       colorClass = "text-green";
@@ -114,6 +116,7 @@ function parseQueryStatus(data) {
       fieldtext = "Blocked (regex)";
       buttontext =
         '<button type="button" class="btn btn-default btn-sm text-green btn-whitelist"><i class="fas fa-check"></i> Allow</button>';
+      blocked = true;
       break;
     case "DENYLIST":
       colorClass = "text-red";
@@ -121,24 +124,28 @@ function parseQueryStatus(data) {
       fieldtext = "Blocked (exact)";
       buttontext =
         '<button type="button" class="btn btn-default btn-sm text-green btn-whitelist"><i class="fas fa-check"></i> Allow</button>';
+      blocked = true;
       break;
     case "EXTERNAL_BLOCKED_IP":
       colorClass = "text-red";
       icon = "fa-solid fa-ban";
       fieldtext = "Blocked (external, IP)";
       buttontext = "";
+      blocked = true;
       break;
     case "EXTERNAL_BLOCKED_NULL":
       colorClass = "text-red";
       icon = "fa-solid fa-ban";
       fieldtext = "Blocked (external, NULL)";
       buttontext = "";
+      blocked = true;
       break;
     case "EXTERNAL_BLOCKED_NXRA":
       colorClass = "text-red";
       icon = "fa-solid fa-ban";
       fieldtext = "Blocked (external, NXRA)";
       buttontext = "";
+      blocked = true;
       break;
     case "GRAVITY_CNAME":
       colorClass = "text-red";
@@ -147,6 +154,7 @@ function parseQueryStatus(data) {
       buttontext =
         '<button type="button" class="btn btn-default btn-sm text-green btn-whitelist"><i class="fas fa-check"></i> Allow</button>';
       isCNAME = true;
+      blocked = true;
       break;
     case "REGEX_CNAME":
       colorClass = "text-red";
@@ -155,6 +163,7 @@ function parseQueryStatus(data) {
       buttontext =
         '<button type="button" class="btn btn-default btn-sm text-green btn-whitelist"><i class="fas fa-check"></i> Allow</button>';
       isCNAME = true;
+      blocked = true;
       break;
     case "DENYLIST_CNAME":
       colorClass = "text-red";
@@ -163,6 +172,7 @@ function parseQueryStatus(data) {
       buttontext =
         '<button type="button" class="btn btn-default btn-sm text-green btn-whitelist"><i class="fas fa-check"></i> Allow</button>';
       isCNAME = true;
+      blocked = true;
       break;
     case "RETRIED":
       colorClass = "text-green";
@@ -207,6 +217,7 @@ function parseQueryStatus(data) {
     icon: icon,
     isCNAME: isCNAME,
     matchText: matchText,
+    blocked: blocked,
   };
 }
 
@@ -561,6 +572,9 @@ $(function () {
       } else if (querystatus.colorClass !== false) {
         $(row).addClass(querystatus.colorClass);
       }
+
+      // Define row background color
+      $(row).addClass(querystatus.blocked === true ? "blocked-row" : "allowed-row");
 
       // Substitute domain by "." if empty
       var domain = data.domain === 0 ? "." : data.domain;


### PR DESCRIPTION
### What does this PR aim to accomplish?

The new query log implementation lost the color background identifying blocked and allowed queries.


### How does this PR accomplish the above?

Reintroducing the background color for Query Log rows.
![image](https://github.com/pi-hole/web/assets/1385443/f0f4e34d-1695-408a-8a93-c3a3b2dc658f)


### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
