### PR TITLE
Use mg.script_name to retrieve the scriptname

### DIFF
--- a/scripts/lua/header.lp
+++ b/scripts/lua/header.lp
@@ -14,7 +14,8 @@ webhome = pihole.webhome()
 theme = pihole.webtheme()
 
 -- Get name of script by matching whatever is after the last "/" in the URI
-scriptname = mg.request_info.request_uri:match(webhome.."(.*)$")
+scriptname = mg.script_name:match(".*/(.*).lp$"):gsub("-", "/")
+
 -- Fall back to "index.lp" if no match is found (e.g. when accessing the root)
 if scriptname == nil or string.len(scriptname) == 0 then scriptname = "index.lp" end
 


### PR DESCRIPTION
### What does this PR aim to accomplish?

The value of `mg.request_info.request_uri` is wrong when `webserver.paths.prefix` is used, resulting in an empty `scriptname` and breaking some things in the web interface.

This PR changes the function used to retrieve the script name, using a different source.

### How does this PR accomplish the above?

Using `mg.script_name` the value is independent from webhome or prefix.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
