### PR TITLE
Change sidebar load formatting to be consistent.

### DIFF
--- a/scripts/pi-hole/php/header_authenticated.php
+++ b/scripts/pi-hole/php/header_authenticated.php
@@ -133,9 +133,6 @@ list($celsius, $temperaturelimit, $temperatureunit) = getTemperature();
 
 // Get CPU load
 $loaddata = sys_getloadavg();
-foreach ($loaddata as $key => $value) {
-    $loaddata[$key] = round($value, 2);
-}
 
 // Get number of processing units available to PHP
 // (may be less than the number of online processors)

--- a/scripts/pi-hole/php/sidebar.php
+++ b/scripts/pi-hole/php/sidebar.php
@@ -31,7 +31,7 @@
                     } else {
                         echo 'text-green-light';
                     }
-                    echo '"></i> Load:&nbsp;&nbsp;'.$loaddata[0].'&nbsp;&nbsp;'.$loaddata[1].'&nbsp;&nbsp;'.$loaddata[2].'</span>';
+                    echo '"></i> Load:&nbsp;&nbsp;'.vsprintf('%.2f,&nbsp;%.2f,&nbsp;%.2f', $loaddata).'</span>';
                     ?>
                     <br/>
                     <?php


### PR DESCRIPTION
round() is not a good function to use for formatting, as it produces inconsistent results by truncating trailing zeroes. printf() produces consistent results with an appropriate format.

The format string used here is equivalent to library/uptime.c in procps, producing output equivalent to /usr/bin/uptime on Debian.

## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

The system load shown in the web sidebar has inconsistent formatting, in that trailing zeroes are stripped.  By long standing convention, Unix/Linux load average is presented as number rounded to 2 decimal places.  Breaking from this convention can be viewed as visually ugly to veteran users; and potentially confusing for novices who may think something extra is being conveyed by the variation in formatting.

**How does this PR accomplish the above?:**

This moves the formatting being performed by round(), which is not intended to be used for visual formatting, to vprintf().  There is no need to round the numbers being passed around within the scripts, it is sufficient to use the automatic rounding provided by vprintf().  This change makes the load in the sidebar consistent with the output from /usr/bin/uptime on Debian (which is, in turn, consistent with the historical Unix uptime command).

**Link documentation PRs if any are needed to support this PR:**

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
