### PR TITLE
Fix legend crossing out

### DIFF
--- a/scripts/pi-hole/js/charts.js
+++ b/scripts/pi-hole/js/charts.js
@@ -40,7 +40,8 @@ const htmlLegendPlugin = {
     if (
       options.lastLegendItems &&
       items.length === options.lastLegendItems.length &&
-      items.every((item, i) => item.text === options.lastLegendItems[i].text)
+      items.every((item, i) => item.text === options.lastLegendItems[i].text) &&
+      items.every((item, i) => item.hidden === options.lastLegendItems[i].hidden)
     ) {
       return;
     }


### PR DESCRIPTION
# What does this implement/fix?

See title. Fixed by also checking `item.hidden` property when deciding to skip legend regeneration.

Example:

![Screenshot from 2023-11-25 10-54-15](https://github.com/pi-hole/web/assets/16748619/07740c98-9699-46fc-9e01-975784831f7c)

We can click on, e.g., `A` to hide `A`. Hiding the red chart area is working but the chart's legend is not updated:

![Screenshot from 2023-11-25 10-54-50](https://github.com/pi-hole/web/assets/16748619/98211cc0-43c8-439d-82f0-cd7478a9319a)

This is fixed by this PR (see unticked box + crossed out text):

![Screenshot from 2023-11-25 10-54-20](https://github.com/pi-hole/web/assets/16748619/f7739b59-976b-4842-bc7b-ebffc206d04c)

This was originally broken in https://github.com/pi-hole/web/commit/9c1f310af05b75f96ea030d1cb64ae94780747ff of https://github.com/pi-hole/web/pull/2811

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
