### PR TITLE
Add missing priority `ERROR` to taillog `formatFTL()` function

### DIFF
--- a/scripts/pi-hole/js/taillog.js
+++ b/scripts/pi-hole/js/taillog.js
@@ -53,6 +53,7 @@ function formatFTL(line, prio) {
     }
 
     case "ERR":
+    case "ERROR":
     case "EMERG":
     case "ALERT":
     case "CRIT": {


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix the issue identified by an [user in Discourse](https://discourse.pi-hole.net/t/high-cpu-load-when-accessing-the-web-interface/69028), where the `ERROR` entries are not using the expected color.

![image](https://github.com/pi-hole/web/assets/1385443/0a15f1da-e37d-4c46-818e-359f79b5e519)


### How does this PR accomplish the above?

Adding the missing priority `ERROR` to the format function.

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
