### PR TITLE
Fix concurrency issue about const apiUrl

### DIFF
--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global upstreams */
+/* global upstreams:false */
 
 // eslint-disable-next-line no-unused-vars
 var THEME_COLORS = [

--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -8,7 +8,6 @@
 /* global utils:false, moment:false */
 
 var _isLoginPage = false;
-const apiUrl = document.body.dataset.apiurl;
 
 const REFRESH_INTERVAL = {
   logs: 500, // 0.5 sec (logs page)
@@ -115,7 +114,7 @@ function checkBlocking() {
   }
 
   $.ajax({
-    url: apiUrl + "/dns/blocking",
+    url: document.body.dataset.apiurl + "/dns/blocking",
     method: "GET",
   })
     .done(function (data) {
@@ -144,7 +143,7 @@ function piholeChange(action, duration) {
 
   btnStatus.html("<i class='fa fa-spinner fa-spin'> </i>");
   $.ajax({
-    url: apiUrl + "/dns/blocking",
+    url: document.body.dataset.apiurl + "/dns/blocking",
     method: "POST",
     dataType: "json",
     processData: false,
@@ -267,7 +266,7 @@ function updateQueryFrequency(intl, frequency) {
 var ftlinfoTimer = null;
 function updateFtlInfo() {
   $.ajax({
-    url: apiUrl + "/info/ftl",
+    url: document.body.dataset.apiurl + "/info/ftl",
   })
     .done(function (data) {
       var ftl = data.ftl;
@@ -324,7 +323,7 @@ function updateFtlInfo() {
 
 function updateSystemInfo() {
   $.ajax({
-    url: apiUrl + "/info/system",
+    url: document.body.dataset.apiurl + "/info/system",
   })
     .done(function (data) {
       var system = data.system;
@@ -484,7 +483,7 @@ function versionCompare(v1, v2) {
 
 function updateVersionInfo() {
   $.ajax({
-    url: apiUrl + "/info/version",
+    url: document.body.dataset.apiurl + "/info/version",
   }).done(function (data) {
     var version = data.version;
     var updateAvailable = false;

--- a/scripts/js/gravity.js
+++ b/scripts/js/gravity.js
@@ -4,7 +4,6 @@
  *
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
-/* global apiUrl: false */
 
 function eventsource() {
   var alInfo = $("#alInfo");
@@ -16,7 +15,7 @@ function eventsource() {
   alInfo.show();
   alSuccess.hide();
 
-  fetch(apiUrl + "/action/gravity", {
+  fetch(document.body.dataset.apiurl + "/action/gravity", {
     method: "POST",
     headers: { "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr("content") },
   })

--- a/scripts/js/groups-clients.js
+++ b/scripts/js/groups-clients.js
@@ -5,14 +5,14 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, groups:false,, apiFailure:false, updateFtlInfo:false, getGroups:false, processGroupResult:false, delGroupItems:false */
+/* global utils:false, groups:false, apiFailure:false, updateFtlInfo:false, getGroups:false, processGroupResult:false, delGroupItems:false */
 /* exported initTable */
 
 var table;
 
 function reloadClientSuggestions() {
   $.ajax({
-    url: apiUrl + "/clients/_suggestions",
+    url: document.body.dataset.apiurl + "/clients/_suggestions",
     type: "GET",
     dataType: "json",
     success: function (data) {
@@ -96,7 +96,7 @@ function initTable() {
   table = $("#clientsTable").DataTable({
     processing: true,
     ajax: {
-      url: apiUrl + "/clients",
+      url: document.body.dataset.apiurl + "/clients",
       dataSrc: "clients",
       type: "GET",
     },
@@ -402,7 +402,7 @@ function addClient() {
   }
 
   $.ajax({
-    url: apiUrl + "/clients",
+    url: document.body.dataset.apiurl + "/clients",
     method: "post",
     dataType: "json",
     processData: false,
@@ -459,7 +459,7 @@ function editClient() {
   const clientDecoded = utils.hexDecode(client);
   utils.showAlert("info", "", "Editing client...", clientDecoded);
   $.ajax({
-    url: apiUrl + "/clients/" + encodeURIComponent(clientDecoded),
+    url: document.body.dataset.apiurl + "/clients/" + encodeURIComponent(clientDecoded),
     method: "put",
     dataType: "json",
     processData: false,

--- a/scripts/js/groups-common.js
+++ b/scripts/js/groups-common.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global apiFailure:false, utils:false, apiUrl:false, initTable:false, updateFtlInfo:false */
+/* global apiFailure:false, utils:false, initTable:false, updateFtlInfo:false */
 
 var groups = [];
 
@@ -39,7 +39,7 @@ function populateGroupSelect(selectEl) {
 // eslint-disable-next-line no-unused-vars
 function getGroups(groupSelector) {
   $.ajax({
-    url: apiUrl + "/groups",
+    url: document.body.dataset.apiurl + "/groups",
     type: "GET",
     dataType: "json",
     success: function (data) {
@@ -79,7 +79,7 @@ function delGroupItems(type, ids, table, listType = undefined) {
   // Check input validity
   if (!Array.isArray(ids)) return;
 
-  const url = apiUrl + "/" + type + "s:batchDelete";
+  const url = document.body.dataset.apiurl + "/" + type + "s:batchDelete";
 
   // use utils.hexDecode() to decode all clients
   let idstring = "";

--- a/scripts/js/groups-domains.js
+++ b/scripts/js/groups-domains.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, groups:false,, getGroups:false, updateFtlInfo:false, apiFailure:false, processGroupResult:false, delGroupItems:false */
+/* global utils:false, groups:false, getGroups:false, updateFtlInfo:false, apiFailure:false, processGroupResult:false, delGroupItems:false */
 /* exported initTable */
 
 var table;
@@ -91,7 +91,7 @@ function initTable() {
   table = $("#domainsTable").DataTable({
     processing: true,
     ajax: {
-      url: apiUrl + "/domains",
+      url: document.body.dataset.apiurl + "/domains",
       dataSrc: "domains",
       type: "GET",
     },
@@ -507,7 +507,7 @@ function addDomain() {
   const type = action === "add_deny" ? "deny" : "allow";
 
   $.ajax({
-    url: apiUrl + "/domains/" + type + "/" + kind,
+    url: document.body.dataset.apiurl + "/domains/" + type + "/" + kind,
     method: "post",
     dataType: "json",
     processData: false,
@@ -596,7 +596,12 @@ function editDomain() {
   const domainDecoded = utils.hexDecode(domain.split("_")[0]);
   utils.showAlert("info", "", "Editing domain...", domainDecoded);
   $.ajax({
-    url: apiUrl + "/domains/" + newTypestr + "/" + encodeURIComponent(domainDecoded),
+    url:
+      document.body.dataset.apiurl +
+      "/domains/" +
+      newTypestr +
+      "/" +
+      encodeURIComponent(domainDecoded),
     method: "put",
     dataType: "json",
     processData: false,

--- a/scripts/js/groups-lists.js
+++ b/scripts/js/groups-lists.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, groups:false, apiFailure:false, updateFtlInfo:false, getGroups:false, processGroupResult:false, delGroupItems:false */
+/* global utils:false, groups:false, apiFailure:false, updateFtlInfo:false, getGroups:false, processGroupResult:false, delGroupItems:false */
 /* exported initTable */
 
 var table;
@@ -170,7 +170,7 @@ function initTable() {
   table = $("#listsTable").DataTable({
     processing: true,
     ajax: {
-      url: apiUrl + "/lists",
+      url: document.body.dataset.apiurl + "/lists",
       dataSrc: "lists",
       type: "GET",
     },
@@ -519,7 +519,7 @@ function addList(event) {
   }
 
   $.ajax({
-    url: apiUrl + "/lists",
+    url: document.body.dataset.apiurl + "/lists",
     method: "post",
     dataType: "json",
     processData: false,
@@ -588,7 +588,7 @@ function editList() {
   utils.disableAll();
   utils.showAlert("info", "", "Editing address...", address);
   $.ajax({
-    url: apiUrl + "/lists/" + encodeURIComponent(address) + "?type=" + type,
+    url: document.body.dataset.apiurl + "/lists/" + encodeURIComponent(address) + "?type=" + type,
     method: "put",
     dataType: "json",
     processData: false,

--- a/scripts/js/groups.js
+++ b/scripts/js/groups.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, apiFailure:false, updateFtlInfo:false, processGroupResult:false, delGroupItems:false */
+/* global utils:false, apiFailure:false, updateFtlInfo:false, processGroupResult:false, delGroupItems:false */
 
 var table;
 
@@ -26,7 +26,7 @@ $(function () {
   table = $("#groupsTable").DataTable({
     processing: true,
     ajax: {
-      url: apiUrl + "/groups",
+      url: document.body.dataset.apiurl + "/groups",
       error: handleAjaxError,
       dataSrc: "groups",
       type: "GET",
@@ -261,7 +261,7 @@ function addGroup() {
   }
 
   $.ajax({
-    url: apiUrl + "/groups",
+    url: document.body.dataset.apiurl + "/groups",
     method: "post",
     dataType: "json",
     processData: false,
@@ -329,7 +329,7 @@ function editGroup() {
   utils.disableAll();
   utils.showAlert("info", "", "Editing group...", oldName);
   $.ajax({
-    url: apiUrl + "/groups/" + oldName,
+    url: document.body.dataset.apiurl + "/groups/" + oldName,
     method: "put",
     dataType: "json",
     processData: false,

--- a/scripts/js/index.js
+++ b/scripts/js/index.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, Chart:false, apiFailure:false, THEME_COLORS:false, customTooltips:false, htmlLegendPlugin:false,doughnutTooltip:false, ChartDeferred:false, REFRESH_INTERVAL: false, updateQueryFrequency: false */
+/* global utils:false, Chart:false, apiFailure:false, THEME_COLORS:false, customTooltips:false, htmlLegendPlugin:false,doughnutTooltip:false, ChartDeferred:false, REFRESH_INTERVAL: false, updateQueryFrequency: false */
 
 // Define global variables
 var timeLineChart, clientsChart;
@@ -22,7 +22,7 @@ Chart.defaults.set("plugins.deferred", {
 
 var failures = 0;
 function updateQueriesOverTime() {
-  $.getJSON(apiUrl + "/history", function (data) {
+  $.getJSON(document.body.dataset.apiurl + "/history", function (data) {
     // Remove graph if there are no results (e.g. new
     // installation or privacy mode enabled)
     if (jQuery.isEmptyObject(data.history)) {
@@ -92,7 +92,7 @@ function updateQueriesOverTime() {
 }
 
 function updateQueryTypesPie() {
-  $.getJSON(apiUrl + "/stats/query_types", function (data) {
+  $.getJSON(document.body.dataset.apiurl + "/stats/query_types", function (data) {
     var v = [],
       c = [],
       k = [],
@@ -134,7 +134,7 @@ function updateQueryTypesPie() {
 }
 
 function updateClientsOverTime() {
-  $.getJSON(apiUrl + "/history/clients", function (data) {
+  $.getJSON(document.body.dataset.apiurl + "/history/clients", function (data) {
     // Remove graph if there are no results (e.g. new
     // installation or privacy mode enabled)
     if (jQuery.isEmptyObject(data.history)) {
@@ -212,7 +212,7 @@ function updateClientsOverTime() {
 
 var upstreams = {};
 function updateForwardDestinationsPie() {
-  $.getJSON(apiUrl + "/stats/upstreams", function (data) {
+  $.getJSON(document.body.dataset.apiurl + "/stats/upstreams", function (data) {
     var v = [],
       c = [],
       k = [],
@@ -273,13 +273,13 @@ function updateForwardDestinationsPie() {
 function updateTopClientsTable(blocked) {
   let api, style, tablecontent, overlay, clienttable;
   if (blocked) {
-    api = apiUrl + "/stats/top_clients?blocked=true";
+    api = document.body.dataset.apiurl + "/stats/top_clients?blocked=true";
     style = "queries-blocked";
     tablecontent = $("#client-frequency-blocked td").parent();
     overlay = $("#client-frequency-blocked .overlay");
     clienttable = $("#client-frequency-blocked").find("tbody:last");
   } else {
-    api = apiUrl + "/stats/top_clients";
+    api = document.body.dataset.apiurl + "/stats/top_clients";
     style = "queries-permitted";
     tablecontent = $("#client-frequency td").parent();
     overlay = $("#client-frequency .overlay");
@@ -333,13 +333,13 @@ function updateTopClientsTable(blocked) {
 function updateTopDomainsTable(blocked) {
   let api, style, tablecontent, overlay, domaintable;
   if (blocked) {
-    api = apiUrl + "/stats/top_domains?blocked=true";
+    api = document.body.dataset.apiurl + "/stats/top_domains?blocked=true";
     style = "queries-blocked";
     tablecontent = $("#ad-frequency td").parent();
     overlay = $("#ad-frequency .overlay");
     domaintable = $("#ad-frequency").find("tbody:last");
   } else {
-    api = apiUrl + "/stats/top_domains";
+    api = document.body.dataset.apiurl + "/stats/top_domains";
     style = "queries-permitted";
     tablecontent = $("#domain-frequency td").parent();
     overlay = $("#domain-frequency .overlay");
@@ -408,7 +408,7 @@ function updateTopLists() {
 var previousCount = 0;
 var firstSummaryUpdate = true;
 function updateSummaryData(runOnce = false) {
-  $.getJSON(apiUrl + "/stats/summary", function (data) {
+  $.getJSON(document.body.dataset.apiurl + "/stats/summary", function (data) {
     var intl = new Intl.NumberFormat();
     const newCount = parseInt(data.queries.total, 10);
 

--- a/scripts/js/interfaces.js
+++ b/scripts/js/interfaces.js
@@ -5,11 +5,11 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils: false, apiUrl: false */
+/* global utils: false */
 
 $(function () {
   $.ajax({
-    url: apiUrl + "/network/gateway",
+    url: document.body.dataset.apiurl + "/network/gateway",
     data: { detailed: true },
   }).done(function (data) {
     var intl = new Intl.NumberFormat();

--- a/scripts/js/login.js
+++ b/scripts/js/login.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl: false, NProgress:false */
+/* global utils:false, NProgress:false */
 
 var _isLoginPage = true;
 
@@ -91,7 +91,7 @@ function doLogin(password) {
   NProgress.start();
   utils.disableAll();
   $.ajax({
-    url: apiUrl + "/auth",
+    url: document.body.dataset.apiurl + "/auth",
     method: "POST",
     dataType: "json",
     processData: false,
@@ -163,7 +163,7 @@ function showDNSfailure() {
 $(function () {
   // Check if we need to login at all
   $.ajax({
-    url: apiUrl + "/auth",
+    url: document.body.dataset.apiurl + "/auth",
   })
     .done(function (data) {
       // If we are already logged in, redirect to dashboard
@@ -182,7 +182,7 @@ $(function () {
 
   // Get information about HTTPS port and DNS status
   $.ajax({
-    url: apiUrl + "/info/login",
+    url: document.body.dataset.apiurl + "/info/login",
   }).done(function (data) {
     if (data.dns === false) showDNSfailure();
 

--- a/scripts/js/messages.js
+++ b/scripts/js/messages.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils: false, apiUrl: false */
+/* global utils: false */
 var table,
   toasts = {};
 
@@ -13,7 +13,10 @@ $(function () {
   var ignoreNonfatal = localStorage
     ? localStorage.getItem("hideNonfatalDnsmasqWarnings_chkbox") === "true"
     : false;
-  var url = apiUrl + "/info/messages" + (ignoreNonfatal ? "?filter_dnsmasq_warnings=true" : "");
+  var url =
+    document.body.dataset.apiurl +
+    "/info/messages" +
+    (ignoreNonfatal ? "?filter_dnsmasq_warnings=true" : "");
   table = $("#messagesTable").DataTable({
     ajax: {
       url: url,
@@ -157,7 +160,7 @@ function delMsg(id) {
   toasts[id] = utils.showAlert("info", "", "Deleting message...", "ID: " + id, null);
 
   $.ajax({
-    url: apiUrl + "/info/messages/" + id,
+    url: document.body.dataset.apiurl + "/info/messages/" + id,
     method: "DELETE",
   })
     .done(function (response) {

--- a/scripts/js/network.js
+++ b/scripts/js/network.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license.  */
 
-/* global utils:false, apiUrl:false, apiFailure:false */
+/* global utils:false, apiFailure:false */
 
 var tableApi;
 
@@ -64,7 +64,7 @@ function deleteNetworkEntry() {
   utils.disableAll();
   utils.showAlert("info", "", "Deleting network table entry...");
   $.ajax({
-    url: apiUrl + "/network/devices/" + id,
+    url: document.body.dataset.apiurl + "/network/devices/" + id,
     method: "DELETE",
     success: function () {
       utils.enableAll();
@@ -208,7 +208,7 @@ $(function () {
       "<'row'<'col-sm-12'<'table-responsive'tr>>>" +
       "<'row'<'col-sm-5'i><'col-sm-7'p>>",
     ajax: {
-      url: apiUrl + "/network/devices",
+      url: document.body.dataset.apiurl + "/network/devices",
       type: "GET",
       dataType: "json",
       data: {

--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license.  */
 
-/* global moment:false, utils:false, apiUrl:false, REFRESH_INTERVAL:false */
+/* global moment:false, utils:false, REFRESH_INTERVAL:false */
 
 const beginningOfTime = 1262304000; // Jan 01 2010, 00:00 in seconds
 const endOfTime = 2147483647; // Jan 19, 2038, 03:14 in seconds
@@ -431,7 +431,7 @@ function addSelectSuggestion(name, dict, data) {
 
 function getSuggestions(dict) {
   $.get(
-    apiUrl + "/queries/suggestions",
+    document.body.dataset.apiurl + "/queries/suggestions",
     function (data) {
       for (var key in filters) {
         if (Object.hasOwnProperty.call(filters, key)) {
@@ -462,7 +462,7 @@ function filterOn(param, dict) {
 }
 
 function getAPIURL(filters) {
-  var apiurl = apiUrl + "/queries?";
+  var apiurl = document.body.dataset.apiurl + "/queries?";
   for (var key in filters) {
     if (Object.hasOwnProperty.call(filters, key)) {
       var filter = filters[key];
@@ -514,7 +514,7 @@ $(function () {
   }
 
   getSuggestions(GETDict);
-  var apiurl = getAPIURL(GETDict);
+  var apiURL = getAPIURL(GETDict);
 
   if ("from" in GETDict) {
     from = GETDict.from;
@@ -530,7 +530,7 @@ $(function () {
 
   table = $("#all-queries").DataTable({
     ajax: {
-      url: apiurl,
+      url: apiURL,
       error: handleAjaxError,
       dataSrc: "queries",
       data: function (d) {
@@ -740,6 +740,6 @@ function refreshTable() {
   var filters = parseFilters();
   filters.from = from;
   filters.until = until;
-  var apiurl = getAPIURL(filters);
-  table.ajax.url(apiurl).draw();
+  var apiUrl = getAPIURL(filters);
+  table.ajax.url(apiUrl).draw();
 }

--- a/scripts/js/search.js
+++ b/scripts/js/search.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, apiFailure:false */
+/* global utils:false, apiFailure:false */
 var GETDict = {};
 
 $(function () {
@@ -35,7 +35,7 @@ function doSearch() {
 
   $.ajax({
     method: "GET",
-    url: apiUrl + "/search/" + encodeURIComponent(q),
+    url: document.body.dataset.apiurl + "/search/" + encodeURIComponent(q),
     async: false,
     data: {
       partial: partial,

--- a/scripts/js/settings-advanced.js
+++ b/scripts/js/settings-advanced.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, apiFailure: false, applyCheckboxRadioStyle: false, saveSettings:false */
+/* global utils:false, apiFailure: false, applyCheckboxRadioStyle: false, saveSettings:false */
 /* exported createDynamicConfigTabs */
 
 function addAllowedValues(allowed) {
@@ -296,7 +296,7 @@ function generateRow(topic, key, value) {
 
 function createDynamicConfigTabs() {
   $.ajax({
-    url: apiUrl + "/config?detailed=true",
+    url: document.body.dataset.apiurl + "/config?detailed=true",
   })
     .done(function (data) {
       // Create the tabs for the advanced dynamic config topics

--- a/scripts/js/settings-api.js
+++ b/scripts/js/settings-api.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, setConfigValues: false, apiFailure: false, QRious: false */
+/* global utils:false, setConfigValues: false, apiFailure: false, QRious: false */
 
 var apiSessionsTable = null;
 var ownSessionID = null;
@@ -31,7 +31,7 @@ function renderBool(data, type) {
 $(function () {
   apiSessionsTable = $("#APISessionsTable").DataTable({
     ajax: {
-      url: apiUrl + "/auth/sessions",
+      url: document.body.dataset.apiurl + "/auth/sessions",
       type: "GET",
       dataSrc: "sessions",
     },
@@ -247,7 +247,7 @@ function deleteOneSession(id, len, ownSessionDelete) {
   // our own session is then triggered by the last successful deletion of
   // another session (ownSessionDelete == true, len == global deleted)
   $.ajax({
-    url: apiUrl + "/auth/session/" + id,
+    url: document.body.dataset.apiurl + "/auth/session/" + id,
     method: "DELETE",
   })
     .done(function () {
@@ -272,7 +272,7 @@ function deleteOneSession(id, len, ownSessionDelete) {
 
 function processWebServerConfig() {
   $.ajax({
-    url: apiUrl + "/config/webserver?detailed=true",
+    url: document.body.dataset.apiurl + "/config/webserver?detailed=true",
   })
     .done(function (data) {
       setConfigValues("webserver", "webserver", data.config.webserver);
@@ -291,7 +291,7 @@ function processWebServerConfig() {
 
 $("#modal-totp").on("shown.bs.modal", function () {
   $.ajax({
-    url: apiUrl + "/auth/totp",
+    url: document.body.dataset.apiurl + "/auth/totp",
   })
     .done(function (data) {
       TOTPdata = data.totp;
@@ -329,7 +329,7 @@ $("#modal-totp").on("shown.bs.modal", function () {
 var apppwhash = null;
 $("#modal-apppw").on("shown.bs.modal", function () {
   $.ajax({
-    url: apiUrl + "/auth/app",
+    url: document.body.dataset.apiurl + "/auth/app",
   })
     .done(function (data) {
       apppwhash = data.app.hash;
@@ -373,7 +373,7 @@ $("#apppw_clear").on("click", function () {
 
 function setAppPassword() {
   $.ajax({
-    url: apiUrl + "/config",
+    url: document.body.dataset.apiurl + "/config",
     type: "PATCH",
     dataType: "json",
     processData: false,
@@ -426,7 +426,7 @@ $("#totp_code").on("keyup", function () {
 
 function setTOTPSecret(secret) {
   $.ajax({
-    url: apiUrl + "/config",
+    url: document.body.dataset.apiurl + "/config",
     type: "PATCH",
     dataType: "json",
     processData: false,
@@ -478,7 +478,7 @@ $(document).ready(function () {
   processWebServerConfig();
   // Check if TOTP is enabled
   $.ajax({
-    url: apiUrl + "/auth",
+    url: document.body.dataset.apiurl + "/auth",
   }).done(function (data) {
     if (data.session.totp === false) $("#button-enable-totp").removeClass("hidden");
     else $("#button-disable-totp").removeClass("hidden");

--- a/scripts/js/settings-dhcp.js
+++ b/scripts/js/settings-dhcp.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, setConfigValues: false, apiFailure: false */
+/* global utils:false, setConfigValues: false, apiFailure: false */
 
 var dhcpLeaesTable = null,
   toasts = {};
@@ -32,7 +32,7 @@ function renderHostnameCLID(data, type) {
 $(function () {
   dhcpLeaesTable = $("#DHCPLeasesTable").DataTable({
     ajax: {
-      url: apiUrl + "/dhcp/leases",
+      url: document.body.dataset.apiurl + "/dhcp/leases",
       type: "GET",
       dataSrc: "leases",
     },
@@ -167,7 +167,7 @@ function delLease(ip) {
   toasts[ip] = utils.showAlert("info", "", "Deleting lease...", ip, null);
 
   $.ajax({
-    url: apiUrl + "/dhcp/leases/" + encodeURIComponent(ip),
+    url: document.body.dataset.apiurl + "/dhcp/leases/" + encodeURIComponent(ip),
     method: "DELETE",
   })
     .done(function (response) {
@@ -214,7 +214,7 @@ function fillDHCPhosts(data) {
 
 function processDHCPConfig() {
   $.ajax({
-    url: apiUrl + "/config/dhcp?detailed=true",
+    url: document.body.dataset.apiurl + "/config/dhcp?detailed=true",
   })
     .done(function (data) {
       fillDHCPhosts(data.config.dhcp.hosts);

--- a/scripts/js/settings-dns-records.js
+++ b/scripts/js/settings-dns-records.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Precord see LICENSE file for your rights under this license. */
 
-/* global utils: false, apiUrl: false, apiFailure:false, setConfigValues: false */
+/* global utils: false, apiFailure:false, setConfigValues: false */
 
 function hostsDomain(data) {
   // Split record in format IP NAME1 [NAME2 [NAME3 [NAME...]]]
@@ -156,7 +156,7 @@ function deleteRecord() {
 function delHosts(elem) {
   utils.disableAll();
   utils.showAlert("info", "", "Deleting DNS record...", elem);
-  const url = apiUrl + "/config/dns/hosts/" + encodeURIComponent(elem);
+  const url = document.body.dataset.apiurl + "/config/dns/hosts/" + encodeURIComponent(elem);
 
   $.ajax({
     url: url,
@@ -183,7 +183,7 @@ function delHosts(elem) {
 function delCNAME(elem) {
   utils.disableAll();
   utils.showAlert("info", "", "Deleting local CNAME record...", elem);
-  const url = apiUrl + "/config/dns/cnameRecords/" + encodeURIComponent(elem);
+  const url = document.body.dataset.apiurl + "/config/dns/cnameRecords/" + encodeURIComponent(elem);
 
   $.ajax({
     url: url,
@@ -216,7 +216,7 @@ $(document).ready(function () {
   $("#btnAdd-host").on("click", function () {
     utils.disableAll();
     const elem = $("#Hip").val() + " " + $("#Hdomain").val();
-    const url = apiUrl + "/config/dns/hosts/" + encodeURIComponent(elem);
+    const url = document.body.dataset.apiurl + "/config/dns/hosts/" + encodeURIComponent(elem);
     utils.showAlert("info", "", "Adding DNS record...", elem);
     $.ajax({
       url: url,
@@ -242,7 +242,8 @@ $(document).ready(function () {
     var elem = $("#Cdomain").val() + "," + $("#Ctarget").val();
     var ttlVal = parseInt($("#Cttl").val(), 10);
     if (isFinite(ttlVal) && ttlVal >= 0) elem += "," + ttlVal;
-    const url = apiUrl + "/config/dns/cnameRecords/" + encodeURIComponent(elem);
+    const url =
+      document.body.dataset.apiurl + "/config/dns/cnameRecords/" + encodeURIComponent(elem);
     utils.showAlert("info", "", "Adding DNS record...", elem);
     $.ajax({
       url: url,

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global applyCheckboxRadioStyle:false, setConfigValues: false, apiFailure: false, apiUrl: false */
+/* global applyCheckboxRadioStyle:false, setConfigValues: false, apiFailure: false */
 
 // Remove an element from an array (inline)
 function removeFromArray(arr, what) {
@@ -114,7 +114,7 @@ function updateDNSserversTextfield(upstreams, customServers) {
 
 function processDNSConfig() {
   $.ajax({
-    url: apiUrl + "/config/dns?detailed=true", // We need the detailed output to get the DNS server list
+    url: document.body.dataset.apiurl + "/config/dns?detailed=true", // We need the detailed output to get the DNS server list
   })
     .done(function (data) {
       // Initialize the DNS upstreams

--- a/scripts/js/settings-privacy.js
+++ b/scripts/js/settings-privacy.js
@@ -5,11 +5,11 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global setConfigValues: false, apiFailure: false, apiUrl: false */
+/* global setConfigValues: false, apiFailure: false */
 
 function getConfig() {
   $.ajax({
-    url: apiUrl + "/config/?detailed=true",
+    url: document.body.dataset.apiurl + "/config/?detailed=true",
   })
     .done(function (data) {
       setConfigValues("", "", data.config);

--- a/scripts/js/settings-system.js
+++ b/scripts/js/settings-system.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global apiFailure:false, apiUrl: false, Chart:false, THEME_COLORS:false, customTooltips:false, htmlLegendPlugin:false,doughnutTooltip:false, ChartDeferred:false, REFRESH_INTERVAL: false, utils: false */
+/* global apiFailure:false, Chart:false, THEME_COLORS:false, customTooltips:false, htmlLegendPlugin:false,doughnutTooltip:false, ChartDeferred:false, REFRESH_INTERVAL: false, utils: false */
 
 var hostinfoTimer = null;
 var cachePieChart = null;
@@ -83,7 +83,7 @@ function updateCachePie(data) {
 
 function updateHostInfo() {
   $.ajax({
-    url: apiUrl + "/info/host",
+    url: document.body.dataset.apiurl + "/info/host",
   })
     .done(function (data) {
       var host = data.host;
@@ -155,7 +155,7 @@ var metricsTimer = null;
 
 function updateMetrics() {
   $.ajax({
-    url: apiUrl + "/info/metrics",
+    url: document.body.dataset.apiurl + "/info/metrics",
   })
     .done(function (data) {
       var metrics = data.metrics;
@@ -196,7 +196,7 @@ function showQueryLoggingButton(state) {
 
 function getLoggingButton() {
   $.ajax({
-    url: apiUrl + "/config/dns/queryLogging",
+    url: document.body.dataset.apiurl + "/config/dns/queryLogging",
   })
     .done(function (data) {
       showQueryLoggingButton(data.config.dns.queryLogging);
@@ -214,7 +214,7 @@ $(".confirm-restartdns").confirm({
   title: "Confirmation required",
   confirm: function () {
     $.ajax({
-      url: apiUrl + "/action/restartdns",
+      url: document.body.dataset.apiurl + "/action/restartdns",
       type: "POST",
     }).fail(function (data) {
       apiFailure(data);
@@ -238,7 +238,7 @@ $(".confirm-flushlogs").confirm({
   title: "Confirmation required",
   confirm: function () {
     $.ajax({
-      url: apiUrl + "/action/flush/logs",
+      url: document.body.dataset.apiurl + "/action/flush/logs",
       type: "POST",
     }).fail(function (data) {
       apiFailure(data);
@@ -262,7 +262,7 @@ $(".confirm-flusharp").confirm({
   title: "Confirmation required",
   confirm: function () {
     $.ajax({
-      url: apiUrl + "/action/flush/arp",
+      url: document.body.dataset.apiurl + "/action/flush/arp",
       type: "POST",
     }).fail(function (data) {
       apiFailure(data);
@@ -292,7 +292,7 @@ $("#loggingButton").confirm({
     data.config.dns = {};
     data.config.dns.queryLogging = $("#loggingButton").data("state") !== "enabled";
     $.ajax({
-      url: apiUrl + "/config/dns/queryLogging",
+      url: document.body.dataset.apiurl + "/config/dns/queryLogging",
       type: "PATCH",
       dataType: "json",
       processData: false,
@@ -364,7 +364,7 @@ $(function () {
   });
 
   $.ajax({
-    url: apiUrl + "/network/gateway",
+    url: document.body.dataset.apiurl + "/network/gateway",
   })
     .done(function (data) {
       const gateway = data.gateway;

--- a/scripts/js/settings-teleporter.js
+++ b/scripts/js/settings-teleporter.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl: false */
+/* global utils:false */
 
 // Add event listener to import button
 document.getElementById("submit-import").addEventListener("click", function () {
@@ -37,7 +37,7 @@ function importZIP() {
   const formData = new FormData();
   formData.append("import", JSON.stringify(imports));
   formData.append("file", file);
-  fetch(apiUrl + "/teleporter", {
+  fetch(document.body.dataset.apiurl + "/teleporter", {
     method: "POST",
     body: formData,
     headers: { "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr("content") },
@@ -77,7 +77,7 @@ function importZIP() {
 // Inspired by https://stackoverflow.com/a/59576416/2087442
 $("#GETTeleporter").on("click", function () {
   $.ajax({
-    url: apiUrl + "/teleporter",
+    url: document.body.dataset.apiurl + "/teleporter",
     headers: { "X-CSRF-TOKEN": $('meta[name="csrf-token"]').attr("content") },
     method: "GET",
     xhrFields: {

--- a/scripts/js/settings.js
+++ b/scripts/js/settings.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global utils:false, apiUrl:false, apiFailure:false*/
+/* global utils:false, apiFailure:false*/
 
 $(function () {
   // Handle hiding of alerts
@@ -164,7 +164,7 @@ function saveSettings() {
 
   // Apply changes
   $.ajax({
-    url: apiUrl + "/config",
+    url: document.body.dataset.apiurl + "/config",
     method: "PATCH",
     dataType: "json",
     processData: false,

--- a/scripts/js/taillog.js
+++ b/scripts/js/taillog.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global moment: false, apiFailure: false, utils: false, REFRESH_INTERVAL: false, apiUrl: false */
+/* global moment: false, apiFailure: false, utils: false, REFRESH_INTERVAL: false */
 
 var nextID = 0;
 var lastPID = -1;
@@ -84,7 +84,7 @@ function getData() {
   }
 
   $.ajax({
-    url: apiUrl + "/logs/" + GETDict.file + "?nextID=" + nextID,
+    url: document.body.dataset.apiurl + "/logs/" + GETDict.file + "?nextID=" + nextID,
     timeout: 5000,
     method: "GET",
   })

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global moment:false, apiUrl: false, apiFailure: false, updateFtlInfo: false, NProgress:false, WaitMe:false */
+/* global moment:false, apiFailure: false, updateFtlInfo: false, NProgress:false, WaitMe:false */
 
 $(function () {
   // CSRF protection for AJAX requests, this has to be configured globally
@@ -331,7 +331,7 @@ function addFromQueryLog(domain, list) {
   // add Domain to List after Modal has faded in
   alertModal.one("shown.bs.modal", function () {
     $.ajax({
-      url: apiUrl + "/domains/" + list + "/exact",
+      url: document.body.dataset.apiurl + "/domains/" + list + "/exact",
       method: "post",
       dataType: "json",
       processData: false,
@@ -411,7 +411,10 @@ function checkMessages() {
     ? localStorage.getItem("hideNonfatalDnsmasqWarnings_chkbox") === "true"
     : false;
   $.ajax({
-    url: apiUrl + "/info/messages/count" + (ignoreNonfatal ? "?filter_dnsmasq_warnings=true" : ""),
+    url:
+      document.body.dataset.apiurl +
+      "/info/messages/count" +
+      (ignoreNonfatal ? "?filter_dnsmasq_warnings=true" : ""),
     method: "GET",
     dataType: "json",
   })
@@ -465,7 +468,7 @@ function changeBulkDeleteStates(table) {
 
 function doLogout(url) {
   $.ajax({
-    url: apiUrl + "/auth",
+    url: document.body.dataset.apiurl + "/auth",
     method: "DELETE",
   }).always(function () {
     globalThis.location = url;
@@ -640,7 +643,7 @@ let waitMe = null;
 function loadingOverlayTimeoutCallback(reloadAfterTimeout) {
   // Try to ping FTL to see if it finished restarting
   $.ajax({
-    url: apiUrl + "/info/login",
+    url: document.body.dataset.apiurl + "/info/login",
     method: "GET",
     cache: false,
     dataType: "json",


### PR DESCRIPTION
# What does this implement/fix?

Always use `document.body.dataset.apiurl` instead of the intermediate constant `apiUrl`

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/web/issues/3361 Fixes https://github.com/pi-hole/web/issues/3369

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `developmental` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.