### PR TITLE
Remove extra <ul></ul>

### DIFF
--- a/scripts/pi-hole/js/groups-domains.js
+++ b/scripts/pi-hole/js/groups-domains.js
@@ -448,7 +448,7 @@ function delItems(ids) {
 
   utils.disableAll();
   const idstring = ids.join(", ");
-  utils.showAlert("info", "", "Deleting domain...", "<ul>" + domain + "</ul>");
+  utils.showAlert("info", "", "Deleting domain...", domain);
 
   $.ajax({
     url: "/api/domains/" + typestr + "/" + encodeURIComponent(domain),

--- a/scripts/pi-hole/js/groups-lists.js
+++ b/scripts/pi-hole/js/groups-lists.js
@@ -466,7 +466,7 @@ function delItems(ids) {
 
   utils.disableAll();
   const idstring = ids.join(", ");
-  utils.showAlert("info", "", "Deleting list(s) ...", "<ul>" + address + "</ul>");
+  utils.showAlert("info", "", "Deleting list(s) ...", address);
 
   $.ajax({
     url: "/api/lists/" + encodeURIComponent(address),


### PR DESCRIPTION
# What does this implement/fix?

Fixes a bug mentioned in https://github.com/pi-hole/web/pull/2852#issuecomment-1824949146 of extraneous `<ul>` and `</ul>` HTML tags

![Screenshot from 2023-11-24 07-52-17](https://github.com/pi-hole/web/assets/16748619/7a389267-ed46-46f9-90af-12f13346fa71)


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.