### PR TITLE
Show Unicode domains (if domain is punycode-encoded)

### DIFF
--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -151,7 +151,8 @@ function initTable() {
           '" title="' +
           tooltip +
           '" class="breakall">' +
-          data.domain +
+          data.unicode +
+          (data.domain !== data.unicode ? " (" + data.domain + ")" : "") +
           "</code>"
       );
 


### PR DESCRIPTION
# What does this implement/fix?

Show Unicode domains (if different from possibly punycode-encoded raw domains).

This PR depends on https://github.com/pi-hole/FTL/pull/1761

## Before

![Screenshot from 2023-11-19 23-00-02](https://github.com/pi-hole/web/assets/16748619/228666ee-30ba-420e-92b2-7394fb3275ee)

## Now
![Screenshot from 2023-11-19 23-01-17](https://github.com/pi-hole/web/assets/16748619/767dbe2b-3d6e-4cf8-b6f7-7904c5bdffb7)


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.