### PR TITLE
Remove superfluous settings-level-expert class

### DIFF
--- a/settings-all.lp
+++ b/settings-all.lp
@@ -13,7 +13,7 @@ mg.include('scripts/lua/header_authenticated.lp','r')
 PageTitle = "All Settings"
 mg.include('scripts/lua/settings_header.lp','r')
 ?>
-<div class="row settings-level-expert d-none" id="advanced-content">
+<div class="row" id="advanced-content">
     <div class="overlay" id="advanced-overlay">
         <i class="fa fa-sync fa-spin"></i>
     </div>
@@ -28,7 +28,7 @@ mg.include('scripts/lua/settings_header.lp','r')
         <!-- dynamically filled with content -->
     </div>
 
-    <div class="col-sm-12 settings-level-expert d-none save-button-container">
+    <div class="col-sm-12 save-button-container">
         <button type="button" class="btn btn-primary save-button"><i class="fa-solid fa-fw fa-floppy-disk"></i>&nbsp;Save & Apply</button>
     </div>
 </div>

--- a/settings-system.lp
+++ b/settings-system.lp
@@ -185,7 +185,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                                 </tr>
                             </tbody>
                         </table>
-<!--                    <table class="table table-striped table-bordered nowrap settings-level-expert d-none">
+<!--                    <table class="table table-striped table-bordered nowrap">
                             <tbody id="dns-cache-table">
                             </tbody>
                         </table> -->
@@ -230,7 +230,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                                     <th scope="row">Unanswered queries:</th>
                                     <td id="sysinfo-dns-replies-unanswered">&nbsp;</td>
                                 </tr>
-                                <tr class="settings-level-expert d-none">
+                                <tr>
                                     <th scope="row">Authoritative replies:</th>
                                     <td id="sysinfo-dns-replies-auth">&nbsp;</td>
                                 </tr>
@@ -260,7 +260,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                     <div class="col-xs-12 col-md-6 col-lg-3">
                         <button type="button" class="btn btn-danger confirm-flusharp btn-block button-pad destructive_action" disabled>Flush network table</button>
                     </div>
-                    <div class="col-xs-12 col-md-6 col-lg-3 settings-level-expert d-none">
+                    <div class="col-xs-12 col-md-6 col-lg-3">
                         <button type="button" class="btn btn-danger confirm-flushlogs btn-block button-pad destructive_action" disabled>Flush logs (last 24 hours)</button>
                     </div>
                 </div>


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Removes `settings-level-expert` classes where we don't need them. In `settings-system` they are removed because a parent element is hidden already due to `settings-level-expert`. In `settings-all` it's removed because this page can only be accessed in expert mode - no need to hide individual elements.

This ports suggestions from https://github.com/pi-hole/web/pull/3487

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
