### PR TITLE
Sort interfaces

### DIFF
--- a/scripts/js/interfaces.js
+++ b/scripts/js/interfaces.js
@@ -54,12 +54,13 @@ $(function () {
       }
 
       // Show an icon for indenting slave interfaces
-      const indentIcon = master === null ? "" : "<i class='fa fa-diagram-project fa-fw'></i> ";
+      const indentIcon =
+        master === null ? "" : "<span class='child-interface-icon'>&nbsp;&rdca;</span> ";
 
       var obj = {
         text: indentIcon + interface.name + " - " + status,
         class: gateways.has(interface.name) ? "text-bold" : null,
-        icon: "fa fa-network-wired fa-fw",
+        icon: master === null ? "fa fa-network-wired fa-fw" : "",
         nodes: [],
       };
 

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1584,3 +1584,7 @@ textarea.field-sizing-content {
 .bstreeview .list-group-item:hover {
   background-color: rgba(127, 127, 127, 0.18);
 }
+.child-interface-icon {
+  line-height: 0.5em;
+  font-size: 1.7em;
+}


### PR DESCRIPTION
# What does this implement/fix?

Sort interfaces

 - interfaces that do not depend on others (and have no children) are placed at the top of the tree view
 - interfaces that do have children get them directly assigned below them

![image](https://github.com/user-attachments/assets/4ae53c84-c066-47d6-b765-5b9bae7590c2)

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.