### PR TITLE
Fix Upstreams Query Log links

### DIFF
--- a/scripts/pi-hole/js/charts.js
+++ b/scripts/pi-hole/js/charts.js
@@ -5,6 +5,8 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
+/* global upstreams */
+
 // eslint-disable-next-line no-unused-vars
 var THEME_COLORS = [
   "#f56954",
@@ -97,7 +99,8 @@ const htmlLegendPlugin = {
             window.location.href = "queries.lp?type=" + item.text;
           } else if (chart.canvas.id === "forwardDestinationPieChart") {
             // Encode the forward destination as it may contain an "#" character
-            window.location.href = "queries.lp?upstream=" + encodeURIComponent(item.text);
+            const upstream = encodeURIComponent(upstreams[item.text]);
+            window.location.href = "queries.lp?upstream=" + upstream;
           }
         });
       }

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -200,6 +200,7 @@ function updateClientsOverTime() {
     });
 }
 
+var upstreams = {};
 function updateForwardDestinationsPie() {
   $.getJSON("/api/stats/upstreams", function (data) {
     var v = [],
@@ -219,6 +220,12 @@ function updateForwardDestinationsPie() {
       var label = item.name !== null && item.name.length > 0 ? item.name : item.ip;
       if (item.port > 0) {
         label += "#" + item.port;
+      }
+
+      // Store upstreams for generating links to the Query Log
+      upstreams[label] = item.ip;
+      if (item.port > 0) {
+        upstreams[label] += "#" + item.port;
       }
 
       var percent = (100 * item.count) / sum;


### PR DESCRIPTION
# What does this implement/fix?

Fix upstream links yielding no results on the Query Log if names are shown. It works by remembering which name belongs to which address and using this later on when a link is created:

![Screenshot from 2023-11-16 12-51-59](https://github.com/pi-hole/web/assets/16748619/c9d7335c-6af8-472c-bc41-60ae64e23da2)
![Screenshot from 2023-11-16 12-51-49](https://github.com/pi-hole/web/assets/16748619/44886345-a1b2-4416-a32c-cc9034a9508e)


This is a regression of https://github.com/pi-hole/web/pull/2827. This PR fixes https://github.com/pi-hole/web/issues/2833

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.