### PR TITLE
Better user interface to edit reverse DNS servers (`dns.revServers`)

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -183,13 +183,16 @@ function testCookies() {
 
 var iCheckStyle = "primary";
 function applyCheckboxRadioStyle() {
-  // Get all radio/checkboxes for theming, with the exception of the two radio buttons on the custom disable timer,
-  // as well as every element with an id that starts with "status_"
+  // Get all radio/checkboxes for theming, with the exception of:
+  // - the two radio buttons on the custom disable timer,
+  // - radio/checkboxes elements with class "no-icheck",
+  // - every element with an id that starts with "status_"
   var sel = $("input[type='radio'],input[type='checkbox']")
     .not("#selSec")
     .not("#selMin")
     .not("#expert-settings")
     .not("#only-changed")
+    .not(".no-icheck")
     .not("[id^=status_]");
   sel.parent().removeClass();
   sel.parent().addClass("icheck-" + iCheckStyle);

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -135,30 +135,68 @@ function revServerDataTable() {
     ajax: {
       url: "/api/config/dns/revServers",
       type: "GET",
-      dataSrc: "config.dns.revServers",
+      dataSrc: function (json) {
+        const output = [];
+        for (let i = 0; i < json.config.dns.revServers.length; i++) {
+          const cols = json.config.dns.revServers[i].split(",");
+          output.push({
+            enabled: cols[0],
+            network: cols[1],
+            ip: cols[2],
+            domain: cols[3],
+          });
+        }
+
+        return output;
+      },
     },
     autoWidth: false,
     columns: [
-      { data: null, class: "text-center", width: "60px" },
-      { data: null },
-      { data: null },
-      { data: null },
-      { data: null, width: "22px" },
+      { data: null, width: "60px" },
+      { data: "network" },
+      { data: "ip" },
+      { data: "domain" },
+      { data: null, width: "50px" },
     ],
+    bFilter: false,
     ordering: false,
     columnDefs: [
       {
         targets: 0,
-        render: function (data) {
-          return revServersField(data, 0) === "true"
-            ? '<input type="checkbox" class="no-icheck" checked disabled>'
-            : '<input type="checkbox" class="no-icheck" disabled>';
+        class: "input-checkbox text-center",
+        render: function (data, type, row, meta) {
+          const name = "enabled_" + meta.row;
+          const ckbox =
+            '<input type="checkbox" disabled ' +
+            (data.enabled === "true" ? "checked " : "") +
+            `name="${name}" id="${name}" class="no-icheck" data-initial-value="${data.enabled}"` +
+            ">";
+          return ckbox;
         },
       },
       {
         targets: "_all",
-        render: function (data, type, full, meta) {
-          return revServersField(data, meta.col);
+        class: "input-text",
+        render: function (data, type, row, meta) {
+          let name;
+          switch (meta.col) {
+            case 1:
+              name = "network_" + meta.row;
+              break;
+            case 2:
+              name = "ip_" + meta.row;
+              break;
+            case 3:
+              name = "domain_" + meta.row;
+              break;
+            // No default
+          }
+
+          return (
+            '<input type="text" class="form-control" disabled ' +
+            `name="${name}" id="${name}" value="${data}" data-initial-value="${data}"` +
+            ">"
+          );
         },
       },
     ],

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -149,9 +149,11 @@ function revServerDataTable() {
     columnDefs: [
       {
         targets: 0,
-        render: function(data) {
-          return RevServersField(data, 0) == "true" ? '<input type="checkbox" checked disabled>' : '<input type="checkbox" disabled>';
-        }
+        render: function (data) {
+          return RevServersField(data, 0) == "true"
+            ? '<input type="checkbox" class="no-icheck" checked disabled>'
+            : '<input type="checkbox" class="no-icheck" disabled>';
+        },
       },
       {
         targets: "_all",

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -202,6 +202,9 @@ function revServerDataTable() {
     ],
     drawCallback: function () {
       $('button[id^="deleteRevServers"]').on("click", deleteRecord);
+      $('button[id^="editRevServers"]').on("click", editRecord);
+      $('button[id^="saveRevServers"]').on("click", saveRecord).hide();
+      $('button[id^="cancelRevServers"]').on("click", restoreRecord).hide();
 
       // Remove visible dropdown to prevent orphaning
       $("body > .bootstrap-select.dropdown").remove();
@@ -209,6 +212,14 @@ function revServerDataTable() {
     rowCallback: function (row, data, displayNum, displayIndex, dataIndex) {
       $(row).attr("data-index", dataIndex);
       var button = `<button type="button"
+                      class="btn btn-primary btn-xs"
+                      id="editRevServers_${dataIndex}"
+                      data-index="${dataIndex}"
+                      title="Edit"
+                      ${setByEnv ? "disabled" : ""}>
+                      <span class="far fa-edit"></span>
+                    </button>
+                    <button type="button"
                       class="btn btn-danger btn-xs"
                       id="deleteRevServers_${dataIndex}"
                       data-index="${dataIndex}"
@@ -217,6 +228,21 @@ function revServerDataTable() {
                       title="Delete"
                       ${setByEnv ? "disabled" : ""}>
                       <span class="far fa-trash-alt"></span>
+                    </button>
+                    <button type="button"
+                      class="btn btn-success btn-xs"
+                      id="saveRevServers_${dataIndex}"
+                      data-index="${dataIndex}"
+                      title="Save changes">
+                      <span class="far fa-save"></span>
+                    </button>
+                    <button type="button"
+                      class="btn btn-warning btn-xs"
+                      id="cancelRevServers_${dataIndex}"
+                      data-index="${dataIndex}"
+                      data-tag="${Object.values(data)}"
+                      title="Undo changes">
+                      <span class="fas fa-undo"></span>
                     </button>`;
       $("td:eq(4)", row).html(button);
     },
@@ -242,6 +268,15 @@ function revServerDataTable() {
       return data;
     },
   });
+}
+
+function editRecord() {
+}
+
+function saveRecord() {
+}
+
+function restoreRecord() {
 }
 
 function deleteRecord() {

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -272,6 +272,28 @@ function editRecord() {
 }
 
 function saveRecord() {
+  // Find the row index
+  const index = $(this).attr("data-index");
+
+  // Get the edited values from each field
+  const values = [];
+  values[0] = $("#enabled_" + index).prop("checked") ? "true" : "false";
+  values[1] = $("#network_" + index).val();
+  values[2] = $("#ip_" + index).val();
+  values[3] = $("#domain_" + index).val();
+
+  // Save the new values
+  // --- insert $.ajax() call to actually save the data
+  console.log(values.join(","));
+
+  // Finish the edition disabling the fields
+  $(this).closest("tr").find("td input").prop("disabled", true);
+
+  // Show EDIT and DELETE buttons. Hide SAVE and UNDO buttons
+  $(this).siblings('[id^="edit"]').show();
+  $(this).siblings('[id^="delete"]').show();
+  $(this).hide();
+  $(this).siblings('[id^="cancel"]').hide();
 }
 
 function restoreRecord() {

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global applyCheckboxRadioStyle:false, setConfigValues: false, apiFailure: false */
+/* global utils:false, applyCheckboxRadioStyle:false, setConfigValues: false, apiFailure: false */
 
 // Remove an element from an array (inline)
 function removeFromArray(arr, what) {
@@ -107,13 +107,13 @@ function updateDNSserversTextfield(upstreams, customServers) {
   );
 }
 
-function RevServersField(data, fieldIndex) {
+function revServersField(data, fieldIndex) {
   // If an invalid index is received, return null
   if (fieldIndex < 0 || fieldIndex > 4) {
     return null;
   }
 
-  let arrRevServers = data.split(",");
+  const arrRevServers = data.split(",");
   return arrRevServers.length > fieldIndex ? arrRevServers[fieldIndex] : "";
 }
 
@@ -150,7 +150,7 @@ function revServerDataTable() {
       {
         targets: 0,
         render: function (data) {
-          return RevServersField(data, 0) == "true"
+          return revServersField(data, 0) === "true"
             ? '<input type="checkbox" class="no-icheck" checked disabled>'
             : '<input type="checkbox" class="no-icheck" disabled>';
         },
@@ -158,7 +158,7 @@ function revServerDataTable() {
       {
         targets: "_all",
         render: function (data, type, full, meta) {
-          return RevServersField(data, meta.col);
+          return revServersField(data, meta.col);
         },
       },
     ],
@@ -180,7 +180,7 @@ function revServerDataTable() {
                     </button>`;
       $("td:eq(4)", row).html(button);
     },
-    dom: "<'row'<'col-sm-12'<'table-responsive'tr>>>" + "<'row'<'col-sm-12'i>>",
+    dom: "<'row'<'col-sm-12'<'table-responsive'tr>>><'row'<'col-sm-12'i>>",
     paging: false,
     language: {
       emptyTable: "No revese DNS servers defined.",
@@ -207,7 +207,7 @@ function revServerDataTable() {
 function deleteRecord() {
   // Get the tags
   var tags = [$(this).attr("data-tag")];
-  var types = [$(this).attr("data-type")];
+
   // Check input validity
   if (!Array.isArray(tags)) return;
 

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -206,13 +206,15 @@ function revServerDataTable() {
       // Remove visible dropdown to prevent orphaning
       $("body > .bootstrap-select.dropdown").remove();
     },
-    rowCallback: function (row, data) {
-      $(row).attr("data-id", data);
+    rowCallback: function (row, data, displayNum, displayIndex, dataIndex) {
+      $(row).attr("data-index", dataIndex);
       var button = `<button type="button"
                       class="btn btn-danger btn-xs"
-                      id="deleteRevServers${utils.hexEncode(data)}"
-                      data-tag="${data}"
+                      id="deleteRevServers_${dataIndex}"
+                      data-index="${dataIndex}"
+                      data-tag="${Object.values(data)}"
                       data-type="revServers"
+                      title="Delete"
                       ${setByEnv ? "disabled" : ""}>
                       <span class="far fa-trash-alt"></span>
                     </button>`;

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -261,6 +261,14 @@ function revServerDataTable() {
 }
 
 function editRecord() {
+  // Enable fields on the selected row
+  $(this).closest("tr").find("td input").prop("disabled", false);
+
+  // Hide EDIT and DELETE buttons. Show SAVE and UNDO buttons
+  $(this).hide();
+  $(this).siblings('[id^="delete"]').hide();
+  $(this).siblings('[id^="save"]').show();
+  $(this).siblings('[id^="cancel"]').show();
 }
 
 function saveRecord() {

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -107,16 +107,6 @@ function updateDNSserversTextfield(upstreams, customServers) {
   );
 }
 
-function revServersField(data, fieldIndex) {
-  // If an invalid index is received, return null
-  if (fieldIndex < 0 || fieldIndex > 4) {
-    return null;
-  }
-
-  const arrRevServers = data.split(",");
-  return arrRevServers.length > fieldIndex ? arrRevServers[fieldIndex] : "";
-}
-
 function revServerDataTable() {
   var setByEnv = false;
   $.ajax({

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -284,7 +284,7 @@ function saveRecord() {
 
   // Save the new values
   // --- insert $.ajax() call to actually save the data
-  console.log(values.join(","));
+  console.log(values.join(",")); // eslint-disable-line no-console
 
   // Finish the edition disabling the fields
   $(this).closest("tr").find("td input").prop("disabled", true);

--- a/scripts/pi-hole/js/settings-dns.js
+++ b/scripts/pi-hole/js/settings-dns.js
@@ -275,6 +275,26 @@ function saveRecord() {
 }
 
 function restoreRecord() {
+  // Find the row index
+  const index = $(this).attr("data-index");
+
+  // Reset values
+  $("#enabled_" + index).prop("checked", $("#enabled_" + index).attr("data-initial-value"));
+  $("#network_" + index).val($("#network_" + index).attr("data-initial-value"));
+  $("#ip_" + index).val($("#ip_" + index).attr("data-initial-value"));
+  $("#domain_" + index).val($("#domain_" + index).attr("data-initial-value"));
+
+  // Show cancellation message
+  utils.showAlert("info", "fas fa-undo", "Operation canceled", "Original values restored");
+
+  // Finish the edition disabling the fields
+  $(this).closest("tr").find("td input").prop("disabled", true);
+
+  // Show EDIT and DELETE buttons. Hide SAVE and UNDO buttons
+  $(this).siblings('[id^="edit"]').show();
+  $(this).siblings('[id^="delete"]').show();
+  $(this).siblings('[id^="save"]').hide();
+  $(this).hide();
 }
 
 function deleteRecord() {

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -225,7 +225,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                             in your DHCP server for this to work. You can likely find it within the DHCP settings.</p>
                         <p>Enabling Conditional Forwarding will also forward all hostnames (i.e., non-FQDNs) to the router
                             when "Never forward non-FQDNs" is <em>not</em> enabled.</p>
-                        <p>The following list contains all reverse servers you want to add. The expected format is one server per line in form of <code>&lt;enabled&gt;,&lt;ip-address&gt;[/&lt;prefix-len&gt;],&lt;server&gt;[#&lt;port&gt;][,&lt;domain&gt;]</code>. A valid config line could look like <code>true,192.168.0.0/24,192.168.0.1,fritz.box</code></p>
+                        <p>The following list contains all reverse servers you want to add.</p>
 
                         <table id="revServers-table" class="table table-striped table-bordered" width="100%">
                             <thead>

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -240,7 +240,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                             <tfoot class="add-new-item">
                                 <tr>
                                     <th>
-                                        <input id="enabled-revServers" type="checkbox" data-configkeys="revServers">
+                                        <input id="enabled-revServers" type="checkbox" class="no-icheck" data-configkeys="revServers">
                                     </th>
                                     <th>
                                         <input id="network-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="192.168.0.0/24" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -226,7 +226,44 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                         <p>Enabling Conditional Forwarding will also forward all hostnames (i.e., non-FQDNs) to the router
                             when "Never forward non-FQDNs" is <em>not</em> enabled.</p>
                         <p>The following list contains all reverse servers you want to add. The expected format is one server per line in form of <code>&lt;enabled&gt;,&lt;ip-address&gt;[/&lt;prefix-len&gt;],&lt;server&gt;[#&lt;port&gt;][,&lt;domain&gt;]</code>. A valid config line could look like <code>true,192.168.0.0/24,192.168.0.1,fritz.box</code></p>
-                        <textarea class="form-control" rows="3" id="dns.revServers" data-key="dns.revServers" placeholder="Enter reverse DNS servers, one per line" style="resize: vertical;"></textarea>
+
+                        <table id="revServers-table" class="table table-striped table-bordered" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Enabled</th>
+                                    <th>Network Range <sup>1</sup></th>
+                                    <th>Server <sup>2</sup></th>
+                                    <th>Domain <sup>3</sup></th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tfoot class="add-new-item">
+                                <tr>
+                                    <th>
+                                        <input id="enabled-revServers" type="checkbox" data-configkeys="revServers">
+                                    </th>
+                                    <th>
+                                        <input id="network-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="192.168.0.0/24" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <input id="server-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="192.168.0.1" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <input id="domain-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="local" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <button type="button" id="btnAdd-revServers" class="btn btn-primary btn-xs" data-configkeys="revServers"><i class="fa fa-plus"></i></button>
+                                    </th>
+                                </tr>
+                                <tr>
+                                    <th colspan="5">
+                                        <div><small>1: <i>Local network range using <a href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing" target="_blank">CIDR notation</a></i></small></div>
+                                        <div><small>2: <i>IP address of your DHCP server (or router)</i></small></div>
+                                        <div><small>3: <i>Local domain name (optional)</i></small></div>
+                                    </th>
+                                </tr>
+                            </tfoot>
+                        </table>
                     </div>
                 </div>
             </div>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -388,7 +388,8 @@ td.lookatme {
 }
 
 /* Table footer row used to add new items, using inline input fields */
-tfoot.add-new-item > tr > th {
+#revServers-table td,
+#revServers-table tfoot > tr > th {
   font-weight: normal;
   vertical-align: inherit;
 }


### PR DESCRIPTION
### What does this PR aim to accomplish?

Replace the current single `<textarea>` with a table. 
Each reverse server will be in a separate row and each field will be in a separate table cell.

A small legend will improve usability (maybe we will need to change the help text).

**NOTE:**

~~Depends on https://github.com/pi-hole/web/pull/2885~~ _(already merged)_

### How does this PR accomplish the above?

Using _datatables_ plugin and a few functions to deal with _dns.revServers_ entries.  

![image](https://github.com/pi-hole/web/assets/1385443/9c8613ae-bb71-4dbe-89b0-9576942de1a2)

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
