### PR TITLE
Gravity update: Handle color escape sequences

### DIFF
--- a/scripts/js/gravity.js
+++ b/scripts/js/gravity.js
@@ -92,12 +92,26 @@ function parseLines(ta, str) {
   var lines = str.split(/(?=\r)/g);
 
   for (let i = 0; i < lines.length; i++) {
+    if (lines[i].search(/\[[\d;]+m/) !== -1) {
+      // This line contains a color escape sequence - replace
+      lines[i] = lines[i]
+        .replaceAll(/\[(\d;)?[39]0m/g, "<span class=\"log-gray\">")
+        .replaceAll(/\[(\d;)?[39]1m/g, "<span class=\"log-red\">")
+        .replaceAll(/\[(\d;)?[39]2m/g, "<span class=\"log-green\">")
+        .replaceAll(/\[(\d;)?[39]3m/g, "<span class=\"log-yellow\">")
+        .replaceAll(/\[(\d;)?[39]4m/g, "<span class=\"log-blue\">")
+        .replaceAll(/\[(\d;)?[39]5m/g, "<span class=\"log-purple\">")
+        .replaceAll(/\[(\d;)?[39]6m/g, "<span class=\"log-cyan\">")
+        .replaceAll("[0m", "</span>")
+        .replaceAll("[1m", "<span class=\"text-bold\">")
+        .replaceAll("[4m", "<span class=\"text-underline\">");
+    }
     if (lines[i][0] === "\r") {
       // This line starts with the "OVER" sequence. Replace them with "\n" before print
       lines[i] = lines[i].replaceAll("\r[K", "\n").replaceAll("\r", "\n");
 
       // Last line from the textarea will be overwritten, so we remove it
-      ta.text(ta.text().substring(0, ta.text().lastIndexOf("\n")));
+      ta.html(ta.html().substring(0, ta.html().lastIndexOf("\n")));
     }
 
     // Append the new text to the end of the output


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Currently when running gravity update, the color escape sequences used by the shell script are printed literally on the web gui:
```
  [[1;32m✓[0m] DNS resolution is available

  [i] Neutrino emissions detected[0m...
  [[1;32m✓[0m] Pulling blocklist source list into range
  ...
```
This should be the matching real colors instead.

**How does this PR accomplish the above?:**

The patch checks each line fragment for the existance of a pattern that represents an (ANSI) color code escape sequence and substitutes it with a fitting HTML code.

To preserve color coding also when removing line(s) because of OVER escape sequences, the code is changed from using .text() to .html().

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
