### PR TITLE
Unify system setting modal buttons

### DIFF
--- a/scripts/pi-hole/js/settings-system.js
+++ b/scripts/pi-hole/js/settings-system.js
@@ -227,7 +227,7 @@ $(".confirm-restartdns").confirm({
   cancelButton: "No, go back",
   post: true,
   confirmButtonClass: "btn-danger",
-  cancelButtonClass: "btn-success",
+  cancelButtonClass: "btn-default",
   dialogClass: "modal-dialog",
 });
 
@@ -251,7 +251,7 @@ $(".confirm-flushlogs").confirm({
   cancelButton: "No, go back",
   post: true,
   confirmButtonClass: "btn-danger",
-  cancelButtonClass: "btn-success",
+  cancelButtonClass: "btn-default",
   dialogClass: "modal-dialog",
 });
 
@@ -274,8 +274,8 @@ $(".confirm-flusharp").confirm({
   confirmButton: "Yes, flush my network table",
   cancelButton: "No, go back",
   post: true,
-  confirmButtonClass: "btn-warning",
-  cancelButtonClass: "btn-success",
+  confirmButtonClass: "btn-danger",
+  cancelButtonClass: "btn-default",
   dialogClass: "modal-dialog",
 });
 
@@ -312,8 +312,8 @@ $("#loggingButton").confirm({
   confirmButton: "Yes, change query logging",
   cancelButton: "No, go back",
   post: true,
-  confirmButtonClass: "btn-warning",
-  cancelButtonClass: "btn-success",
+  confirmButtonClass: "btn-danger",
+  cancelButtonClass: "btn-default",
   dialogClass: "modal-dialog",
 });
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Unifies the colors of the buttons on the modal appearing after clicking one of the four 'danger' system setting buttons.
They now all use those colors:
![Screenshot at 2024-08-26 22-49-13](https://github.com/user-attachments/assets/17362ecd-56d0-4b6b-a7cb-40dfbf508a2c)


**How does this PR accomplish the above?:**

Fixes https://github.com/pi-hole/web/issues/3117


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
