### PR TITLE
Add a tooltip to the dashboard showing the last time gravity was updated

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -416,6 +416,19 @@ function updateSummaryData(runOnce = false) {
     $("span#percent_blocked").text(formattedPercentage);
     $("span#gravity_size").text(intl.format(parseInt(data.gravity.domains_being_blocked, 10)));
 
+    const lastupdate = parseInt(data.gravity.last_update, 10);
+    var updatetxt = "Lists were never updated";
+    if (lastupdate > 0) {
+      updatetxt =
+        "Lists updated " +
+        utils.datetimeRelative(lastupdate) +
+        "\n(" +
+        utils.datetime(lastupdate, false, false) +
+        ")";
+    }
+
+    $(".small-box:has(#gravity_size)").attr("title", updatetxt);
+
     if (2 * previousCount < newCount && newCount > 100 && !firstSummaryUpdate) {
       // Update the charts if the number of queries has increased significantly
       // Do not run this on the first update as reloading the same data after


### PR DESCRIPTION
### What does this PR aim to accomplish?

Re-introduces the tooltip removed when PHP was replaced 
(https://discourse.pi-hole.net/t/domains-on-adlists-doesnt-show-last-gravity-update/72082).

This is a follow up of https://github.com/pi-hole/FTL/pull/2048


### Link documentation PRs if any are needed to support this PR:

None

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
