### PR TITLE
Add some tolerance to the autoscrolling feature of taillog

### DIFF
--- a/scripts/pi-hole/js/taillog.js
+++ b/scripts/pi-hole/js/taillog.js
@@ -115,7 +115,22 @@ function getData() {
 var gAutoScrolling = true;
 $("#output").on("scroll", function () {
   // Check if we are at the bottom of the output
-  if ($("#output").scrollTop() + $("#output").innerHeight() >= $("#output")[0].scrollHeight) {
+  //
+  // - $("#output")[0].scrollHeight: This gets the entire height of the content
+  //   of the "output" element, including the part that is not visible due to
+  //   scrolling.
+  // - $("#output").innerHeight(): This gets the inner height of the "output"
+  //   element, which is the visible part of the content.
+  // - $("#output").scrollTop(): This gets the number of pixels that the content
+  //   of the "output" element is scrolled vertically from the top.
+  //
+  // By subtracting the inner height and the scroll top from the scroll height,
+  // you get the distance from the bottom of the scrollable area.
+  const bottom =
+    $("#output")[0].scrollHeight - $("#output").innerHeight() - $("#output").scrollTop();
+  // Add a tolerance of four line heights
+  const tolerance = 4 * parseFloat($("#output").css("line-height"));
+  if (bottom <= tolerance) {
     // Auto-scrolling is enabled
     gAutoScrolling = true;
     $("#autoscrolling").addClass("fa-check");


### PR DESCRIPTION
# What does this implement/fix?

On initial load of the taillog page, the "autoscroll" feature is enabled so you will always see the most recent log events. If something catches you attention you can stop this by simply scrolling a bit up. You can then re-enable autoscroll by scrolling again down to the very bottom.

So far, so good. This seems to work reasonably well. however, you have to scroll down *all the way* because the textbox must be at the *exact* bottom for autoscrolling to be re-enabled. This PR improves this behavior by **adding a tolerance of four line heights** for autoscrolling to be re-engage.

This PR is correlated to [this Discourse post (German)](https://discourse.pi-hole.net/t/verschiedene-fragen-zur-beta-6-und-3-vorschlage/66600/5?u=dl6er).

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.