### PR TITLE
Improve memory unit selection for devices with less than 1 GB of RAM

### DIFF
--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -330,8 +330,20 @@ function updateSystemInfo() {
       var system = data.system;
       var percentRAM = system.memory.ram["%used"];
       var percentSwap = system.memory.swap["%used"];
-      var totalRAMGB = system.memory.ram.total / 1024 / 1024;
-      var totalSwapGB = system.memory.swap.total / 1024 / 1024;
+      let totalRAM = system.memory.ram.total / 1024;
+      let totalRAMUnit = "MB";
+      if (totalRAM > 1024) {
+        totalRAM /= 1024;
+        totalRAMUnit = "GB";
+      }
+
+      let totalSwap = system.memory.swap.total / 1024;
+      let totalSwapUnit = "MB";
+      if (totalSwap > 1024) {
+        totalSwap /= 1024;
+        totalSwapUnit = "GB";
+      }
+
       var swap =
         system.memory.swap.total > 0
           ? ((1e2 * system.memory.swap.used) / system.memory.swap.total).toFixed(1) + " %"
@@ -347,14 +359,14 @@ function updateSystemInfo() {
       );
       $("#memory").prop(
         "title",
-        "Total memory: " + totalRAMGB.toFixed(1) + " GB, Swap usage: " + swap
+        "Total memory: " + totalRAM.toFixed(1) + " " + totalRAMUnit + ", Swap usage: " + swap
       );
       $("#sysinfo-memory-ram").text(
-        percentRAM.toFixed(1) + "% of " + totalRAMGB.toFixed(1) + " GB is used"
+        percentRAM.toFixed(1) + "% of " + totalRAM.toFixed(1) + " " + totalRAMUnit + " is used"
       );
       if (system.memory.swap.total > 0) {
         $("#sysinfo-memory-swap").text(
-          percentSwap.toFixed(1) + "% of " + totalSwapGB.toFixed(1) + " GB is used"
+          percentSwap.toFixed(1) + "% of " + totalSwap.toFixed(1) + " " + totalSwapUnit + " is used"
         );
       } else {
         $("#sysinfo-memory-swap").text("No swap space available");


### PR DESCRIPTION
# What does this implement/fix?

Avoid showing "0.3 GB" on devices what have only 256 MB of memory

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.