### PR TITLE
Hide top tables depending on privacy level

### DIFF
--- a/scripts/js/index.js
+++ b/scripts/js/index.js
@@ -327,7 +327,7 @@ function updateTopClientsTable(blocked) {
       if (privacyLevel > 1) {
         table.remove();
       } else {
-        clienttable.append('<tr><td colspan="3"><center>- No data -</center></td></tr>');
+        clienttable.append('<tr><td colspan="3" class="text-center">- No data -</td></tr>');
         overlay.hide();
       }
 
@@ -404,7 +404,7 @@ function updateTopDomainsTable(blocked) {
       if (privacyLevel > 0) {
         table.remove();
       } else {
-        domaintable.append('<tr><td colspan="3"><center>- No data -</center></td></tr>');
+        domaintable.append('<tr><td colspan="3" class="text-center">- No data -</td></tr>');
         overlay.hide();
       }
 

--- a/scripts/js/index.js
+++ b/scripts/js/index.js
@@ -277,18 +277,21 @@ function updateForwardDestinationsPie() {
 function updateTopClientsTable(blocked) {
   let api;
   let style;
+  let table;
   let tablecontent;
   let overlay;
   let clienttable;
   if (blocked) {
     api = document.body.dataset.apiurl + "/stats/top_clients?blocked=true";
     style = "queries-blocked";
+    table = $("#client-frequency-blocked");
     tablecontent = $("#client-frequency-blocked td").parent();
     overlay = $("#client-frequency-blocked .overlay");
     clienttable = $("#client-frequency-blocked").find("tbody:last");
   } else {
     api = document.body.dataset.apiurl + "/stats/top_clients";
     style = "queries-permitted";
+    table = $("#client-frequency");
     tablecontent = $("#client-frequency td").parent();
     overlay = $("#client-frequency .overlay");
     clienttable = $("#client-frequency").find("tbody:last");
@@ -301,10 +304,10 @@ function updateTopClientsTable(blocked) {
     let percentage;
     const sum = blocked ? data.blocked_queries : data.total_queries;
 
-    // Add note if there are no results (e.g. privacy mode enabled)
+    // Remove table if there are no results (e.g. new
+    // installation or privacy mode enabled)
     if (jQuery.isEmptyObject(data.clients)) {
-      clienttable.append('<tr><td colspan="3"><center>- No data -</center></td></tr>');
-      overlay.hide();
+      table.remove();
       return;
     }
 
@@ -342,18 +345,21 @@ function updateTopClientsTable(blocked) {
 function updateTopDomainsTable(blocked) {
   let api;
   let style;
+  let table
   let tablecontent;
   let overlay;
   let domaintable;
   if (blocked) {
     api = document.body.dataset.apiurl + "/stats/top_domains?blocked=true";
     style = "queries-blocked";
+    table = $("#ad-frequency");
     tablecontent = $("#ad-frequency td").parent();
     overlay = $("#ad-frequency .overlay");
     domaintable = $("#ad-frequency").find("tbody:last");
   } else {
     api = document.body.dataset.apiurl + "/stats/top_domains";
     style = "queries-permitted";
+    table = $("#domain-frequency");
     tablecontent = $("#domain-frequency td").parent();
     overlay = $("#domain-frequency .overlay");
     domaintable = $("#domain-frequency").find("tbody:last");
@@ -368,10 +374,10 @@ function updateTopDomainsTable(blocked) {
     let urlText;
     const sum = blocked ? data.blocked_queries : data.total_queries;
 
-    // Add note if there are no results (e.g. privacy mode enabled)
+    // Remove table if there are no results (e.g. new
+    // installation or privacy mode enabled)
     if (jQuery.isEmptyObject(data.domains)) {
-      domaintable.append('<tr><td colspan="3"><center>- No data -</center></td></tr>');
-      overlay.hide();
+      table.remove();
       return;
     }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Removes the 'top' tables from the dashboard when no data is available due to higher privacy level. This restores v5 behavior. Currently the table is shown with a 'no data' note. 

If the privacy level is not high enough to hide the table but no data is provided (new installations, failures) the tables are shown with a 'no data' info.

Fixes https://github.com/pi-hole/web/issues/3249

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
