### PR TITLE
Fix console warning when no password set

### DIFF
--- a/scripts/js/logout.js
+++ b/scripts/js/logout.js
@@ -11,7 +11,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const logoutButton = document.getElementById("logout-button");
   const logoutUrl = document.body.dataset.webhome + "login";
 
-  logoutButton.addEventListener("click", event => {
+  logoutButton?.addEventListener("click", event => {
     event.preventDefault();
     utils.doLogout(logoutUrl);
   });


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

Noticed while starting a container with web password explicitly set to empty.

![image](https://github.com/user-attachments/assets/e8e519ef-9558-4ced-8f5a-692b1e57f43a)

Ensures that `logoutButton` exists before chaining the `addEventListener` method

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_