### PR TITLE
Show N/A in version footer if component version could not be obtained

### DIFF
--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -526,7 +526,7 @@ function updateVersionInfo() {
     }
 
     versions.forEach(function (v) {
-      if (v.local !== null) {
+      if (v.local !== null && v.local !== "" && v.local !== "null") {
         // reset update status for each component
         var updateComponentAvailable = false;
         var localVersion = v.local;
@@ -591,6 +591,8 @@ function updateVersionInfo() {
         } else {
           $("#versions").append("<li><strong>" + v.name + "</strong> " + localVersion + "</li>");
         }
+      } else {
+        $("#versions").append("<li><strong>" + v.name + "</strong> N/A</li>");
       }
     });
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Show the footer version info even if a local version could not be obtained.

![2025-02-27_13-46_1](https://github.com/user-attachments/assets/4041bd22-1a58-40ca-8245-166f2085d531)
![2025-02-27_13-46](https://github.com/user-attachments/assets/146e5967-a43f-493a-a3f7-8248b7d23f09)


**How does this PR accomplish the above?:**

Extend the check of an unset/empty/literal 'null' with an `else`

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
