### PR TITLE
Base expert icon on expert class not FTL advanced flag

### DIFF
--- a/scripts/pi-hole/js/settings.js
+++ b/scripts/pi-hole/js/settings.js
@@ -39,9 +39,12 @@ function setConfigValues(topic, key, value) {
   var escapedKey = key.replaceAll(".", "\\.");
   var envTitle = $(`[data-configkeys~='${key}']`);
 
-  if (value.flags.advanced && envTitle.find(".advanced-warning").length === 0) {
+  if (
+    envTitle.parents().parents().hasClass("settings-level-expert") &&
+    envTitle.find(".expert-warning").length === 0
+  ) {
     envTitle.append(
-      `<span class="advanced-warning">&nbsp;&nbsp;<i class="fas fa-wrench" title="Expert level setting"></i></span>`
+      `<span class="expert-warning">&nbsp;&nbsp;<i class="fas fa-wrench" title="Expert level setting"></i></span>`
     );
   }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Show the wrench icon for expert level settings based on the expert class of the the parents (set manually) not based on the FTL 'advanced-setting' flag. 

This PR is the counterpart for https://github.com/pi-hole/FTL/pull/1883 which will remove the advanced flag, but keeps the wrench icon at the setting boxes when they are considered expert-level.

For background see https://github.com/pi-hole/web/pull/2882#issuecomment-1881872571

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
