### PR TITLE
Sort IPv4 before IPv6 addresses on the network overview

### DIFF
--- a/scripts/js/network.js
+++ b/scripts/js/network.js
@@ -138,6 +138,19 @@ $(function () {
       var ips = [],
         iptitles = [];
 
+      // Sort IPs, IPv4 before IPv6, then alphabetically
+      data.ips.sort(function (a, b) {
+        if (a.ip.includes(":") && !b.ip.includes(":")) {
+          return 1;
+        }
+
+        if (!a.ip.includes(":") && b.ip.includes(":")) {
+          return -1;
+        }
+
+        return a.ip.localeCompare(b.ip);
+      });
+
       for (index = 0; index < data.ips.length; index++) {
         var ip = data.ips[index],
           iptext = ip.ip;


### PR DESCRIPTION
# What does this implement/fix?

See title and linked Discourse thread.

---

**Related issue or feature (if applicable):** https://discourse.pi-hole.net/t/network-table-show-ipv4-over-ipv6/77413

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.