### PR TITLE
Use the same interface name used by FTL in DNS Settings page

### DIFF
--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -102,10 +102,20 @@ function fillDNSupstreams(value, servers) {
 }
 
 function setInterfaceName(name) {
-  // If dns.interface is empty in pihole.toml, we show "eth0"
+  // If dns.interface is empty in pihole.toml, we use the first interface
   // (same default value used by FTL)
   if (name === "") {
-    name = "eth0";
+    $.ajax({
+      url: document.body.dataset.apiurl + "/network/gateway",
+      async: false,
+    })
+      .done(data => {
+        name = data.gateway[0].interface;
+      })
+      .fail(data => {
+        apiFailure(data);
+        name = "not found";
+      });
   }
 
   $("#interface-name-1").text(name);


### PR DESCRIPTION
### What does this PR aim to accomplish?

If `dns.interface` is empty in pihole.toml we use the first interface returned by `network/gateway` endpoint, just like FTL.

Complement of https://github.com/pi-hole/web/pull/3436 and https://github.com/pi-hole/FTL/pull/2456

### How does this PR accomplish the above?

Use the value of `gateway[0].interface`.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
