### PR TITLE
Fix edge-case interpretation of DHCP lease expiration field

### DIFF
--- a/scripts/pi-hole/js/utils.js
+++ b/scripts/pi-hole/js/utils.js
@@ -152,6 +152,10 @@ function showAlert(type, icon, title, message) {
 }
 
 function datetime(date, html, humanReadable) {
+  if (date === 0 && humanReadable) {
+    return "Never";
+  }
+
   var format = html === false ? "Y-MM-DD HH:mm:ss z" : "Y-MM-DD [<br class='hidden-lg'>]HH:mm:ss z";
   var timestr = moment.unix(Math.floor(date)).format(format).trim();
   return humanReadable


### PR DESCRIPTION
# What does this implement/fix?

Fix interpretation of lease expiration field in case it is 0. This does not mean 1st of January 1970 but really a never expiring lease:

![Screenshot from 2024-01-26 16-56-32](https://github.com/pi-hole/web/assets/16748619/ad352f17-c88d-45ee-8a80-5c0a6b07687c)


**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/lease-expired-54-years-ago/67888

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.