### PR TITLE
Make DNSSEC icon conditional in Queries Log

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -612,14 +612,16 @@ $(function () {
 
       // Prefix colored DNSSEC icon to domain text
       var dnssecIcon = "";
-      dnssecIcon =
-        '<i class="mr-2 fa fa-fw ' +
-        dnssec.icon +
-        " " +
-        dnssec.color +
-        '" title="DNSSEC: ' +
-        dnssec.text +
-        '"></i>';
+      if (dnssec.color !== "") {
+        dnssecIcon =
+          '<i class="mr-2 fa fa-fw ' +
+          dnssec.icon +
+          " " +
+          dnssec.color +
+          '" title="DNSSEC: ' +
+          dnssec.text +
+          '"></i>';
+      }
 
       // Escape HTML in domain
       domain = dnssecIcon + utils.escapeHtml(domain);

--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -626,7 +626,7 @@ $(function () {
 
       // Prefix colored DNSSEC icon to domain text
       var dnssecIcon = "";
-      if (doDnssec !== false) {
+      if (doDnssec === true) {
         const dnssec = parseDNSSEC(data);
         dnssecIcon =
           '<i class="mr-2 fa fa-fw ' +

--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -26,6 +26,17 @@ var filters = [
   "reply",
   "dnssec",
 ];
+var doDnssec = false;
+
+// Check if pihole is validiting DNSSEC
+function getDnssecConfig() {
+  $.getJSON(
+    document.body.dataset.apiurl + "/config/dns/dnssec",
+    function (data) {
+        doDnssec = data.config.dns.dnssec;
+    }
+  );
+}
 
 function initDateRangePicker() {
   $("#querytime").daterangepicker(
@@ -498,6 +509,10 @@ function liveUpdate() {
 }
 
 $(function () {
+
+  // Do we want to show DNSSEC icons?
+  getDnssecConfig();
+
   // Do we want to filter queries?
   var GETDict = utils.parseQueryString();
 
@@ -588,7 +603,6 @@ $(function () {
     },
     rowCallback: function (row, data) {
       var querystatus = parseQueryStatus(data);
-      const dnssec = parseDNSSEC(data);
 
       if (querystatus.icon !== false) {
         $("td:eq(1)", row).html(
@@ -612,7 +626,8 @@ $(function () {
 
       // Prefix colored DNSSEC icon to domain text
       var dnssecIcon = "";
-      if (dnssec.color !== "") {
+      if (doDnssec !== false) {
+        const dnssec = parseDNSSEC(data);
         dnssecIcon =
           '<i class="mr-2 fa fa-fw ' +
           dnssec.icon +

--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -26,14 +26,14 @@ var filters = [
   "reply",
   "dnssec",
 ];
-var doDnssec = false;
+var doDNSSEC = false;
 
 // Check if pihole is validiting DNSSEC
 function getDnssecConfig() {
   $.getJSON(
     document.body.dataset.apiurl + "/config/dns/dnssec",
     function (data) {
-        doDnssec = data.config.dns.dnssec;
+        doDNSSEC = data.config.dns.dnssec;
     }
   );
 }
@@ -626,7 +626,7 @@ $(function () {
 
       // Prefix colored DNSSEC icon to domain text
       var dnssecIcon = "";
-      if (doDnssec === true) {
+      if (doDNSSEC === true) {
         const dnssec = parseDNSSEC(data);
         dnssecIcon =
           '<i class="mr-2 fa fa-fw ' +

--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -32,8 +32,8 @@ var doDNSSEC = false;
 function getDnssecConfig() {
   $.getJSON(
     document.body.dataset.apiurl + "/config/dns/dnssec",
-    function (data) {
-        doDNSSEC = data.config.dns.dnssec;
+    function(data) {
+      doDNSSEC = data.config.dns.dnssec;
     }
   );
 }
@@ -509,7 +509,6 @@ function liveUpdate() {
 }
 
 $(function () {
-
   // Do we want to show DNSSEC icons?
   getDnssecConfig();
 
@@ -521,7 +520,7 @@ $(function () {
       var element = filters[sel];
       $("#" + element + "_filter").select2({
         width: "100%",
-        tags: sel < 3, // Only the first three are allowed to freely specify input
+        tags: sel < 4, // Only the first four (client(IP/name), domain, upstream) are allowed to freely specify input
         placeholder: "Select...",
         allowClear: true,
       });

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1587,7 +1587,7 @@ textarea.field-sizing-content {
 /* Used in query log page */
 td.dnssec {
   padding-inline-start: 2.25em !important;
-  text-indent: -1.25em
+  text-indent: -1.25em;
 }
 td.dnssec i {
   text-indent: 0;

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1583,3 +1583,13 @@ textarea.field-sizing-content {
   line-height: 0.5em;
   font-size: 1.7em;
 }
+
+/* Used in query log page */
+td.dnssec {
+  padding-inline-start: 2.25em !important;
+  text-indent: -1.25em
+}
+td.dnssec i {
+  text-indent: 0;
+  margin-left: -0.5rem;
+}


### PR DESCRIPTION
---

**What does this PR aim to accomplish?:**

Avoid emitting the DNSSEC icon in Domain column if DNSSEC is not being used/tracked

**How does this PR accomplish the above?:**

Check for (dnssec.color !== "") which is the same convention used elsewhere in the script

![image](https://github.com/user-attachments/assets/26746d85-48e3-4e52-b13e-eb13899535db)
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
