### PR TITLE
Query Log: Show X-icon instead of reply time if no reply was received

### DIFF
--- a/scripts/pi-hole/js/queries.js
+++ b/scripts/pi-hole/js/queries.js
@@ -617,6 +617,11 @@ $(function () {
         $("td:eq(4)", row).text(data.client.ip);
       }
 
+      // Show X-icon instead of reply time if no reply was received
+      if (data.reply.type === "UNKNOWN") {
+        $("td:eq(5)", row).html('<i class="fa fa-times"></i>');
+      }
+
       if (querystatus.buttontext !== false) {
         $("td:eq(6)", row).html(querystatus.buttontext);
       }


### PR DESCRIPTION
# What does this implement/fix?

![image](https://github.com/user-attachments/assets/527c80ee-12b7-4474-9098-99cda6da1f31)

This makes it easier to recognize errors with upstream servers as the `X` is better visually recognizable than a `0.0 ms`.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.