### PR TITLE
Improve HTTPS detection behind reverse proxy

### DIFF
--- a/scripts/js/settings-teleporter.js
+++ b/scripts/js/settings-teleporter.js
@@ -105,3 +105,10 @@ $("#GETTeleporter").on("click", function () {
     },
   });
 });
+
+$(function () {
+  // Show warning if not accessed over HTTPS
+  if (location.protocol !== "https:") {
+    $("#encryption-warning").show();
+  }
+});

--- a/scripts/lua/footer.lp
+++ b/scripts/lua/footer.lp
@@ -68,6 +68,6 @@ end
 <!-- ./wrapper -->
 <script src="<?=pihole.fileversion('scripts/js/footer.js')?>"></script>
 
-<div id="advanced-info-data" style="display: none;" data-starttime="<?=starttime?>" data-endtime="<?=mg.time(true)?>" data-client-ip="<?=mg.request_info.remote_addr?>" data-tls="<?=tostring(is_secure)?>" data-xff="<?=x_forwarded_for?>"></div>
+<div id="advanced-info-data" style="display: none;" data-starttime="<?=starttime?>" data-endtime="<?=mg.time(true)?>" data-client-ip="<?=mg.request_info.remote_addr?>" data-xff="<?=x_forwarded_for?>"></div>
 </body>
 </html>

--- a/scripts/lua/header.lp
+++ b/scripts/lua/header.lp
@@ -39,9 +39,6 @@ function in_array (val, tab)
     return false
 end
 
--- Connection is considered secure if running natively on HTTPS
-is_secure = mg.request_info.https
-
 -- Variable to check if user is already authenticated
 is_authenticated = mg.request_info.is_authenticated
 

--- a/settings-teleporter.lp
+++ b/settings-teleporter.lp
@@ -21,7 +21,7 @@ mg.include('scripts/lua/settings_header.lp','r')
             </div>
             <div class="box-body">
                 <p><strong>Warning:</strong><br>This archive contains sensitive information about your Pi-hole installation, e.g. your 2FA-TOTP secret (if enabled). Please be careful with this file and do not share it with anyone even if they claim to help you.</p>
-                <? if not is_secure then ?><p class='text-danger'><strong>Warning:</strong><br>You are currently not using an end-to-end encryption. This means that secrets like your 2FA-TOTP secret will be transmitted in plain text. We recommend to use HTTPS when exporting your configuration.</p><? end ?>
+                <p class='text-danger' id="encryption-warning" style="display: none;"><strong>Warning:</strong><br>You are currently not using an end-to-end encryption. This means that secrets like your 2FA-TOTP secret will be transmitted in plain text. We recommend to use HTTPS when exporting your configuration.</p>
                 <div class="pull-right">
                     <a class="btn btn-app btn-success" id="GETTeleporter" target="_blank">
                         <i class="fa fa-save fa-xl"></i><br>Export


### PR DESCRIPTION
# What does this implement/fix?

Move the decision whether we are showing the no-HTTPS warning from server-side (where no https may be used when a reverse proxy is used) to user-side where this is more definite

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.