### PR TITLE
Fix Teleporter file selection on Mac OS

### DIFF
--- a/settings-teleporter.lp
+++ b/settings-teleporter.lp
@@ -38,7 +38,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             <div class="box-body">
                 <div class="form-group">
                     <label for="file">File input</label>
-                    <input type="file" name="file" id="file" accept=".zip,.tar.gz">
+                    <input type="file" name="file" id="file" accept="application/gzip,application/zip">
                     <p class="help-block">When importing settings from a <em>newer</em> version of Pi-hole, not yet existing settings will be ignored. When importing from an <em>older</em> version of Pi-hole, settings for newer features will be initialized with their default values.</p>
                 </div>
                 <div class="pull-right">


### PR DESCRIPTION
# What does this implement/fix?

Use MIME type instead of explicit file type endings during the file selection of the Teleporter input field. Even when the latter should be fine according to the standards, Safari (and, in general, any browser on Mac) seems to ignore this and support only mimetype-based selections. This is backed by several similar reports on Stackoverflow over the past couple of years.

I am **not** convinced this is the best way of implementing this - in particular because we are not in the wrong here - Mac OS is clearly not complying with standards here - and this is a mere compromise to please them.

**Related issue or feature (if applicable):** See link below.

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.