### PR TITLE
Continue tailing log after FTL restart

### DIFF
--- a/scripts/pi-hole/js/taillog.js
+++ b/scripts/pi-hole/js/taillog.js
@@ -8,6 +8,7 @@
 /* global moment: false, apiFailure: false, utils: false */
 
 var nextID = 0;
+var lastPID = -1;
 
 // Check every 0.5s for fresh data
 const interval = 500;
@@ -41,6 +42,22 @@ function getData() {
     method: "GET",
   })
     .done(function (data) {
+      // Check if we have a new PID -> FTL was restarted
+      if (lastPID !== data.pid) {
+        if (lastPID !== -1) {
+          $("#output").append("<i class='text-danger'>*** FTL restarted ***</i><br>");
+        }
+
+        // Remember PID
+        lastPID = data.pid;
+        // Reset nextID
+        nextID = 0;
+
+        getData();
+        return;
+      }
+
+      // Set placeholder text if log file is empty and we have no new lines
       if (data.log.length === 0) {
         if (nextID === 0) {
           $("#output").html("<i>*** Log file is empty ***</i>");


### PR DESCRIPTION
# What does this implement/fix?

Reset `nextID` on change of FTL's PID to appreciate the new counter after a restart:

![Screenshot from 2023-11-23 09-36-17](https://github.com/pi-hole/web/assets/16748619/2228f15e-9507-4df8-9e2d-36e33ee88b6e)


This is PR is part of a bug fix fixing that no new log lines are shown after FTL restarts as `nextID` was not reset.

Needs FTL from PR https://github.com/pi-hole/FTL/pull/1780

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.