### PR TITLE
Fix DataTables warning message in Network page

### DIFF
--- a/scripts/js/network.js
+++ b/scripts/js/network.js
@@ -249,8 +249,8 @@ $(() => {
         },
       },
       { data: "numQueries", width: "9%", render: $.fn.dataTable.render.text() },
-      { data: "", width: "6%", orderable: false },
-      { data: "", width: "6%", orderable: false },
+      { data: null, width: "6%", orderable: false },
+      { data: null, width: "6%", orderable: false },
       { data: "ips[].name", visible: false, class: "hide" },
     ],
 


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fix DataTables warning message:
```
DataTables warning: table id=network-entries - Requested unknown parameter '' for row 0, column 7.
```



Fix #3471


### How does this PR accomplish the above?

Use `null` instead of an empty string to define columns initially empty

**Link documentation PRs if any are needed to support this PR:**

<!--- Replace this with a link to your documentation PR  -->

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [ ] I have read the above and my PR is ready for review. *Check this box to confirm*
