### PR TITLE
Clarify what an empty netmask field does (Settings -> DHCP page)

### DIFF
--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -61,15 +61,18 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                         </div>
                     </div>
                     <div class="col-xs-12 col-sm-6 col-md-12 col-lg-6">
-                        <label>Netmask (<code>0.0.0.0</code> = auto)</label>
+                        <label>Netmask</label>
                         <div class="form-group">
                             <div class="input-group">
                                 <div class="input-group-addon">Netmask</div>
                                 <input type="text" class="form-control DHCPgroup" id="dhcp.netmask" data-key="dhcp.netmask"
                                     autocomplete="off" spellcheck="false" autocapitalize="none"
-                                    autocorrect="off" value="">
+                                    autocorrect="off" value="" placeholder="automatic">
                             </div>
                         </div>
+                    </div>
+                    <div class="col-md-12">
+                        <p>Leave the netmask field empty to have Pi-hole infer it from the configured IP address of your device. If you want to specify a netmask, you can use the format <code>255.255.255.0</code>.</p>
                     </div>
                     <div class="col-md-12">
                         <div><input type="checkbox" id="dhcp.ipv6" data-key="dhcp.ipv6" class="DHCPgroup">&nbsp;<label for="dhcp.ipv6"><strong>Enable additional IPv6 support (SLAAC + RA)</strong></label></div>


### PR DESCRIPTION
# What does this implement/fix?

Fixes a issue discovered [on Discourse](https://discourse.pi-hole.net/t/dnsmasq-warn-after-setting-pihole-as-dhcp/68100/9?u=dl6er): The netmask field should be left empty for automatic discovery. For compatibility reasons, an "empty" address and `0.0.0.0` happens to be interpreted in the same way by FTL which is why the user entering `0.0.0.0` worked regardless.

We should still fix this.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.