### PR TITLE
Use new dnssec.color instead of the removed dnssecClass variable

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -359,8 +359,8 @@ function formatInfo(data) {
   var edeInfo = "";
   if (data.ede !== null && data.ede.text !== null) {
     edeInfo = divStart + "Extended DNS error:&nbsp;&nbsp;<strong";
-    if (dnssecClass !== false) {
-      edeInfo += ' class="' + dnssecClass + '"';
+    if (dnssec.color !== "") {
+      edeInfo += ' class="' + dnssec.color + '"';
     }
 
     edeInfo += ">" + data.ede.text + "</strong></div>";


### PR DESCRIPTION
# What does this implement/fix?

See title. This fixes a hidden merge conflict that arose as regression of merging both https://github.com/pi-hole/web/pull/3184 and https://github.com/pi-hole/web/pull/3185 which had in parts incompatible changes.

Symptoms are failing tests on `development` as well as displaying issues on the Query Log for queries where EDE (extended DNS errors) are available (usually DNSSEC BOGUS queries).

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.