### PR TITLE
Use margin-right instead of spaces after dnssec icon in Query Log

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -609,13 +609,13 @@ $(function () {
       // Prefix colored DNSSEC icon to domain text
       var dnssecIcon = "";
       dnssecIcon =
-        '<i class="fa fa-fw ' +
+        '<i class="mr-2 fa fa-fw ' +
         dnssec.icon +
         " " +
         dnssec.color +
         '" title="DNSSEC: ' +
         dnssec.text +
-        '"></i>&nbsp;&nbsp;';
+        '"></i>';
 
       // Escape HTML in domain
       domain = dnssecIcon + utils.escapeHtml(domain);


### PR DESCRIPTION
### What does this PR aim to accomplish?

Replaces the spaces after the DNSSEC icon in the Query Log.

This allows users to copy the domain column text without extra spaces.

### How does this PR accomplish the above?

Using CSS class `mr-2` to add a margin-right of 0.5em to the icon.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
