### PR TITLE
Fix group editing

### DIFF
--- a/scripts/pi-hole/js/groups.js
+++ b/scripts/pi-hole/js/groups.js
@@ -7,8 +7,7 @@
 
 /* global utils:false, apiFailure:false, updateFtlInfo:false, processGroupResult:false, delGroupItems:false */
 
-var table,
-  idNames = {};
+var table;
 
 function handleAjaxError(xhr, textStatus) {
   if (textStatus === "timeout") {
@@ -73,20 +72,20 @@ $(function () {
         "\nDatabase ID: " +
         data.id;
       $("td:eq(1)", row).html(
-        '<input id="name_' + data.id + '" title="' + tooltip + '" class="form-control">'
+        '<input id="name_' + dataId + '" title="' + tooltip + '" class="form-control">'
       );
-      var nameEl = $("#name_" + data.id, row);
+      var nameEl = $("#name_" + dataId, row);
       nameEl.val(data.name);
       nameEl.on("change", editGroup);
 
       $("td:eq(2)", row).html(
         '<input type="checkbox" id="enabled_' +
-          data.id +
+          dataId +
           '"' +
           (data.enabled ? " checked" : "") +
           ">"
       );
-      var enabledEl = $("#enabled_" + data.id, row);
+      var enabledEl = $("#enabled_" + dataId, row);
       enabledEl.bootstrapToggle({
         on: "Enabled",
         off: "Disabled",
@@ -96,9 +95,9 @@ $(function () {
       });
       enabledEl.on("change", editGroup);
 
-      $("td:eq(3)", row).html('<input id="comment_' + data.id + '" class="form-control">');
+      $("td:eq(3)", row).html('<input id="comment_' + dataId + '" class="form-control">');
       var comment = data.comment !== null ? data.comment : "";
-      var commentEl = $("#comment_" + data.id, row);
+      var commentEl = $("#comment_" + dataId, row);
       commentEl.val(comment);
       commentEl.on("change", editGroup);
 
@@ -292,7 +291,7 @@ function editGroup() {
   const elem = $(this).attr("id");
   const tr = $(this).closest("tr");
   const id = tr.attr("data-id");
-  const oldName = idNames[id];
+  const oldName = utils.hexDecode(id);
   const name = tr.find("#name_" + id).val();
   const enabled = tr.find("#enabled_" + id).is(":checked");
   const comment = tr.find("#comment_" + id).val();


### PR DESCRIPTION
# What does this implement/fix?

Fix editing of groups not being possible. We need to use the group name's for the REST API, not their database ID. We encode the names for safety as users could have used conflicting characters in groups names. This is not new altogether - we do the same for lists as they are allowed to contain `/` which obviously have some meaning in URLs.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.