### PR TITLE
Add some color to gravity output

### DIFF
--- a/scripts/js/gravity.js
+++ b/scripts/js/gravity.js
@@ -85,16 +85,21 @@ function parseLines(ta, str) {
       ta.html(ta.html().substring(0, ta.html().lastIndexOf("\n")));
     }
 
-    // Replace ANSI escape codes with HTML tags
-    line = line.replaceAll("[0m", "</span>"); //COL_NC
-    line = line.replaceAll("[1m", '<span class="text-bold">'); //COL_BOLD
-    line = line.replaceAll("[90m", '<span class="log-gray">'); //COL_GRAY
-    line = line.replaceAll("[91m", '<span class="log-red">'); //COL_RED
-    line = line.replaceAll("[32m", '<span class="log-green">'); //COL_GREEN
-    line = line.replaceAll("[33m", '<span class="log-yellow">'); //COL_YELLOW
-    line = line.replaceAll("[94m", '<span class="log-blue">'); //COL_BLUE
-    line = line.replaceAll("[95m", '<span class="log-purple">'); //COL_PURPLE
-    line = line.replaceAll("[96m", '<span class="log-cyan">'); //COL_CYAN
+    // Track the number of opening spans
+    let spanCount = 0;
+
+    // Replace ANSI escape codes with HTML tags and count opening spans
+    line = line.replaceAll("[1m", () => { spanCount++; return '<span class="text-bold">'; }); //COL_BOLD
+    line = line.replaceAll("[90m", () => { spanCount++; return '<span class="log-gray">'; }); //COL_GRAY
+    line = line.replaceAll("[91m", () => { spanCount++; return '<span class="log-red">'; }); //COL_RED
+    line = line.replaceAll("[32m", () => { spanCount++; return '<span class="log-green">'; }); //COL_GREEN
+    line = line.replaceAll("[33m", () => { spanCount++; return '<span class="log-yellow">'; }); //COL_YELLOW
+    line = line.replaceAll("[94m", () => { spanCount++; return '<span class="log-blue">'; }); //COL_BLUE
+    line = line.replaceAll("[95m", () => { spanCount++; return '<span class="log-purple">'; }); //COL_PURPLE
+    line = line.replaceAll("[96m", () => { spanCount++; return '<span class="log-cyan">'; }); //COL_CYAN
+
+    // Replace [0m with the appropriate number of closing spans
+    line = line.replaceAll("[0m", "</span>".repeat(spanCount)); //COL_NC
 
     // Append the new text to the end of the output
     ta.append(line);

--- a/scripts/js/gravity.js
+++ b/scripts/js/gravity.js
@@ -90,26 +90,39 @@ function parseLines(ta, str) {
 
     // Mapping of ANSI escape codes to their corresponding CSS class names.
     const ansiMappings = {
-      "\[1m": "text-bold", //COL_BOLD
-      "\[90m": "log-gray", //COL_GRAY
-      "\[91m": "log-red", //COL_RED
-      "\[32m": "log-green", //COL_GREEN
-      "\[33m": "log-yellow", //COL_YELLOW
-      "\[94m": "log-blue", //COL_BLUE
-      "\[95m": "log-purple", //COL_PURPLE
-      "\[96m": "log-cyan" //COL_CYAN
+      "\u001B[1m": "text-bold", //COL_BOLD
+      "\u001B[90m": "log-gray", //COL_GRAY
+      "\u001B[91m": "log-red", //COL_RED
+      "\u001B[32m": "log-green", //COL_GREEN
+      "\u001B[33m": "log-yellow", //COL_YELLOW
+      "\u001B[94m": "log-blue", //COL_BLUE
+      "\u001B[95m": "log-purple", //COL_PURPLE
+      "\u001B[96m": "log-cyan", //COL_CYAN
     };
 
-    // Replace ANSI escape codes with HTML tags and count opening spans
-    for (const [ansiCode, cssClass] of Object.entries(ansiMappings)) {
-      line = line.replaceAll(ansiCode, () => {
-        spanCount++;
-        return `<span class="${cssClass}">`;
-      });
-    }
+    // Create a regex that matches all ANSI codes (including reset)
+    /* eslint-disable-next-line no-control-regex */
+    const ansiRegex = /(\u001B\[(?:1|90|91|32|33|94|95|96|0)m)/g;
 
-    // Replace [0m with the appropriate number of closing spans
-    line = line.replaceAll("[0m", "</span>".repeat(spanCount)); //COL_NC
+    // Process the line sequentially, replacing ANSI codes with their corresponding HTML spans
+    // we use a counter to keep track of how many spans are open and close the correct number of spans when we encounter a reset code
+    /* eslint-disable-next-line unicorn/prefer-string-replace-all */
+    line = line.replace(ansiRegex, match => {
+      if (match === "\u001B[0m") {
+        // Reset/close all open spans
+        const closingTags = "</span>".repeat(spanCount);
+        spanCount = 0;
+        return closingTags;
+      }
+
+      if (ansiMappings[match]) {
+        // Opening span
+        spanCount++;
+        return `<span class="${ansiMappings[match]}">`;
+      }
+
+      return match; // Return unchanged if not recognized
+    });
 
     // Append the new text to the end of the output
     ta.append(line);

--- a/scripts/js/gravity.js
+++ b/scripts/js/gravity.js
@@ -89,6 +89,7 @@ function parseLines(ta, str) {
     let spanCount = 0;
 
     // Replace ANSI escape codes with HTML tags and count opening spans
+    /* eslint-disable prettier/prettier */
     line = line.replaceAll("[1m", () => { spanCount++; return '<span class="text-bold">'; }); //COL_BOLD
     line = line.replaceAll("[90m", () => { spanCount++; return '<span class="log-gray">'; }); //COL_GRAY
     line = line.replaceAll("[91m", () => { spanCount++; return '<span class="log-red">'; }); //COL_RED
@@ -97,6 +98,7 @@ function parseLines(ta, str) {
     line = line.replaceAll("[94m", () => { spanCount++; return '<span class="log-blue">'; }); //COL_BLUE
     line = line.replaceAll("[95m", () => { spanCount++; return '<span class="log-purple">'; }); //COL_PURPLE
     line = line.replaceAll("[96m", () => { spanCount++; return '<span class="log-cyan">'; }); //COL_CYAN
+    /* eslint-enable prettier/prettier */
 
     // Replace [0m with the appropriate number of closing spans
     line = line.replaceAll("[0m", "</span>".repeat(spanCount)); //COL_NC

--- a/scripts/js/gravity.js
+++ b/scripts/js/gravity.js
@@ -88,17 +88,25 @@ function parseLines(ta, str) {
     // Track the number of opening spans
     let spanCount = 0;
 
+    // Mapping of ANSI escape codes to their corresponding CSS class names.
+    const ansiMappings = {
+      "\[1m": "text-bold", //COL_BOLD
+      "\[90m": "log-gray", //COL_GRAY
+      "\[91m": "log-red", //COL_RED
+      "\[32m": "log-green", //COL_GREEN
+      "\[33m": "log-yellow", //COL_YELLOW
+      "\[94m": "log-blue", //COL_BLUE
+      "\[95m": "log-purple", //COL_PURPLE
+      "\[96m": "log-cyan" //COL_CYAN
+    };
+
     // Replace ANSI escape codes with HTML tags and count opening spans
-    /* eslint-disable prettier/prettier */
-    line = line.replaceAll("[1m", () => { spanCount++; return '<span class="text-bold">'; }); //COL_BOLD
-    line = line.replaceAll("[90m", () => { spanCount++; return '<span class="log-gray">'; }); //COL_GRAY
-    line = line.replaceAll("[91m", () => { spanCount++; return '<span class="log-red">'; }); //COL_RED
-    line = line.replaceAll("[32m", () => { spanCount++; return '<span class="log-green">'; }); //COL_GREEN
-    line = line.replaceAll("[33m", () => { spanCount++; return '<span class="log-yellow">'; }); //COL_YELLOW
-    line = line.replaceAll("[94m", () => { spanCount++; return '<span class="log-blue">'; }); //COL_BLUE
-    line = line.replaceAll("[95m", () => { spanCount++; return '<span class="log-purple">'; }); //COL_PURPLE
-    line = line.replaceAll("[96m", () => { spanCount++; return '<span class="log-cyan">'; }); //COL_CYAN
-    /* eslint-enable prettier/prettier */
+    for (const [ansiCode, cssClass] of Object.entries(ansiMappings)) {
+      line = line.replaceAll(ansiCode, () => {
+        spanCount++;
+        return `<span class="${cssClass}">`;
+      });
+    }
 
     // Replace [0m with the appropriate number of closing spans
     line = line.replaceAll("[0m", "</span>".repeat(spanCount)); //COL_NC

--- a/scripts/js/gravity.js
+++ b/scripts/js/gravity.js
@@ -85,9 +85,16 @@ function parseLines(ta, str) {
       ta.html(ta.html().substring(0, ta.html().lastIndexOf("\n")));
     }
 
-    // Add some color to the text
-    line = line.replaceAll("[✓]", '[<span class="log-green">✓</span>]');
-    line = line.replaceAll("[✗]", '[<span class="log-red">✗</span>]');
+    // Replace ANSI escape codes with HTML tags
+    line = line.replaceAll("[0m", "</span>"); //COL_NC
+    line = line.replaceAll("[1m", '<span class="text-bold">'); //COL_BOLD
+    line = line.replaceAll("[90m", '<span class="log-gray">'); //COL_GRAY
+    line = line.replaceAll("[91m", '<span class="log-red">'); //COL_RED
+    line = line.replaceAll("[32m", '<span class="log-green">'); //COL_GREEN
+    line = line.replaceAll("[33m", '<span class="log-yellow">'); //COL_YELLOW
+    line = line.replaceAll("[94m", '<span class="log-blue">'); //COL_BLUE
+    line = line.replaceAll("[95m", '<span class="log-purple">'); //COL_PURPLE
+    line = line.replaceAll("[96m", '<span class="log-cyan">'); //COL_CYAN
 
     // Append the new text to the end of the output
     ta.append(line);

--- a/scripts/js/gravity.js
+++ b/scripts/js/gravity.js
@@ -82,8 +82,12 @@ function parseLines(ta, str) {
       line = line.replaceAll("\r[K", "\n").replaceAll("\r", "\n");
 
       // Last line from the textarea will be overwritten, so we remove it
-      ta.text(ta.text().substring(0, ta.text().lastIndexOf("\n")));
+      ta.html(ta.html().substring(0, ta.html().lastIndexOf("\n")));
     }
+
+    // Add some color to the text
+    line = line.replaceAll("[✓]", '[<span class="log-green">✓</span>]');
+    line = line.replaceAll("[✗]", '[<span class="log-red">✗</span>]');
 
     // Append the new text to the end of the output
     ta.append(line);


### PR DESCRIPTION

**What does this PR aim to accomplish?:**

Add some color to gravity output. When we call `gravity`  from the web interface, all ANSI escape codes are removed from the output stream from `COL_TABLE`

https://github.com/pi-hole/pi-hole/blob/ec892ec096cd1adb90b0209d4c0a155953faf813/advanced/Scripts/COL_TABLE#L17-L29

However, we can re-add them because we know the tick and the cross are shown in colors.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
