### PR TITLE
Remove a few unused CSS rules from pi-hole.css and LCARS theme

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1094,10 +1094,6 @@ table.dataTable tbody > tr > .selected {
   padding: 5px;
 }
 
-.faint-border {
-  border-color: rgba(127, 127, 127, 0.1);
-}
-
 .pre-scrollable {
   /* use dynamic unit to account for mobile browser interface height */
   max-height: max(195px, 100dvh - 170px);

--- a/style/themes/lcars.css
+++ b/style/themes/lcars.css
@@ -615,14 +615,6 @@ p.login-box-msg,
   flex: 1 1 auto;
 }
 
-#pihole-diagnosis {
-  min-width: 50px;
-}
-
-#pihole-diagnosis svg {
-  font-size: 28px;
-}
-
 .warning-count {
   position: relative;
   margin: 0;
@@ -2077,11 +2069,6 @@ td.highlight {
 .small-box .icon,
 .select2-selection__clear {
   font-family: sans-serif;
-}
-
-/*** size correction to fit in one line - Settings/DNS ***/
-#dns .col-md-11 {
-  width: 84%;
 }
 
 /*** add style to the information/about dropdown ***/


### PR DESCRIPTION
### What does this PR aim to accomplish and how does this PR accomplish the above?

As title says.

Removing 2 rules used only to format 2 items in v5 settings pages and 2 rules used to format `#pihole-diagnosis` (the old triangle icon, removed a long time ago).

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
