### PR TITLE
Tweak "Web Interface - API" settings page

### DIFF
--- a/settings-api.lp
+++ b/settings-api.lp
@@ -15,85 +15,33 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
 ?>
 <div class="row">
     <div class="col-md-6 settings-level-basic">
-        <div class="row">
-            <div class="col-md-12 settings-level-expert">
-                <div class="box box-warning">
-                    <div class="box-header with-border">
-                        <h3 class="box-title" data-configkeys="webserver.api.excludeDomains webserver.api.excludeClients">Exclusions</h3>
-                    </div>
-                    <div class="box-body">
-                        <div class="row">
-                            <div class="col-md-6">
-                                <p><strong>Domains to be excluded from Top Domain Lists and Query Log</strong></p>
-                                <textarea class="form-control field-sizing-content" rows="4" id="webserver.api.excludeDomains" data-key="webserver.api.excludeDomains" placeholder="Enter regex domains, one per line" style="resize: vertical;"></textarea>
-                                <p class="help-block">Domains may be described by their domain name (like <code>^example\.com$</code>)</p>
-                            </div>
-                            <div class="col-md-6">
-                                <p><strong>Clients to be excluded from Top Client Lists and Query Log </strong></p>
-                                <textarea class="form-control field-sizing-content" rows="4" id="webserver.api.excludeClients" data-key="webserver.api.excludeClients" placeholder="Enter regex clients, one per line" style="resize: vertical;"></textarea>
-                                <p class="help-block">Clients may be described either by their IP addresses (IPv4 and IPv6 are supported), or hostnames (like <code>^laptop\.lan$</code>).</p>
-                            </div>
-                        </div>
-                        <div class="row">
-                            <div class="col-md-12">
-                            <p><strong>Important</strong>:<br>Those input fields accept regex entries only.<br>Please refer to  <a href="https://docs.pi-hole.net/regex/tutorial/" rel="noopener" target="_blank">our guide</a> how to construct valid regex entries.
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="col-md-12 settings-level-basic">
-                <div class="box box-warning">
-                    <div class="box-header with-border">
-                        <h3 class="box-title" data-configkeys="webserver.interface.theme webserver.interface.boxed">Theme settings</h3>
-                    </div>
-                    <div class="box-body">
-                        <div class="row">
-                            <div class="col-lg-12">
-                                <div class="row form-group">
-                                    <div class="col-lg-3">
-                                        <label for="webserver.interface.theme">Used theme:</label>
-                                    </div>
-                                    <div class="col-md-9">
-                                        <select id="webserver.interface.theme" data-key="webserver.interface.theme" class="form-control" placeholder="">
-                                            <option disabled selected>Loading...</option>
-                                        </select>
-                                    </div>
-                                </div>
-                                <div>
-                                    <input type="checkbox" id="webserver.interface.boxed" data-key="webserver.interface.boxed">
-                                    <label for="webserver.interface.boxed"><strong>Should the web interface use the boxed layout?</strong></label>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div><!-- TODO: Why is this commented out?
-    <div class="col-md-6">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title">Query Log</h3>
+                <h3 class="box-title" data-configkeys="webserver.interface.theme webserver.interface.boxed">Theme settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">
                     <div class="col-lg-12">
-                        <div>
-                            <input type="checkbox" name="querylog-permitted" id="querylog-permitted" <? if queryLog == 'permittedonly' or queryLog == 'all' then ?>checked<? end ?>>
-                            <label for="querylog-permitted"><strong>Show permitted domain entries</strong></label>
-                            <p class="help-block"><span class="text-red">This will show all permitted domain entries in the query log.</span></p>
+                        <div class="row form-group">
+                            <div class="col-lg-3">
+                                <label for="webserver.interface.theme">Used theme:</label>
+                            </div>
+                            <div class="col-md-9">
+                                <select id="webserver.interface.theme" data-key="webserver.interface.theme" class="form-control" placeholder="">
+                                    <option disabled selected>Loading...</option>
+                                </select>
+                            </div>
                         </div>
                         <div>
-                            <input type="checkbox" name="querylog-blocked" id="querylog-blocked" <? if queryLog == 'blockedonly' or queryLog == 'all' then ?>checked<? end ?>>
-                            <label for="querylog-blocked"><strong>Show blocked domain entries</strong></label>
-                            <p class="help-block"><span class="text-red">This will show all blocked domain entries in the query log.</span></p>
+                            <input type="checkbox" id="webserver.interface.boxed" data-key="webserver.interface.boxed">
+                            <label for="webserver.interface.boxed"><strong>Should the web interface use the boxed layout?</strong></label>
                         </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>-->
+    </div>
+
     <div class="col-md-6 settings-level-expert">
         <div class="box box-warning">
             <div class="box-header with-border">
@@ -151,6 +99,61 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
             </div>
         </div>
     </div>
+</div>
+
+<div class="row">
+        <div class="col-md-12 settings-level-expert">
+        <div class="box box-warning">
+            <div class="box-header with-border">
+                <h3 class="box-title" data-configkeys="webserver.api.excludeDomains webserver.api.excludeClients">Exclusions</h3>
+            </div>
+            <div class="box-body">
+                <div class="row">
+                    <div class="col-md-6">
+                        <p><strong>Domains to be excluded from Top Domain Lists and Query Log</strong></p>
+                        <textarea class="form-control field-sizing-content" rows="4" id="webserver.api.excludeDomains" data-key="webserver.api.excludeDomains" placeholder="Enter regex domains, one per line" style="resize: vertical;"></textarea>
+                        <p class="help-block">Domains may be described by their domain name (like <code>^example\.com$</code>)</p>
+                    </div>
+                    <div class="col-md-6">
+                        <p><strong>Clients to be excluded from Top Client Lists and Query Log </strong></p>
+                        <textarea class="form-control field-sizing-content" rows="4" id="webserver.api.excludeClients" data-key="webserver.api.excludeClients" placeholder="Enter regex clients, one per line" style="resize: vertical;"></textarea>
+                        <p class="help-block">Clients may be described either by their IP addresses (IPv4 and IPv6 are supported), or hostnames (like <code>^laptop\.lan$</code>).</p>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-md-12">
+                    <p><strong>Important</strong>:<br>Those input fields accept regex entries only.<br>Please refer to  <a href="https://docs.pi-hole.net/regex/tutorial/" rel="noopener" target="_blank">our guide</a> how to construct valid regex entries.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- TODO: Why is this commented out?
+    <div class="col-md-6">
+        <div class="box box-warning">
+            <div class="box-header with-border">
+                <h3 class="box-title">Query Log</h3>
+            </div>
+            <div class="box-body">
+                <div class="row">
+                    <div class="col-lg-12">
+                        <div>
+                            <input type="checkbox" name="querylog-permitted" id="querylog-permitted" <? if queryLog == 'permittedonly' or queryLog == 'all' then ?>checked<? end ?>>
+                            <label for="querylog-permitted"><strong>Show permitted domain entries</strong></label>
+                            <p class="help-block"><span class="text-red">This will show all permitted domain entries in the query log.</span></p>
+                        </div>
+                        <div>
+                            <input type="checkbox" name="querylog-blocked" id="querylog-blocked" <? if queryLog == 'blockedonly' or queryLog == 'all' then ?>checked<? end ?>>
+                            <label for="querylog-blocked"><strong>Show blocked domain entries</strong></label>
+                            <p class="help-block"><span class="text-red">This will show all blocked domain entries in the query log.</span></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>-->
+
     <div class="col-md-12 settings-level-expert">
         <div class="box box-warning">
             <div class="box-header with-border">

--- a/settings-api.lp
+++ b/settings-api.lp
@@ -23,18 +23,45 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                 <div class="row">
                     <div class="col-lg-12">
                         <div class="row form-group">
-                            <div class="col-lg-3">
-                                <label for="webserver.interface.theme">Used theme:</label>
+                            <div class="col-sm-3">
+                                <label for="webserver.interface.theme">Theme:</label>
                             </div>
-                            <div class="col-md-9">
+                            <div class="col-sm-9">
                                 <select id="webserver.interface.theme" data-key="webserver.interface.theme" class="form-control" placeholder="">
                                     <option disabled selected>Loading...</option>
                                 </select>
                             </div>
                         </div>
-                        <div>
-                            <input type="checkbox" id="webserver.interface.boxed" data-key="webserver.interface.boxed">
-                            <label for="webserver.interface.boxed"><strong>Should the web interface use the boxed layout?</strong></label>
+                    </div>
+                    <div class="col-lg-12">
+                        <div class="row form-group">
+                            <div class="col-sm-12">
+                                <div>
+                                    <input type="checkbox" id="webserver.interface.boxed" data-key="webserver.interface.boxed">
+                                    <label for="webserver.interface.boxed"><strong>Use the boxed layout</strong></label>
+                                    <p class="help-block">The boxed layout is helpful when working on large screens because it prevents the site from stretching very wide.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-lg-12">
+                        <div class="row form-group">
+                            <div class="col-sm-6">
+                                <label for="webserver.api.temp.limit"><strong>Temperature limit for "hot":</strong></label>
+                            </div>
+                            <div class="col-sm-6">
+                                <input class="form-control" type="number" data-type="integer" id="webserver.api.temp.limit" data-key="webserver.api.temp.limit">
+                            </div>
+                        </div>
+                        <div class="row form-group">
+                            <div class="col-sm-6">
+                                <label for="webserver.api.temp.unit">Temperature unit:</label>
+                            </div>
+                            <div class="col-sm-6">
+                                <select id="webserver.api.temp.unit" data-key="webserver.api.temp.unit" class="form-control" placeholder="">
+                                    <option disabled selected>Loading...</option>
+                                </select>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -68,26 +95,6 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
                             <input type="checkbox" id="webserver.api.allow_destructive" data-key="webserver.api.allow_destructive">
                             <label for="webserver.api.allow_destructive"><strong>Permit destructive actions via API</strong></label>
                             <p class="help-block">This will allow clients to perform destructive actions via the API, such as rebooting or shutting down the system Pi-hole is running on.</p>
-                        </div>
-                    </div>
-                    <div class="col-lg-12">
-                        <div class="row form-group">
-                            <div class="col-sm-6">
-                                <label for="webserver.api.temp.limit"><strong>Temperature limit for "hot":</strong></label>
-                            </div>
-                            <div class="col-sm-6">
-                                <input class="form-control" type="number" data-type="integer" id="webserver.api.temp.limit" data-key="webserver.api.temp.limit">
-                            </div>
-                        </div>
-                        <div class="row form-group">
-                            <div class="col-sm-6">
-                                <label for="webserver.api.temp.unit">Temperature unit:</label>
-                            </div>
-                            <div class="col-sm-6">
-                                <select id="webserver.api.temp.unit" data-key="webserver.api.temp.unit" class="form-control" placeholder="">
-                                    <option disabled selected>Loading...</option>
-                                </select>
-                            </div>
                         </div>
                     </div>
                     <div class="col-lg-12 pt-3">


### PR DESCRIPTION
### What does this PR aim to accomplish?

Currently the temperature options are inside the "Advanced Settings" box.

Also, when you toggle between "Basic" and "Expert" views, "Expert" boxes appears before the "Basic" ones, causing a layout shift or jump.  

### How does this PR accomplish the above?

- Move temperature options to the Theme box, as they are not advanced options;
- Use full width for "Exclusions" box;
- Reorder the boxes to minimize layout shift.

![web_settings](https://github.com/pi-hole/web/assets/1385443/9e08d017-a587-4cf8-9a78-e315314b558d)

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
