### PR TITLE
Fix the "title" attribute to show all IPs/hostnames

### DIFF
--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -95,7 +95,6 @@ $(function () {
     rowCallback: function (row, data) {
       var color;
       var index;
-      var maxiter;
       var iconClasses;
       var lastQuery = parseInt(data.lastQuery, 10);
       var diff = getTimestamp() - lastQuery;
@@ -137,18 +136,21 @@ $(function () {
       $("td:eq(5)", row).html(data.numQueries.toLocaleString());
 
       var ips = [],
-        iptxt = [];
-      maxiter = Math.min(data.ips.length, MAXIPDISPLAY);
-      for (index = 0; index < maxiter; index++) {
-        var ip = data.ips[index];
+        iptitles = [];
+
+      for (index = 0; index < data.ips.length; index++) {
+        var ip = data.ips[index],
+          iptext = ip.ip;
+
         if (ip.name !== null && ip.name.length > 0) {
-          iptxt.push(ip.ip + " (" + ip.name + ")");
-          ips.push(
-            '<a href="queries.lp?client_ip=' + ip.ip + '">' + ip.ip + " (" + ip.name + ")</a>"
-          );
-        } else {
-          iptxt.push(ip.ip);
-          ips.push('<a href="queries.lp?client_ip=' + ip.ip + '">' + ip.ip + "</a>");
+          iptext = iptext + " (" + ip.name + ")";
+        }
+
+        iptitles.push(iptext);
+
+        // Only add IPs to the table if we have not reached the maximum
+        if (index < MAXIPDISPLAY) {
+          ips.push('<a href="queries.lp?client_ip=' + ip.ip + '">' + iptext + "</a>");
         }
       }
 
@@ -157,7 +159,7 @@ $(function () {
         // have more to show here
         ips.push("...");
         // Show the IPs on the title when there are more than MAXIPDISPLAY items
-        $("td:eq(0)", row).attr("title", iptxt.join("\n"));
+        $("td:eq(0)", row).attr("title", iptitles.join("\n"));
       }
 
       // Show the IPs in the first column

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -136,15 +136,20 @@ $(function () {
       // Set number of queries to localized string (add thousand separators)
       $("td:eq(5)", row).html(data.numQueries.toLocaleString());
 
-      var ips = [];
+      var ips = [],
+        iptxt = [];
       maxiter = Math.min(data.ips.length, MAXIPDISPLAY);
       for (index = 0; index < maxiter; index++) {
         var ip = data.ips[index];
-        if (ip.name !== null && ip.name.length > 0)
+        if (ip.name !== null && ip.name.length > 0) {
+          iptxt.push(ip.ip + " (" + ip.name + ")");
           ips.push(
             '<a href="queries.lp?client_ip=' + ip.ip + '">' + ip.ip + " (" + ip.name + ")</a>"
           );
-        else ips.push('<a href="queries.lp?client_ip=' + ip.ip + '">' + ip.ip + "</a>");
+        } else {
+          iptxt.push(ip.ip);
+          ips.push('<a href="queries.lp?client_ip=' + ip.ip + '">' + ip.ip + "</a>");
+        }
       }
 
       if (data.ips.length > MAXIPDISPLAY) {
@@ -154,9 +159,7 @@ $(function () {
       }
 
       $("td:eq(0)", row).html(ips.join("<br>"));
-      $("td:eq(0)", row).on("hover", function () {
-        this.title = data.ips.join("\n");
-      });
+      $("td:eq(0)", row).attr("title", iptxt.join("\n"));
 
       // MAC + Vendor field if available
       if (data.macVendor && data.macVendor.length > 0) {

--- a/scripts/pi-hole/js/network.js
+++ b/scripts/pi-hole/js/network.js
@@ -156,10 +156,12 @@ $(function () {
         // We hit the maximum above, add "..." to symbolize we would
         // have more to show here
         ips.push("...");
+        // Show the IPs on the title when there are more than MAXIPDISPLAY items
+        $("td:eq(0)", row).attr("title", iptxt.join("\n"));
       }
 
+      // Show the IPs in the first column
       $("td:eq(0)", row).html(ips.join("<br>"));
-      $("td:eq(0)", row).attr("title", iptxt.join("\n"));
 
       // MAC + Vendor field if available
       if (data.macVendor && data.macVendor.length > 0) {


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix the tooltip used on the network table when there are more than 3 IPs/hostnames. 

Related to: https://discourse.pi-hole.net/t/tools-network-limited-to-3-hostnames-and-ips-hover-not-working/71512

### How?

The original code used to add the text to the title was adding the text on `hover`, but this was broken some time ago, when jquery warnings where fixed. 
Also, dynamically adding the title "on hover" is not the best way to do it. 

Now the title is added to the element at the same time we add the links.

### Link documentation PRs if any are needed to support this PR:

None

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
