### PR TITLE
Fix the insertion of multiple domains as wildcard

### DIFF
--- a/scripts/js/groups-domains.js
+++ b/scripts/js/groups-domains.js
@@ -499,11 +499,11 @@ function addDomain() {
   // Check if the wildcard checkbox was marked and transform the domains into regex
   if (kind === "exact" && wildcardChecked) {
     for (var i = 0; i < domains.length; i++) {
-      // Transform domain to wildcard if specified by user
-      domains[i] = "(\\.|^)" + domains[i].replaceAll(".", "\\.") + "$";
-
-      // strip leading "*." if specified by user in wildcard mode
+      // Strip leading "*." if specified by user in wildcard mode
       if (domains[i].startsWith("*.")) domains[i] = domains[i].substr(2);
+
+      // Transform domain into a wildcard regex
+      domains[i] = "(\\.|^)" + domains[i].replaceAll(".", "\\.") + "$";
     }
 
     kind = "regex";

--- a/scripts/js/groups-domains.js
+++ b/scripts/js/groups-domains.js
@@ -496,15 +496,17 @@ function addDomain() {
     return;
   }
 
-  for (var i = 0; i < domains.length; i++) {
-    if (kind === "exact" && wildcardChecked) {
+  // Check if the wildcard checkbox was marked and transform the domains into regex
+  if (kind === "exact" && wildcardChecked) {
+    for (var i = 0; i < domains.length; i++) {
       // Transform domain to wildcard if specified by user
       domains[i] = "(\\.|^)" + domains[i].replaceAll(".", "\\.") + "$";
-      kind = "regex";
 
       // strip leading "*." if specified by user in wildcard mode
       if (domains[i].startsWith("*.")) domains[i] = domains[i].substr(2);
     }
+
+    kind = "regex";
   }
 
   // determine list type


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix https://github.com/pi-hole/web/issues/3257

When selecting the "Add domain as wildcard" checkbox with multiple domains, only the first one was changed into a wildcard regex.

### How does this PR accomplish the above?

Changing `kind` variable from "exact" to "regex" only after the loop.

The issue happened because the previous code were modifying this variable inside the loop, but after the first domain, the check failed _(the kind was wrongly changed before all domains were parsed)_ and the rest of the domains were not changed into wildcards.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
