### PR TITLE
Add rel="noreferrer" to external hyperlinks

### DIFF
--- a/groups-domains.lp
+++ b/groups-domains.lp
@@ -75,7 +75,7 @@ mg.include('scripts/lua/header_authenticated.lp','r')
                                     </div>
                                     <div class="form-group">
                                         <strong>Hint:</strong> Need help to write a proper RegEx rule? Have a look at our online
-                                        <a href="https://docs.pi-hole.net/ftldns/regex/tutorial" rel="noopener" target="_blank">
+                                        <a href="https://docs.pi-hole.net/ftldns/regex/tutorial" rel="noopener noreferrer" target="_blank">
                                             regular expressions tutorial</a>.
                                     </div>
                                 </div>

--- a/login.lp
+++ b/login.lp
@@ -72,7 +72,7 @@ mg.include('scripts/lua/header.lp','r')
                             </div>
                             <div class="box-body">
                                 <p>Your Pi-hole has two-factor authentication enabled. You have to
-                                    enter a valid <a href="https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm" rel="noopener" target="_blank">TOTP</a>
+                                    enter a valid <a href="https://en.wikipedia.org/wiki/Time-based_One-time_Password_algorithm" rel="noopener noreferrer" target="_blank">TOTP</a>
                                     token in addition to your password. You see this message because your
                                     token was incorrect or has already expired.</p>
                             </div>
@@ -104,9 +104,9 @@ mg.include('scripts/lua/header.lp','r')
             </div>
             <!-- /.login-card-body -->
             <div class="login-footer" style="margin-top: 15px; display: flex; justify-content: space-between;">
-                <a class="btn btn-default btn-sm" role="button" href="https://docs.pi-hole.net/" rel="noopener" target="_blank"><i class="fas fa-question-circle"></i> Documentation</a>
-                <a class="btn btn-default btn-sm" role="button" href="https://github.com/pi-hole/" rel="noopener" target="_blank"><i class="fab fa-github"></i> GitHub</a>
-                <a class="btn btn-default btn-sm" role="button" href="https://discourse.pi-hole.net/" rel="noopener" target="_blank"><i class="fab fa-discourse"></i> Pi-hole Discourse</a>
+                <a class="btn btn-default btn-sm" role="button" href="https://docs.pi-hole.net/" rel="noopener noreferrer" target="_blank"><i class="fas fa-question-circle"></i> Documentation</a>
+                <a class="btn btn-default btn-sm" role="button" href="https://github.com/pi-hole/" rel="noopener noreferrer" target="_blank"><i class="fab fa-github"></i> GitHub</a>
+                <a class="btn btn-default btn-sm" role="button" href="https://discourse.pi-hole.net/" rel="noopener noreferrer" target="_blank"><i class="fab fa-discourse"></i> Pi-hole Discourse</a>
             </div>
         </div>
     </section>
@@ -114,7 +114,7 @@ mg.include('scripts/lua/header.lp','r')
 
 <div class="login-donate">
     <div class="text-center" style="font-size:125%">
-        <strong><a href="https://pi-hole.net/donate/" rel="noopener" target="_blank"><i class="fa fa-heart text-red"></i> Donate</a></strong> if you found this useful.
+        <strong><a href="https://pi-hole.net/donate/" rel="noopener noreferrer" target="_blank"><i class="fa fa-heart text-red"></i> Donate</a></strong> if you found this useful.
     </div>
 </div>
 <script src="<?=pihole.fileversion('scripts/js/footer.js')?>"></script>

--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -517,7 +517,7 @@ function updateVersionInfo() {
               v.url +
               "/" +
               localVersion +
-              '" rel="noopener" target="_blank">' +
+              '" rel="noopener noreferrer" target="_blank">' +
               localVersion +
               "</a>";
             if (versionCompare(v.local, v.remote) === -1) {
@@ -548,7 +548,7 @@ function updateVersionInfo() {
               v.url +
               "/" +
               localVersion +
-              '" rel="noopener" target="_blank">' +
+              '" rel="noopener noreferrer" target="_blank">' +
               localVersion +
               "</a>";
           }
@@ -563,7 +563,7 @@ function updateVersionInfo() {
               localVersion +
               '&nbsp&middot; <a class="lookatme" lookatme-text="Update available!" href="' +
               v.url +
-              '" rel="noopener" target="_blank">Update available!</a></li>'
+              '" rel="noopener noreferrer" target="_blank">Update available!</a></li>'
           );
           // if at least one component can be updated, display the update-hint footer
           updateAvailable = true;
@@ -575,11 +575,11 @@ function updateVersionInfo() {
 
     if (dockerUpdate)
       $("#update-hint").html(
-        'To install updates, <a href="https://github.com/pi-hole/docker-pi-hole#upgrading-persistence-and-customizations" rel="noopener" target="_blank">replace this old container with a fresh upgraded image</a>.'
+        'To install updates, <a href="https://github.com/pi-hole/docker-pi-hole#upgrading-persistence-and-customizations" rel="noopener noreferrer" target="_blank">replace this old container with a fresh upgraded image</a>.'
       );
     else if (updateAvailable)
       $("#update-hint").html(
-        'To install updates, run <code><a href="https://docs.pi-hole.net/main/update/" rel="noopener" target="_blank">pihole -up</a></code>.'
+        'To install updates, run <code><a href="https://docs.pi-hole.net/main/update/" rel="noopener noreferrer" target="_blank">pihole -up</a></code>.'
       );
 
     clearTimeout(versionTimer);

--- a/scripts/lua/footer.lp
+++ b/scripts/lua/footer.lp
@@ -52,7 +52,7 @@ end
     <footer class="main-footer">
         <div class="row row-centered text-center">
             <div class="col-xs-12 col-sm-6">
-                <strong><a href="https://pi-hole.net/donate/" rel="noopener" target="_blank"><i class="fa fa-heart text-red"></i> Donate</a></strong> if you found this useful.
+                <strong><a href="https://pi-hole.net/donate/" rel="noopener noreferrer" target="_blank"><i class="fa fa-heart text-red"></i> Donate</a></strong> if you found this useful.
             </div>
         </div>
 

--- a/scripts/lua/header_authenticated.lp
+++ b/scripts/lua/header_authenticated.lp
@@ -28,7 +28,7 @@ mg.include('header.lp','r')
     <div>
         <input type="checkbox" id="js-hide">
         <div class="js-warn" id="js-warn-exit"><h1>JavaScript Is Disabled</h1><p>JavaScript is required for the site to function.</p>
-            <p>To learn how to enable JavaScript click <a href="https://www.enable-javascript.com/" rel="noopener" target="_blank">here</a></p><label for="js-hide">Close</label>
+            <p>To learn how to enable JavaScript click <a href="https://www.enable-javascript.com/" rel="noopener noreferrer" target="_blank">here</a></p><label for="js-hide">Close</label>
         </div>
     </div>
     <!-- /JS Warning -->
@@ -76,14 +76,14 @@ mg.include('header.lp','r')
                             <li class="user-body" id="advanced-info" style="display:none;"></li>
                             <!-- Menu Footer -->
                             <li class="user-footer">
-                                <a class="btn-link" href="https://pi-hole.net/" rel="noopener" target="_blank">
+                                <a class="btn-link" href="https://pi-hole.net/" rel="noopener noreferrer" target="_blank">
                                     <? mg.include('../../img/logo-bw.svg', 'r') ?>
                                     Pi-hole Website
                                 </a>
-                                <a class="btn-link" href="https://docs.pi-hole.net/" rel="noopener" target="_blank"><i class="fa-fw menu-icon fa-solid fa-circle-question"></i> Documentation</a>
-                                <a class="btn-link" href="https://discourse.pi-hole.net/" rel="noopener" target="_blank"><i class="fa-fw menu-icon fab fa-discourse"></i> Pi-hole Discourse</a>
-                                <a class="btn-link" href="https://github.com/pi-hole" rel="noopener" target="_blank"><i class="fa-fw menu-icon fab fa-github"></i> GitHub</a>
-                                <a class="btn-link" href="https://discourse.pi-hole.net/c/announcements/5" rel="noopener" target="_blank"><i class="fa-fw menu-icon fa-solid fa-rocket"></i> Pi-hole Releases</a>
+                                <a class="btn-link" href="https://docs.pi-hole.net/" rel="noopener noreferrer" target="_blank"><i class="fa-fw menu-icon fa-solid fa-circle-question"></i> Documentation</a>
+                                <a class="btn-link" href="https://discourse.pi-hole.net/" rel="noopener noreferrer" target="_blank"><i class="fa-fw menu-icon fab fa-discourse"></i> Pi-hole Discourse</a>
+                                <a class="btn-link" href="https://github.com/pi-hole" rel="noopener noreferrer" target="_blank"><i class="fa-fw menu-icon fab fa-github"></i> GitHub</a>
+                                <a class="btn-link" href="https://discourse.pi-hole.net/c/announcements/5" rel="noopener noreferrer" target="_blank"><i class="fa-fw menu-icon fa-solid fa-rocket"></i> Pi-hole Releases</a>
                                 <? if pihole.needLogin() then ?>
                                 <a class="btn-link" href="#" id="logout-button"><i class="fa-fw menu-icon fa-solid fa-arrow-right-from-bracket"></i> Log out</a>
                                 <? end ?>

--- a/scripts/lua/sidebar.lp
+++ b/scripts/lua/sidebar.lp
@@ -258,7 +258,7 @@
                 <!-- Donate button -->
                 <li class="header text-uppercase">Donate</li>
                 <li class="menu-donate">
-                    <a href="https://pi-hole.net/donate/" rel="noopener" target="_blank">
+                    <a href="https://pi-hole.net/donate/" rel="noopener noreferrer" target="_blank">
                         <i class="fas fa-fw menu-icon fa-donate"></i> <span>Donate</span>
                     </a>
                 </li>

--- a/settings-api.lp
+++ b/settings-api.lp
@@ -102,7 +102,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                 </div>
                 <div class="row">
                     <div class="col-md-12">
-                        <p><strong>Important</strong>:<br>Those input fields accept regex entries only.<br>Please refer to  <a href="https://docs.pi-hole.net/regex/tutorial/" rel="noopener" target="_blank">our guide</a> how to construct valid regex entries.</p>
+                        <p><strong>Important</strong>:<br>Those input fields accept regex entries only.<br>Please refer to  <a href="https://docs.pi-hole.net/regex/tutorial/" rel="noopener noreferrer" target="_blank">our guide</a> how to construct valid regex entries.</p>
                     </div>
                 </div>
             </div>

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -99,7 +99,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                             rate-limited clients are short-circuited at the same time.</p>
                         <p>Rate-limiting may be disabled altogether by setting both
                             values to zero. See
-                            <a href="https://docs.pi-hole.net/ftldns/configfile/#rate_limit" rel="noopener" target="_blank">our documentation</a>
+                            <a href="https://docs.pi-hole.net/ftldns/configfile/#rate_limit" rel="noopener noreferrer" target="_blank">our documentation</a>
                             for further details.</p>
                     </div>
                 </div>
@@ -144,7 +144,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                                     in your router!) they are safe to use.</p>
                             </div>
                         </div>
-                        <p>See <a href="https://docs.pi-hole.net/ftldns/interfaces/" rel="noopener" target="_blank">our documentation</a> for further technical details.</p>
+                        <p>See <a href="https://docs.pi-hole.net/ftldns/interfaces/" rel="noopener noreferrer" target="_blank">our documentation</a> for further technical details.</p>
                     </div>
                 </div>
             </div>
@@ -173,7 +173,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                             <p class="help-block">All reverse lookups for private IP ranges (i.e., <code>192.168.0.x/24</code>, etc.)
                                 which are not found in <code>/etc/hosts</code> or the DHCP leases are answered
                                 with "no such domain" rather than being forwarded upstream. The set
-                                of prefixes affected is the list given in <a href="https://tools.ietf.org/html/rfc6303">RFC6303</a>.</p>
+                                of prefixes affected is the list given in <a href="https://tools.ietf.org/html/rfc6303" rel="noopener noreferrer" target="_blank">RFC6303</a>.</p>
                                 <p><strong>Important:</strong><br>Enabling these two options may increase your privacy,
                                 but may also prevent you from being able to access local hostnames if the Pi-hole is not used as DHCP server.
                                 Make sure you have set up conditional forwarding in this case.</p>
@@ -189,7 +189,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                                 Use an upstream DNS server which supports DNSSEC when activating DNSSEC. Note that
                                 the size of your log might increase significantly
                                 when enabling DNSSEC. A DNSSEC resolver test can be found
-                                <a href="https://dnssec.vs.uni-due.de/" rel="noopener" target="_blank">here</a>.</p>
+                                <a href="https://dnssec.vs.uni-due.de/" rel="noopener noreferrer" target="_blank">here</a>.</p>
                         </div>
                     </div>
                 </div>
@@ -219,7 +219,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                             whereas an even wider network of 10.0.0.1 - 10.255.255.255 results in <code>10.0.0.0/8</code>.
                             Setting up IPv6 ranges is exactly similar to setting up IPv4 here and fully supported.
                             Feel free to reach out to us on our
-                            <a href="https://discourse.pi-hole.net" rel="noopener" target="_blank">Discourse forum</a>
+                            <a href="https://discourse.pi-hole.net" rel="noopener noreferrer" target="_blank">Discourse forum</a>
                             in case you need any assistance setting up local host name resolution for your particular system.</p>
                         <p>You can also specify a local domain name (like <code>fritz.box</code>) to ensure queries to
                             devices ending in your local domain name will not leave your network, however, this is optional.

--- a/settings-system.lp
+++ b/settings-system.lp
@@ -191,7 +191,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                         </table> -->
                     </div>
                     <div class="col-lg-12">
-                        See also our <a href="https://docs.pi-hole.net/ftldns/dns-cache/" rel="noopener" target="_blank">DNS cache documentation</a>.<br>&nbsp;
+                        See also our <a href="https://docs.pi-hole.net/ftldns/dns-cache/" rel="noopener noreferrer" target="_blank">DNS cache documentation</a>.<br>&nbsp;
                     </div>
                     <div class="col-lg-12" id="cache-metrics-chart">
                         <div style="width:50%">


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This change ensures that the browser does not send the HTTP referer header when navigating to external sites, which can help prevent leaking information such as the internal Pi-hole URL, thereby improving user privacy.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
