### PR TITLE
Save the state of the query log table infinitely

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -572,6 +572,7 @@ $(function () {
       [10, 25, 50, 100, "All"],
     ],
     stateSave: true,
+    stateDuration: 0,
     stateSaveCallback: function (settings, data) {
       utils.stateSaveCallback("query_log_table", data);
     },


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Save the state of the query log table in the local storage infinitely as we do it for all other tables as well.
`stateDuration` was not set, so it defaulted to 7200 seconds
https://datatables.net/reference/option/stateDuration

Fixes https://github.com/pi-hole/web/issues/3252

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
