### PR TITLE
Query Log: Add QUERY_EXTERNAL_BLOCKED_EDE15 rules

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -149,6 +149,13 @@ function parseQueryStatus(data) {
       buttontext = "";
       blocked = true;
       break;
+    case "QUERY_EXTERNAL_BLOCKED_EDE15":
+      colorClass = "text-red";
+      icon = "fa-solid fa-ban";
+      fieldtext = "Blocked (external, EDE15)";
+      buttontext = "";
+      blocked = true;
+      break;
     case "GRAVITY_CNAME":
       colorClass = "text-red";
       icon = "fa-solid fa-ban";


### PR DESCRIPTION
# What does this implement/fix?

Query Log is missing a rule for colorization of `QUERY_EXTERNAL_BLOCKED_EDE15`

---

**Related issue or feature (if applicable):** private communication on Discourse

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.