### PR TITLE
Modify status text if a reply was received for clarify

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -99,7 +99,9 @@ function parseQueryStatus(data) {
     case "FORWARDED":
       colorClass = "text-green";
       icon = "fa-solid fa-cloud-download-alt";
-      fieldtext = "Forwarded to " + data.upstream;
+      fieldtext =
+        (data.reply.type !== "UNKNOWN" ? "Forwarded, reply from " : "Forwarded to ") +
+        data.upstream;
       buttontext =
         '<button type="button" class="btn btn-default btn-sm text-red btn-blacklist"><i class="fa fa-ban"></i> Deny</button>';
       break;


### PR DESCRIPTION
# What does this implement/fix?

Following on https://github.com/pi-hole/FTL/issues/2169 I propose to rename the text for forwarded queries we received a reply for. The rationale is that this may not always be 100% exact as Pi-hole may have forwarded the query to multiple servers to check if which of the configured upstreams is the fastest. Pi-hole will then only mention the server which replied first. The same holds true in case users manually added `all-servers`. The change highlights that the shown record is *based* on the reply from the given server.

![grafik](https://github.com/user-attachments/assets/abfdadf0-8cf8-4855-9e18-005e05098efa)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.