### PR TITLE
Local records: better layout to avoid text overlapping in smaller screens

### DIFF
--- a/scripts/pi-hole/js/settings-dns-records.js
+++ b/scripts/pi-hole/js/settings-dns-records.js
@@ -49,7 +49,7 @@ function populateDataTable(endpoint) {
     columns = [
       { data: null, render: CNAMEdomain },
       { data: null, render: CNAMEtarget },
-      { data: null, render: CNAMEttl },
+      { data: null, width: "40px", render: CNAMEttl },
       { data: null, width: "22px", orderable: false },
     ];
   }
@@ -266,4 +266,7 @@ $(document).ready(function () {
         console.log(exception); // eslint-disable-line no-console
       });
   });
+
+  // Add a small legend below the CNAME table
+  $("#cnameRecords-Table").after("<small>* <b>TTL</b> in seconds <i>(optional)</i></small>");
 });

--- a/scripts/pi-hole/js/settings-dns-records.js
+++ b/scripts/pi-hole/js/settings-dns-records.js
@@ -99,7 +99,7 @@ function populateDataTable(endpoint) {
       $(`td:eq(${endpoint === "hosts" ? 2 : 3})`, row).html(button);
     },
     dom:
-      "<'row'<'col-sm-6'l><'col-sm-6'f>>" +
+      "<'row'<'col-sm-5'l><'col-sm-7'f>>" +
       "<'row'<'col-sm-12'p>>" +
       "<'row'<'col-sm-12'<'table-responsive'tr>>>" +
       "<'row'<'col-sm-12'p>>" +

--- a/scripts/pi-hole/js/settings-dns-records.js
+++ b/scripts/pi-hole/js/settings-dns-records.js
@@ -73,6 +73,7 @@ function populateDataTable(endpoint) {
       type: "GET",
       dataSrc: `config.dns.${endpoint}`,
     },
+    autoWidth: false,
     columns: columns,
     columnDefs: [
       {

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -35,10 +35,10 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                             <tfoot class="add-new-item">
                                 <tr>
                                     <th>
-                                        <input id="Hdomain" type="url" class="form-control" data-configkeys="hosts" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Hdomain" type="url" class="form-control" data-configkeys="hosts" placeholder="Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </th>
                                     <th>
-                                        <input id="Hip" type="text" class="form-control" data-configkeys="hosts" placeholder="Associated IP address" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Hip" type="text" class="form-control" data-configkeys="hosts" placeholder="Associated IP" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </th>
                                     <th>
                                         <button type="button" id="btnAdd-host" class="btn btn-primary btn-xs" data-configkeys="hosts"><i class="fa fa-plus"></i></button>
@@ -71,20 +71,20 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 <tr>
                                     <th>Domain</th>
                                     <th>Target</th>
-                                    <th>TTL <i class="small">(optional)</i></th>
+                                    <th>TTL *</th>
                                     <th></th>
                                 </tr>
                             </thead>
                             <tfoot class="add-new-item">
                                 <tr>
                                     <th>
-                                        <input id="Cdomain" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Cdomain" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </th>
                                     <th>
-                                        <input id="Ctarget" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Associated Target Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Ctarget" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Target Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </th>
                                     <th>
-                                        <input id="Cttl" type="numeric" class="form-control" data-configkeys="cnameRecords" placeholder="TTL in seconds" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="Cttl" type="numeric" class="form-control" data-configkeys="cnameRecords" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </th>
                                     <th>
                                         <button type="button" id="btnAdd-cname" class="btn btn-primary btn-xs" data-configkeys="cnameRecords"><i class="fa fa-plus"></i></button>

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -14,7 +14,7 @@ PageTitle = "Local DNS Settings"
 mg.include('scripts/pi-hole/lua/settings_header.lp','r')
 ?>
 <div class="row">
-    <div class="col-md-6 settings-level-1">
+    <div class="col-md-12 col-lg-6 settings-level-1">
         <div class="box">
             <div class="box-header with-border">
                 <h3 class="box-title" id="title-hosts" data-configkeys="dns.hosts">Local DNS records</h3>
@@ -70,7 +70,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             </div>
         </div>
     </div>
-    <div class="col-md-6 settings-level-1">
+    <div class="col-md-12 col-lg-6 settings-level-1">
         <div class="box">
             <div class="box-header with-border">
                 <h3 class="box-title" id="title-cnameRecords" data-configkeys="dns.cnameRecords">Local CNAME records records</h3>

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -71,7 +71,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                 <tr>
                                     <th>Domain</th>
                                     <th>Target</th>
-                                    <th>TTL</th>
+                                    <th>TTL <i class="small">(optional)</i></th>
                                     <th></th>
                                 </tr>
                             </thead>

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -45,9 +45,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                     </div>
                                 </div>
                             </div>
-                            <div class="box-footer clearfix">
-                                <strong>Note:</strong>
-                                <p>Adding/removing local DNS records will flush the cache but does not require a restart of the DNS server.</p>
+                            <div class="box-footer">
                                 <button type="button" id="btnAdd-host" class="btn btn-primary pull-right" data-configkeys="hosts">Add</button>
                             </div>
                         </div>
@@ -67,6 +65,10 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                         <button type="button" id="resetButton" class="btn btn-default btn-sm text-red hidden">Clear Filters</button>
                     </div>
                 </div>
+            </div>
+            <div class="box-footer">
+                <strong>Note:</strong>
+                <p>Adding/removing local DNS records will flush the cache but does not require a restart of the DNS server.</p>
             </div>
         </div>
     </div>
@@ -105,13 +107,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                                     </div>
                                 </div>
                             </div>
-                            <div class="box-footer clearfix">
-                                <strong>Note:</strong>
-                                <p>The target of a <code>CNAME</code> must be a domain that the Pi-hole already has in its cache or is authoritative for. This is a universal limitation of <code>CNAME</code> records.</p>
-                                <p>The reason for this is that Pi-hole will not send additional queries upstream when serving <code>CNAME</code> replies. As consequence, if you set a target that isn't already known, the reply to the client may be incomplete. Pi-hole just returns the information it knows at the time of the query. This results in certain limitations for <code>CNAME</code> targets,
-                                for instance, only <i>active</i> DHCP leases work as targets - mere DHCP <i>leases</i> aren't sufficient as they aren't (yet) valid DNS records.</p>
-                                <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this could result in invalid SSL certificate errors when the target server does not serve content for the requested domain.</p>
-                                <p>Adding/removing local CNAME records will restart the DNS server.</p>
+                            <div class="box-footer">
                                 <button type="button" id="btnAdd-cname" class="btn btn-primary pull-right" data-configkeys="cnameRecords">Add</button>
                             </div>
                         </div>
@@ -132,6 +128,14 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                         <button type="button" id="resetButton" class="btn btn-default btn-sm text-red hidden">Clear Filters</button>
                     </div>
                 </div>
+            </div>
+            <div class="box-footer">
+                <strong>Note:</strong>
+                <p>The target of a <code>CNAME</code> must be a domain that the Pi-hole already has in its cache or is authoritative for. This is a universal limitation of <code>CNAME</code> records.</p>
+                <p>The reason for this is that Pi-hole will not send additional queries upstream when serving <code>CNAME</code> replies. As consequence, if you set a target that isn't already known, the reply to the client may be incomplete. Pi-hole just returns the information it knows at the time of the query. This results in certain limitations for <code>CNAME</code> targets,
+                for instance, only <i>active</i> DHCP leases work as targets - mere DHCP <i>leases</i> aren't sufficient as they aren't (yet) valid DNS records.</p>
+                <p>Additionally, you can't <code>CNAME</code> external domains (<code>bing.com</code> to <code>google.com</code>) successfully as this could result in invalid SSL certificate errors when the target server does not serve content for the requested domain.</p>
+                <p>Adding/removing local CNAME records will restart the DNS server.</p>
             </div>
         </div>
     </div>

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -22,45 +22,29 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="box-body">
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="box collapsed-box">
-                            <!-- /.box-header -->
-                            <div class="box-header with-border">
-                                <h3 class="box-title">
-                                    Add new DNS record
-                                </h3>
-                                <div class="box-tools pull-right">
-                                    <button type="button" class="btn btn-box-tool" data-configkeys="hosts" data-widget="collapse"><i class="fa fa-plus"></i></button>
-                                </div>
-                            </div>
-                            <!-- /.box-header -->
-                            <div class="box-body">
-                                <div class="row">
-                                    <div class="form-group col-md-6">
-                                        <label for="domain">Domain:</label>
-                                        <input id="Hdomain" type="url" class="form-control" data-configkeys="hosts" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
-                                    </div>
-                                    <div class="form-group col-md-6">
-                                        <label for="target">IP address:</label>
-                                        <input id="Hip" type="text" class="form-control" data-configkeys="hosts" placeholder="Associated IP address" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="box-footer">
-                                <button type="button" id="btnAdd-host" class="btn btn-primary pull-right" data-configkeys="hosts">Add</button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-12">
                         <h3 class="box-title">List of local DNS records</h3>
                             <!-- /.box-header -->
                         <table id="hosts-Table" class="table table-striped table-bordered" width="100%">
                             <thead>
-                            <tr>
-                                <th>Domain</th>
-                                <th>IP</th>
-                                <th></th>
-                            </tr>
+                                <tr>
+                                    <th>Domain</th>
+                                    <th>IP</th>
+                                    <th></th>
+                                </tr>
                             </thead>
+                            <tfoot class="add-new-item">
+                                <tr>
+                                    <th>
+                                        <input id="Hdomain" type="url" class="form-control" data-configkeys="hosts" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <input id="Hip" type="text" class="form-control" data-configkeys="hosts" placeholder="Associated IP address" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <button type="button" id="btnAdd-host" class="btn btn-primary btn-xs" data-configkeys="hosts"><i class="fa fa-plus"></i></button>
+                                    </th>
+                                </tr>
+                            </tfoot>
                         </table>
                         <button type="button" id="resetButton" class="btn btn-default btn-sm text-red hidden">Clear Filters</button>
                     </div>
@@ -80,50 +64,33 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="box-body">
                 <div class="row">
                     <div class="col-md-12">
-                        <div class="box collapsed-box">
-                            <!-- /.box-header -->
-                            <div class="box-header with-border">
-                                <h3 class="box-title">
-                                    Add new CNAME record
-                                </h3>
-                                <div class="box-tools pull-right">
-                                    <button type="button" class="btn btn-box-tool" data-configkeys="cnameRecords" data-widget="collapse"><i class="fa fa-plus"></i></button>
-                                </div>
-                            </div>
-                            <!-- /.box-header -->
-                            <div class="box-body">
-                                <div class="row">
-                                    <div class="form-group col-md-5">
-                                        <label for="domain">Domain:</label>
-                                        <input id="Cdomain" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
-                                    </div>
-                                    <div class="form-group col-md-5">
-                                        <label for="target">Target Domain:</label>
-                                        <input id="Ctarget" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Associated Target Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
-                                    </div>
-                                    <div class="form-group col-md-2">
-                                        <label for="target">TTL (optional):</label>
-                                        <input id="Cttl" type="numeric" class="form-control" data-configkeys="cnameRecords" placeholder="TTL in seconds" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="box-footer">
-                                <button type="button" id="btnAdd-cname" class="btn btn-primary pull-right" data-configkeys="cnameRecords">Add</button>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-md-12">
                         <h3 class="box-title">List of local CNAME records</h3>
                             <!-- /.box-header -->
                         <table id="cnameRecords-Table" class="table table-striped table-bordered" width="100%">
                             <thead>
-                            <tr>
-                                <th>Domain</th>
-                                <th>Target</th>
-                                <th>TTL</th>
-                                <th></th>
-                            </tr>
+                                <tr>
+                                    <th>Domain</th>
+                                    <th>Target</th>
+                                    <th>TTL</th>
+                                    <th></th>
+                                </tr>
                             </thead>
+                            <tfoot class="add-new-item">
+                                <tr>
+                                    <th>
+                                        <input id="Cdomain" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Add a domain (example.com or sub.example.com)" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <input id="Ctarget" type="url" class="form-control" data-configkeys="cnameRecords" placeholder="Associated Target Domain" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <input id="Cttl" type="numeric" class="form-control" data-configkeys="cnameRecords" placeholder="TTL in seconds" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <button type="button" id="btnAdd-cname" class="btn btn-primary btn-xs" data-configkeys="cnameRecords"><i class="fa fa-plus"></i></button>
+                                    </th>
+                                </tr>
+                            </tfoot>
                         </table>
                         <button type="button" id="resetButton" class="btn btn-default btn-sm text-red hidden">Clear Filters</button>
                     </div>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -373,10 +373,16 @@ td.lookatme {
   font-family: inherit;
 }
 
-.form-inline .dataTables .form-control {
+.form-inline .dataTable .form-control {
   display: inline-block;
   width: 100%;
   vertical-align: middle;
+}
+
+/* Table footer row used to add new items, using inline input fields */
+tfoot.add-new-item > tr > th {
+  font-weight: normal;
+  vertical-align: inherit;
 }
 
 .select2-container--default .select2-results > .select2-results__options {


### PR DESCRIPTION
### What does this PR aim to accomplish?

Second part of #2854 fix.
Avoid text overlapping in smaller screens.

### How does this PR accomplish the above?*

- Using a single column in medium and small screens. Only use 2 columns in large screens.
- Small adjustments to grid holding the datatables control elements.
- Replacing the collapsible box: moving the input fields to the table footer and notes to the bottom.

![image](https://github.com/pi-hole/web/assets/1385443/004eaa62-59a8-4509-886b-de108a11447e)

![mobile](https://github.com/pi-hole/web/assets/1385443/e50ffb45-d07c-40ae-a89f-c4f4b117fd9b)


### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
