### PR TITLE
Auto resize some textarea fields

### DIFF
--- a/scripts/pi-hole/js/settings-advanced.js
+++ b/scripts/pi-hole/js/settings-advanced.js
@@ -209,7 +209,7 @@ function generateRow(topic, key, value) {
       box +=
         '<label class="col-sm-5 control-label">Values (one item per line)</label>' +
         '<div class="col-sm-7">' +
-        '<textarea class="form-control" data-key="' +
+        '<textarea class="form-control field-sizing-content" data-key="' +
         key +
         '"' +
         extraAttributes +

--- a/settings-api.lp
+++ b/settings-api.lp
@@ -25,12 +25,12 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                         <div class="row">
                             <div class="col-md-6">
                                 <p><strong>Domains to be excluded from Top Domain Lists and Query Log</strong></p>
-                                <textarea class="form-control" rows="4" id="webserver.api.excludeDomains" data-key="webserver.api.excludeDomains" placeholder="Enter regex domains, one per line" style="resize: vertical;"></textarea>
+                                <textarea class="form-control field-sizing-content" rows="4" id="webserver.api.excludeDomains" data-key="webserver.api.excludeDomains" placeholder="Enter regex domains, one per line" style="resize: vertical;"></textarea>
                                 <p class="help-block">Domains may be described by their domain name (like <code>^example\.com$</code>)</p>
                             </div>
                             <div class="col-md-6">
                                 <p><strong>Clients to be excluded from Top Client Lists and Query Log </strong></p>
-                                <textarea class="form-control" rows="4" id="webserver.api.excludeClients" data-key="webserver.api.excludeClients" placeholder="Enter regex clients, one per line" style="resize: vertical;"></textarea>
+                                <textarea class="form-control field-sizing-content" rows="4" id="webserver.api.excludeClients" data-key="webserver.api.excludeClients" placeholder="Enter regex clients, one per line" style="resize: vertical;"></textarea>
                                 <p class="help-block">Clients may be described either by their IP addresses (IPv4 and IPv6 are supported), or hostnames (like <code>^laptop\.lan$</code>).</p>
                             </div>
                         </div>

--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -156,7 +156,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                 <div class="row">
                     <div class="col-xs-12 col-md-6">
                         <p>Specify per host parameters for the DHCP server. This allows a machine with a particular hardware address to be always allocated the same hostname, IP address and lease time. A hostname specified like this overrides any supplied by the DHCP client on the machine. It is also allowable to omit the hardware address and include the hostname, in which case the IP address and lease times will apply to any machine claiming that name.</p>
-                        <textarea class="form-control" id="dhcp-hosts" data-key="dhcp.hosts" style="resize: vertical;"></textarea><br>&nbsp;
+                        <textarea class="form-control field-sizing-content" id="dhcp-hosts" data-key="dhcp.hosts" style="resize: vertical;"></textarea><br>&nbsp;
                         <p>Each entry should be on a separate line, and should be of the form:</p>
                         <pre>[&lt;hwaddr&gt;][,id:&lt;client_id&gt;|*][,set:&lt;tag&gt;][,tag:&lt;tag&gt;][,&lt;ipaddr&gt;][,&lt;hostname&gt;][,&lt;lease_time&gt;][,ignore]</pre>
                         <p>Only one entry per MAC address is allowed.</p>

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -226,7 +226,7 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                         <p>Enabling Conditional Forwarding will also forward all hostnames (i.e., non-FQDNs) to the router
                             when "Never forward non-FQDNs" is <em>not</em> enabled.</p>
                         <p>The following list contains all reverse servers you want to add. The expected format is one server per line in form of <code>&lt;enabled&gt;,&lt;ip-address&gt;[/&lt;prefix-len&gt;],&lt;server&gt;[#&lt;port&gt;][,&lt;domain&gt;]</code>. A valid config line could look like <code>true,192.168.0.0/24,192.168.0.1,fritz.box</code></p>
-                        <textarea class="form-control" rows="3" id="dns.revServers" data-key="dns.revServers" placeholder="Enter reverse DNS servers, one per line" style="resize: vertical;"></textarea>
+                        <textarea class="form-control field-sizing-content" id="dns.revServers" data-key="dns.revServers" placeholder="Enter reverse DNS servers, one per line" style="resize: vertical;"></textarea>
                     </div>
                 </div>
             </div>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1471,3 +1471,7 @@ table.dataTable tbody > tr > .selected {
     text-align: right;
   }
 }
+
+.field-sizing-content {
+  field-sizing: content;
+}

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1472,6 +1472,10 @@ table.dataTable tbody > tr > .selected {
   }
 }
 
-.field-sizing-content {
+textarea.field-sizing-content {
+  min-block-size: 3.5rlh;
+  max-block-size: 20rlh;
+  min-inline-size: 20ch;
+  max-inline-size: 50ch;
   field-sizing: content;
 }

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1476,6 +1476,5 @@ textarea.field-sizing-content {
   min-block-size: 3.5rlh;
   max-block-size: 20rlh;
   min-inline-size: 20ch;
-  max-inline-size: 50ch;
   field-sizing: content;
 }


### PR DESCRIPTION
# What does this implement/fix?

Implements auto resizing for selected `<textarea>` input fields

>[!NOTE]
> This feature is *brand new* and requires an up-to-date browser. To date, only Chrome 123.0+ supports this.

Examples:
![0](https://github.com/pi-hole/web/assets/16748619/3046093b-ac05-4fcf-acc8-9fff3cea798a)
![1](https://github.com/pi-hole/web/assets/16748619/134ff2b3-4334-4f77-8821-23c794788313)
![many](https://github.com/pi-hole/web/assets/16748619/a94ef6da-4f81-41d4-8ead-f5067c6b6893)

![regex](https://github.com/pi-hole/web/assets/16748619/e5cdf9f7-d46f-4c31-96bc-ee8d536b1b65)

![1](https://github.com/pi-hole/web/assets/16748619/00b8c503-3096-4902-94d2-1254c4f7eb10)
![2](https://github.com/pi-hole/web/assets/16748619/07bbbf9a-8011-4f2a-ba3c-eca66fd59ac8)
![3](https://github.com/pi-hole/web/assets/16748619/d75a4935-cec5-471b-bfdb-ef0f67c644bd)


There is some protection installed to ensure fields can neither get too small...

![Screenshot from 2024-04-01 19-54-44](https://github.com/pi-hole/web/assets/16748619/d36621e6-cc9e-4e7f-be3a-db23a161c7c8)

... nor too large (scrolling is enabled in this case):

![Screenshot from 2024-04-01 19-55-50](https://github.com/pi-hole/web/assets/16748619/28b860af-6eb5-4196-bd9c-ca8c39660ece)

----

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/autoresize-von-textarea-dhcp-hosts-form-control-static-dhcp-configuration/68855

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.