### PR TITLE
Use number_format for CPU load

### DIFF
--- a/scripts/pi-hole/php/header_authenticated.php
+++ b/scripts/pi-hole/php/header_authenticated.php
@@ -134,7 +134,7 @@ list($celsius, $temperaturelimit, $temperatureunit) = getTemperature();
 // Get CPU load
 $loaddata = sys_getloadavg();
 foreach ($loaddata as $key => $value) {
-    $loaddata[$key] = round($value, 2);
+    $loaddata[$key] = number_format($value, 2, '.', '');
 }
 
 // Get number of processing units available to PHP


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs) 

---

**What does this PR aim to accomplish?:**

CPU load in the header is currently rounded which can result in the value being 0 or 1 rather than 0.00 and 1.00. Adding the additional zeros in my opinion gives a better visual appearance. 

**How does this PR accomplish the above?:**

Replace `round` with `number_format` and also making sure to use a dot as decimal separator. Since `number_format` is taking the current locale into account this could otherwise lead to the separator being a comma. 

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
