### PR TITLE
Improve custom DNS hosts file parsing

### DIFF
--- a/scripts/pi-hole/php/func.php
+++ b/scripts/pi-hole/php/func.php
@@ -200,18 +200,22 @@ function getCustomDNSEntries()
     $handle = fopen($customDNSFile, 'r');
     if ($handle) {
         while (($line = fgets($handle)) !== false) {
-            $line = str_replace("\r", '', $line);
-            $line = str_replace("\n", '', $line);
-            $explodedLine = explode(' ', $line);
+            $line = trim($line);
 
-            if (count($explodedLine) != 2) {
+            if (!$line || $line[0] == '#') {
+                continue;
+            }
+
+            $explodedLine = preg_split('/\s+/', $line);
+
+            if (count($explodedLine) < 2) {
                 continue;
             }
 
             $data = new stdClass();
             $data->ip = $explodedLine[0];
             $data->domain = $explodedLine[1];
-            $data->domains = array_slice($explodedLine, 0, -1);
+            $data->domains = array_slice($explodedLine, 1);
             $entries[] = $data;
         }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Improve parsing of custom DNS hosts file. This is useful when directly importing an existing hosts file in to pihole, which may contain comments or variable whitespace.

This allows entries with variable whitespace to appear in the web interface.

**How does this PR accomplish the above?:**

Modify parsing code to allow variable whitespace, and exclude comments

**Link documentation PRs if any are needed to support this PR:**

n/a

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
