### PR TITLE
Remove api.localAPIauth checkbox

### DIFF
--- a/settings-api.lp
+++ b/settings-api.lp
@@ -52,17 +52,10 @@ mg.include('scripts/pi-hole/lua/settings_header.lp','r')
     <div class="col-md-6 settings-level-expert">
         <div class="box box-warning">
             <div class="box-header with-border">
-                <h3 class="box-title" data-configkeys="webserver.api.localAPIauth webserver.api.prettyJSON webserver.api.allow_destructive">Advanced Settings</h3>
+                <h3 class="box-title" data-configkeys="webserver.api.prettyJSON webserver.api.allow_destructive">Advanced Settings</h3>
             </div>
             <div class="box-body">
                 <div class="row">
-                    <div class="col-lg-12">
-                        <div>
-                            <input type="checkbox" id="webserver.api.localAPIauth" data-key="webserver.api.localAPIauth">
-                            <label for="webserver.api.localAPIauth"><strong>Local clients need to authenticate to access the API</strong></label>
-                            <p class="help-block">This will require local clients to authenticate to access the API. This is useful if you want to prevent local users from accessing the API without knowing the password.</p>
-                        </div>
-                    </div>
                     <div class="col-lg-12">
                         <div>
                             <input type="checkbox" id="webserver.api.prettyJSON" data-key="webserver.api.prettyJSON">


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Removes the obsolet `webserver.api.localAPIauth` checkbox from the web interface. The endpoint was removed from FTL during v6 development. 

See report at https://discourse.pi-hole.net/t/web-interface-api-settings-advanced-settings-not-saved/73590

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
