### PR TITLE
Allow open details only on normal rows

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -603,8 +603,8 @@ $(function () {
     event.stopPropagation();
   });
 
-  // Add event listener for opening and closing details
-  $("#all-queries tbody").on("click", "tr", function () {
+  // Add event listener for opening and closing details, except on rows with "details-row" class
+  $("#all-queries tbody").on("click", "tr:not(.details-row)", function () {
     var tr = $(this);
     var row = table.row(tr);
 
@@ -618,8 +618,8 @@ $(function () {
       row.child.hide();
       tr.removeClass("shown");
     } else {
-      // Open this row
-      row.child(formatInfo(row.data())).show();
+      // Open this row. Add a class to the row
+      row.child(formatInfo(row.data()), "details-row").show();
       tr.addClass("shown");
     }
   });


### PR DESCRIPTION
Detail rows don't have their own details, so don't allow the click event

### What does this PR aim to accomplish?

Fix https://github.com/pi-hole/web/issues/2841

### How does this PR accomplish the above?

Add a class "child-row" to every detail row, then don't allow the click event on row with class "child-row".

_Note: this class can be used in the future to apply styles to the row contents._

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
