### PR TITLE
Fix height of taillog pre element

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1122,17 +1122,20 @@ table.dataTable tbody > tr > .selected {
 }
 
 .pre-scrollable {
-  max-height: max(195px, 100vh - 170px);
+  /* use dynamic unit to account for mobile browser interface height */
+  max-height: max(195px, 100dvh - 170px);
   overflow-y: scroll;
 }
 @media screen and (max-width: 767px) {
   .pre-scrollable {
-    max-height: max(195px, 100vh - 220px);
+    /* reduce max-height on mobile (higher header) */
+    max-height: max(195px, 100dvh - 220px);
   }
 }
 @media screen and (max-width: 546px) {
   .pre-scrollable {
-    max-height: max(195px, 100vh - 240px);
+    /* reduce max-height even more (box-header text wraps, increasing the height) */
+    max-height: max(195px, 100dvh - 240px);
   }
 }
 

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1122,8 +1122,18 @@ table.dataTable tbody > tr > .selected {
 }
 
 .pre-scrollable {
-  max-height: 100vb;
+  max-height: max(195px, 100vh - 170px);
   overflow-y: scroll;
+}
+@media screen and (max-width: 767px) {
+  .pre-scrollable {
+    max-height: max(195px, 100vh - 220px);
+  }
+}
+@media screen and (max-width: 546px) {
+  .pre-scrollable {
+    max-height: max(195px, 100vh - 240px);
+  }
 }
 
 .hr-small {

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1122,7 +1122,7 @@ table.dataTable tbody > tr > .selected {
 }
 
 .pre-scrollable {
-  max-height: calc(100vh - 300px);
+  max-height: 100vb;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
# What does this implement/fix?

Use block (`Xvb`) instead of viewport (`Xvh`) height to fix maximum height of taillog `<pre>` element

### Before
![Screenshot 2023-11-29 at 13-35-49 Pi-hole ryzen](https://github.com/pi-hole/web/assets/16748619/2f3cbd09-7ac3-47a9-90f8-b18821d0b788)

### Now
![Screenshot 2023-11-29 at 13-35-26 Pi-hole ryzen](https://github.com/pi-hole/web/assets/16748619/bb7e0393-a726-4ec5-b929-a1361db8f8d5)


---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
