### PR TITLE
Replace references of `devel` with `development` in prep for change of branch name

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     day: saturday
     time: "10:00"
   open-pull-requests-limit: 10
-  target-branch: devel
+  target-branch: development
   versioning-strategy: increase
   reviewers:
     - "pi-hole/web-maintainers"
@@ -18,7 +18,7 @@ updates:
     day: saturday
     time: "10:00"
   open-pull-requests-limit: 10
-  target-branch: devel
+  target-branch: development
   reviewers:
     - "pi-hole/web-maintainers"
 - package-ecosystem: composer
@@ -28,39 +28,6 @@ updates:
     day: saturday
     time: "10:00"
   open-pull-requests-limit: 10
-  target-branch: development-v6
-  reviewers:
-    - "pi-hole/web-maintainers"
-
-# As above, but for development-v6
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "10:00"
-  open-pull-requests-limit: 10
-  target-branch: development-v6
-  versioning-strategy: increase
-  reviewers:
-    - "pi-hole/web-maintainers"
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "10:00"
-  open-pull-requests-limit: 10
-  target-branch: development-v6
-  reviewers:
-    - "pi-hole/web-maintainers"
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "10:00"
-  open-pull-requests-limit: 10
-  target-branch: development-v6
+  target-branch: development
   reviewers:
     - "pi-hole/web-maintainers"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches:
       - master
-      - devel
+      - development
       - "!dependabot/**"
   pull_request:
     # The branches below must be a subset of the branches above
     branches:
       - master
-      - devel
+      - development
   schedule:
     - cron: "0 0 * * 0"
 

--- a/.github/workflows/sync-back-to-dev.yml
+++ b/.github/workflows/sync-back-to-dev.yml
@@ -13,6 +13,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.7
       - name: Opening pull request
-        run: gh pr create -B devel -H master --title 'Sync master back into development' --body 'Created by Github action' --label 'internal'
+        run: gh pr create -B development -H master --title 'Sync master back into development' --body 'Created by Github action' --label 'internal'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - devel
+      - development
       - master
   pull_request:
     branches:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,8 +31,8 @@ When requesting or submitting new features, first consider whether it might be u
 
 ## Technical Requirements
 
-- Submit Pull Requests to the **devel branch only**.
-- Before Submitting your Pull Request, merge `devel` with your new branch and fix any conflicts. (Make sure you don't break anything in development!)
+- Submit Pull Requests to the **development branch only**.
+- Before Submitting your Pull Request, merge `development` with your new branch and fix any conflicts. (Make sure you don't break anything in development!)
 - Commit Unix line endings.
 - Please use the Pi-hole brand: **Pi-hole** (Take a special look at the capitalized 'P' and a low 'h' with a hyphen)
 - (Optional fun) keep to the theme of Star Trek/black holes/gravity.


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Counterpart to https://github.com/pi-hole/pi-hole/pull/5748, should we go along the path of renaming `devel` to `development` (we probably should)

These PRs should be either the last things merged into `development-v6` or the first things merged into `development` after the merge of `v6`->`development`

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_