### PR TITLE
Don't try to fill client/domain tables if there is no data

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -295,6 +295,8 @@ function updateTopClientsTable(blocked) {
     // Add note if there are no results (e.g. privacy mode enabled)
     if (jQuery.isEmptyObject(data.clients)) {
       clienttable.append('<tr><td colspan="3"><center>- No data -</center></td></tr>');
+      overlay.hide();
+      return;
     }
 
     // Populate table with content
@@ -352,6 +354,8 @@ function updateTopDomainsTable(blocked) {
     // Add note if there are no results (e.g. privacy mode enabled)
     if (jQuery.isEmptyObject(data.domains)) {
       domaintable.append('<tr><td colspan="3"><center>- No data -</center></td></tr>');
+      overlay.hide();
+      return;
     }
 
     // Populate table with content


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/web/issues/3068.

Do not try to populate top domain/client tables at the dashboard if there is no data to fill in.
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
