### PR TITLE
Fix incorrect redirection

### DIFF
--- a/scripts/pi-hole/js/footer.js
+++ b/scripts/pi-hole/js/footer.js
@@ -698,7 +698,12 @@ function applyExpertSettings() {
 
     // If we left with an empty page (no visible boxes) after switching from
     // Expert to Basic settings, redirect to admin/settings/system instead
-    if ($(".box:visible").length === 0) {
+    //  - class settings-selector is present (this class is present in every
+    //    settings pages, but not in other pages - it is there on the "all"
+    //    settings page as well, even when the button has "only modified"
+    //    functionality there), and
+    //  - there are no visible boxes (the page is empty)
+    if ($(".settings-selector").length > 0 && $(".box:visible").length === 0) {
       window.location.href = "/admin/settings/system";
     }
   }


### PR DESCRIPTION
# What does this implement/fix?

We should not try to apply settings levels (incl. all the consequences such as ill-fated redirects) when we have already detected that there are no expert-settings elements on this page.

---

**Related issue or feature (if applicable):** https://github.com/pi-hole/web/issues/2992

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.