### PR TITLE
Add dnsmasq tail log formatting

### DIFF
--- a/scripts/pi-hole/js/taillog.js
+++ b/scripts/pi-hole/js/taillog.js
@@ -19,6 +19,25 @@ const fadeIn = true;
 // Mark new lines with a red line above them
 const markUpdates = true;
 
+// Format a line of the dnsmasq log
+function formatLine(line) {
+  // Remove dnsmasq + PID
+  let txt = line.replaceAll(/ dnsmasq\[\d*]/g, "");
+
+  if (line.includes("denied") || line.includes("gravity blocked")) {
+    // Red bold text for blocked domains
+    txt = `<b class="log-red">${txt}</b>`;
+  } else if (line.includes("query[A") || line.includes("query[DHCP")) {
+    // Bold text for initial query lines
+    txt = `<b>${txt}</b>`;
+  } else {
+    // Grey text for all other lines
+    txt = `<span class="text-muted">${txt}</span>`;
+  }
+
+  return txt;
+}
+
 // Function that asks the API for new data
 function getData() {
   // Only update when spinner is spinning
@@ -71,6 +90,9 @@ function getData() {
       }
 
       data.log.forEach(function (line) {
+        // Format line if this is the dnsmasq log
+        if (GETDict.file === "dnsmasq") line.message = formatLine(line.message);
+
         // Add new line to output
         $("#output").append(
           '<span><span style="border-left: 2px red" class="left-line">&nbsp;</span><span class="text-muted">' +

--- a/scripts/pi-hole/js/taillog.js
+++ b/scripts/pi-hole/js/taillog.js
@@ -95,7 +95,7 @@ function getData() {
 
         // Add new line to output
         $("#output").append(
-          '<span><span style="border-left: 2px red" class="left-line">&nbsp;</span><span class="text-muted">' +
+          '<span class="log-entry"><span class="text-muted">' +
             moment(1000 * line.timestamp).format("YYYY-MM-DD HH:mm:ss.SSS") +
             "</span> " +
             line.message +

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1429,3 +1429,7 @@ table.dataTable tbody > tr > .selected {
   margin: 0.5em 0;
   align-items: start;
 }
+
+.log-entry {
+  padding-left: 0.5em;
+}


### PR DESCRIPTION
# What does this implement/fix?

Port [the colorful tail log feature](https://github.com/pi-hole/web/blob/master/scripts/pi-hole/php/tailLog.php#L15-L28) from Pi-hole v5.0 (PHP) to v6.0 (Javascript):

![Screenshot from 2023-11-28 19-32-21](https://github.com/pi-hole/web/assets/16748619/81f051f9-51db-4432-aa74-3e01b696496f)


---


**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.