### PR TITLE
Ensure blocking mode timer is started even when set via a third-party API call

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -39,10 +39,16 @@ function secondsTimeSpanToHMS(s) {
   return h + ":" + (m < 10 ? "0" + m : m) + ":" + (s < 10 ? "0" + s : s); //zero padding on minutes and seconds
 }
 
-function piholeChanged(blocking) {
-  var status = $("#status");
-  var ena = $("#pihole-enable");
-  var dis = $("#pihole-disable");
+function piholeChanged(blocking, timer = null) {
+  const status = $("#status");
+  const ena = $("#pihole-enable");
+  const dis = $("#pihole-disable");
+  const enaT = $("#enableTimer");
+
+  if (timer !== null && parseFloat(timer) > 0) {
+    enaT.html(Date.now() + parseFloat(timer) * 1000);
+    setTimeout(countDown, 100);
+  }
 
   switch (blocking) {
     case "enabled": {
@@ -83,7 +89,7 @@ function piholeChanged(blocking) {
 function countDown() {
   var ena = $("#enableLabel");
   var enaT = $("#enableTimer");
-  var target = new Date(parseInt(enaT.html(), 10));
+  var target = new Date(parseInt(enaT.text(), 10));
   var seconds = Math.round((target.getTime() - Date.now()) / 1000);
 
   //Stop and remove timer when user enabled early
@@ -97,7 +103,7 @@ function countDown() {
     ena.text("Enable Blocking (" + secondsTimeSpanToHMS(seconds) + ")");
   } else {
     ena.text("Enable Blocking");
-    piholeChanged("enabled");
+    piholeChanged("enabled", null);
     if (localStorage) {
       localStorage.removeItem("countDownTarget");
     }
@@ -116,7 +122,7 @@ function checkBlocking() {
     method: "GET",
   })
     .done(function (data) {
-      piholeChanged(data.blocking);
+      piholeChanged(data.blocking, data.timer);
       utils.setTimer(checkBlocking, REFRESH_INTERVAL.blocking);
     })
     .fail(function (data) {
@@ -126,8 +132,7 @@ function checkBlocking() {
 }
 
 function piholeChange(action, duration) {
-  var enaT = $("#enableTimer");
-  var btnStatus;
+  let btnStatus = null;
 
   switch (action) {
     case "enable":
@@ -155,11 +160,7 @@ function piholeChange(action, duration) {
     .done(function (data) {
       if (data.blocking === action + "d") {
         btnStatus.html("");
-        piholeChanged(data.blocking);
-        if (duration > 0) {
-          enaT.html(Date.now() + duration * 1000);
-          setTimeout(countDown, 100);
-        }
+        piholeChanged(data.blocking, data.timer);
       }
     })
     .fail(function (data) {


### PR DESCRIPTION
# What does this implement/fix?

See title. It works by initiating/resetting the timer whenever the API tells us there is a timer. Before, it was only started when the button in the GUI was clicked.

Fixes the issue originally reported in https://github.com/pi-hole/FTL/issues/1845

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.