### PR TITLE
Remove test leftover

### DIFF
--- a/scripts/pi-hole/js/settings-dns-records.js
+++ b/scripts/pi-hole/js/settings-dns-records.js
@@ -230,7 +230,6 @@ $(document).ready(function () {
         $("#Hdomain").val("");
         $("#Hip").val("");
         $("#hosts-Table").DataTable().ajax.reload(null, false);
-        $("#hosts-Table").DataTable().rows().deselect();
       })
       .fail(function (data, exception) {
         utils.enableAll();
@@ -257,7 +256,6 @@ $(document).ready(function () {
         $("#Cdomain").val("");
         $("#Ctarget").val("");
         $("#cnameRecords-Table").DataTable().ajax.reload(null, false);
-        $("#cnameRecords-Table").DataTable().rows().deselect();
       })
       .fail(function (data, exception) {
         utils.enableAll();


### PR DESCRIPTION
Cleanup.

After testing an alternative branch using buttons to delete multiple items, all code including the buttons were removed, but the call to the `deselect()` function was left.