### PR TITLE
Add support for legacy Teleporter archives

### DIFF
--- a/scripts/pi-hole/js/settings-teleporter.js
+++ b/scripts/pi-hole/js/settings-teleporter.js
@@ -51,7 +51,7 @@ function importZIP() {
         $("#modal-import-success-title").text("Import successful");
         var text = "<p>Processed files:<ul>";
         for (var i = 0; i < data.files.length; i++) {
-          text += "<li>/" + utils.escapeHtml(data.files[i]) + "</li>";
+          text += "<li>" + utils.escapeHtml(data.files[i]) + "</li>";
         }
 
         text += "</ul></p>";

--- a/settings-teleporter.lp
+++ b/settings-teleporter.lp
@@ -20,8 +20,8 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                 <h3 class="box-title">Export your Pi-hole's configuration</h3>
             </div>
             <div class="box-body">
-                <p>Warning: This archive contains sensitive information about your Pi-hole installation, e.g. the API token and the 2FA-TOTP secret (if enabled). Please be careful with this file and do not share it with anyone even if they claim to help you.</p>
-                <? if not is_secure then ?><p class='text-danger'>Warning: You are currently not using an end-to-end encryption. This means that your API token and 2FA-TOTP secret will be transmitted in plain text. We recommend to use HTTPS when exporting your configuration.</p><? end ?>
+                <p>Warning: This archive contains sensitive information about your Pi-hole installation, e.g. your 2FA-TOTP secret (if enabled). Please be careful with this file and do not share it with anyone even if they claim to help you.</p>
+                <? if not is_secure then ?><p class='text-danger'>Warning: You are currently not using an end-to-end encryption. This means that secrets like your 2FA-TOTP secret will be transmitted in plain text. We recommend to use HTTPS when exporting your configuration.</p><? end ?>
                 <div class="pull-right">
                     <a class="btn btn-app btn-success" id="GETTeleporter" target="_blank">
                         <i class="fa fa-save"></i><br>Export

--- a/settings-teleporter.lp
+++ b/settings-teleporter.lp
@@ -38,7 +38,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="box-body">
                 <div class="form-group">
                     <label for="file">File input</label>
-                    <input type="file" name="file" id="file" accept=".zip">
+                    <input type="file" name="file" id="file" accept=".zip,.tar.gz">
                     <p class="help-block">When importing settings from a <em>newer</em> version of Pi-hole, not yet existing settings will be ignored. When importing from an <em>older</em> version of Pi-hole, settings for newer features will be initialized with their default values.</p>
                 </div>
                 <div class="pull-right">


### PR DESCRIPTION
# What does this implement/fix?

A very small PR accompanying https://github.com/pi-hole/FTL/pull/1766. It ensures users can select `.tar.gz` files for uploading and removed a doubled slash, possibly causing paths to be shown like `//etc/pihole/setupVars.conf`.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.