### PR TITLE
Use the combination of the 2 fields in "Type" column to allow correct sorting

### DIFF
--- a/scripts/js/groups-domains.js
+++ b/scripts/js/groups-domains.js
@@ -106,7 +106,7 @@ function initTable() {
       { data: "id", visible: false },
       { data: null, visible: true, orderable: false, width: "15px" },
       { data: "domain" },
-      { data: "type", searchable: false },
+      { data: null, searchable: false },
       { data: "enabled", searchable: false },
       { data: "comment" },
       { data: "groups", searchable: false },
@@ -118,6 +118,12 @@ function initTable() {
         className: "select-checkbox",
         render: function () {
           return "";
+        },
+      },
+      {
+        targets: 3,
+        render: function (data) {
+          return data.kind + "_" + data.type;
         },
       },
       {


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix a small issue, where the domains are sorted only by the `type`, but the column actually shows a combination of `kind`+`type`, resulting in an apparent unsorted list.

<img src="https://github.com/user-attachments/assets/95028228-d302-41d1-8945-c6e5abb48a16" width="400">


### How does this PR accomplish the above?

Uses both fields (`kind` and `type`) as data for the column, allowing the correct sort.

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
