### PR TITLE
Fix mass-deletion of DHCP leases

### DIFF
--- a/scripts/pi-hole/js/settings-dhcp.js
+++ b/scripts/pi-hole/js/settings-dhcp.js
@@ -118,7 +118,7 @@ $(function () {
           var ids = [];
           $("tr.selected").each(function () {
             // ... add the row identified by "data-id".
-            ids.push(parseInt($(this).attr("data-id"), 10));
+            ids.push($(this).attr("data-id"));
           });
           // Delete all selected rows at once
           delLease(ids);

--- a/scripts/pi-hole/js/settings-dhcp.js
+++ b/scripts/pi-hole/js/settings-dhcp.js
@@ -60,7 +60,7 @@ $(function () {
       },
     ],
     drawCallback: function () {
-      $('button[id^="deleteLease_"]').on("click", deleteLease);
+      $('button[id^="deleteLease_"]').on("click", delLease);
 
       // Hide buttons if all messages were deleted
       var hasRows = this.api().rows({ filter: "applied" }).data().length > 0;
@@ -115,13 +115,10 @@ $(function () {
         className: "btn-sm datatable-bt deleteSelected",
         action: function () {
           // For each ".selected" row ...
-          var ids = [];
           $("tr.selected").each(function () {
-            // ... add the row identified by "data-id".
-            ids.push($(this).attr("data-id"));
+            // ... delete the row identified by "data-id".
+            delLease($(this).attr("data-id"));
           });
-          // Delete all selected rows at once
-          delLease(ids);
         },
       },
     ],
@@ -159,24 +156,14 @@ $(function () {
   });
 });
 
-function deleteLease() {
-  // Passes the button data-del-id attribute as IP
-  var ips = [$(this).attr("data-del-ip")];
-
-  // Check input validity
-  if (!Array.isArray(ips)) return;
-
-  // Exploit prevention: Return early for non-numeric IDs
-  for (var ip in ips) {
-    if (Object.hasOwnProperty.call(ips, ip)) {
-      delLease(ips);
-    }
-  }
-}
-
-function delLease(ip) {
+function delLease(ip = null) {
   utils.disableAll();
   utils.showAlert("info", "", "Deleting lease...");
+
+  // If no IP is passed, use the button data-del-ip attribute
+  if (ip === null) {
+    ip = $(this).attr("data-del-ip");
+  }
 
   $.ajax({
     url: "/api/dhcp/leases/" + ip,


### PR DESCRIPTION
# What does this implement/fix?

See title. Running `parseInt("192.168.1.2", 10)`  does not result in a meaningful IP address. There is no room for exploiting anything here so we can use the input without sanitation. This bug has been reported [on Discourse](https://discourse.pi-hole.net/t/trying-to-delete-all-active-dhcp-leases-at-once-fails/66598).

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.