### PR TITLE
Fix gravity count when FTL fails to return this value

### DIFF
--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -416,8 +416,6 @@ function updateSummaryData(runOnce = false) {
     $("span#percent_blocked").text(formattedPercentage);
     updateQueryFrequency(intl, data.queries.frequency);
 
-    const gravityCount = parseInt(data.gravity.domains_being_blocked, 10);
-    $("span#gravity_size").text(intl.format(gravityCount > 0 ? gravityCount : 0));
     const lastupdate = parseInt(data.gravity.last_update, 10);
     var updatetxt = "Lists were never updated";
     if (lastupdate > 0) {
@@ -427,6 +425,15 @@ function updateSummaryData(runOnce = false) {
         "\n(" +
         utils.datetime(lastupdate, false, false) +
         ")";
+    }
+
+    const gravityCount = parseInt(data.gravity.domains_being_blocked, 10);
+    if (gravityCount < 0) {
+      // Error. Change the title text and show the error code in parentheses
+      updatetxt = "Error! Update gravity to reset this value.";
+      $("span#gravity_size").text("Error (" + gravityCount + ")");
+    } else {
+      $("span#gravity_size").text(intl.format(gravityCount));
     }
 
     $(".small-box:has(#gravity_size)").attr("title", updatetxt);

--- a/scripts/pi-hole/js/index.js
+++ b/scripts/pi-hole/js/index.js
@@ -414,9 +414,10 @@ function updateSummaryData(runOnce = false) {
     $("span#blocked_queries").text(intl.format(parseFloat(data.queries.blocked)));
     var formattedPercentage = utils.toPercent(data.queries.percent_blocked, 1);
     $("span#percent_blocked").text(formattedPercentage);
-    $("span#gravity_size").text(intl.format(parseInt(data.gravity.domains_being_blocked, 10)));
     updateQueryFrequency(intl, data.queries.frequency);
 
+    const gravityCount = parseInt(data.gravity.domains_being_blocked, 10);
+    $("span#gravity_size").text(intl.format(gravityCount > 0 ? gravityCount : 0));
     const lastupdate = parseInt(data.gravity.last_update, 10);
     var updatetxt = "Lists were never updated";
     if (lastupdate > 0) {


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fixes the `-2 Domains on the Lists` issue.

### How does this PR accomplish the above?

When FTL fails to count the number of domains on the lists, the value `-2` is returned, but this value should not be printed.

This PR shows `0` in this case.

### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
