### PR TITLE
Move local DNS records from expert to basic settings level

### DIFF
--- a/scripts/pi-hole/lua/sidebar.lp
+++ b/scripts/pi-hole/lua/sidebar.lp
@@ -163,7 +163,7 @@
                                 <i class="fa-fw menu-icon fa-solid fa-file-export"></i> <span>Teleporter</span>
                             </a>
                         </li>
-                        <li class="<? if scriptname == 'settings/dnsrecords' then ?> active<? end ?> settings-level-expert">
+                        <li class="<? if scriptname == 'settings/dnsrecords' then ?> active<? end ?>">
                             <a href="<?=webhome?>settings/dnsrecords">
                                 <i class="fa-fw menu-icon fa-solid fa-address-book"></i> <span>Local DNS Records</span>
                             </a>

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -14,7 +14,7 @@ PageTitle = "Local DNS Settings"
 mg.include('scripts/pi-hole/lua/settings_header.lp','r')
 ?>
 <div class="row">
-    <div class="col-md-12 col-lg-6 settings-level-expert">
+    <div class="col-md-12 col-lg-6">
         <div class="box">
             <div class="box-header with-border">
                 <h3 class="box-title" id="title-hosts" data-configkeys="dns.hosts">Local DNS records</h3>
@@ -56,7 +56,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             </div>
         </div>
     </div>
-    <div class="col-md-12 col-lg-6 settings-level-expert">
+    <div class="col-md-12 col-lg-6">
         <div class="box">
             <div class="box-header with-border">
                 <h3 class="box-title" id="title-cnameRecords" data-configkeys="dns.cnameRecords">Local CNAME records records</h3>


### PR DESCRIPTION
# What does this implement/fix?

A very simple PR. It does what the title says. This is achieved by removing the CSS classes. Everything else is pure magic.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.