### PR TITLE
Use the same default interface used by FTL if none is set in pihole.toml

### DIFF
--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -102,6 +102,12 @@ function fillDNSupstreams(value, servers) {
 }
 
 function setInterfaceName(name) {
+  // If dns.interface is empty in pihole.toml, we show "eth0"
+  // (same default value used by FTL)
+  if (name === "") {
+    name = "eth0";
+  }
+
   $("#interface-name-1").text(name);
   $("#interface-name-2").text(name);
 }


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fixes an issue where the web interface shows an empty interface:

![image](https://github.com/user-attachments/assets/9bd38c80-01ee-4d70-9004-794be0a02f42)


### How does this PR accomplish the above?

The Core PR https://github.com/pi-hole/pi-hole/pull/6216, sets `eth0` during the installation minimizing the chance of this happening, but this only fixes new installations and the issue still happens if an user manually sets an empty interface in `pihole.toml`.

This PR shows the default interface (`eth0`, same used by FTL) if the API returns an empty string.


### Link documentation PRs if any are needed to support this PR:

none

---

**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
