### PR TITLE
Handle pie chart item style conditionally

### DIFF
--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -91,17 +91,18 @@ globalThis.htmlLegendPlugin = {
       if (isQueryTypeChart || isForwardDestinationChart) {
         // Text (link to query log page)
         link.title = `List ${item.text} queries`;
-
+        link.className = "legend-label-text clickable";
         if (isQueryTypeChart) {
           link.href = `queries?type=${item.text}`;
         } else if (isForwardDestinationChart) {
           // Encode the forward destination as it may contain an "#" character
           link.href = `queries?upstream=${encodeURIComponent(upstreams[item.text])}`;
         }
+      } else {
+        link.className = "legend-label-text";
       }
 
       link.style.textDecoration = item.hidden ? "line-through" : "";
-      link.className = "legend-label-text";
       link.textContent = item.text;
 
       li.append(boxSpan, link);

--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -67,6 +67,7 @@ globalThis.htmlLegendPlugin = {
       const boxSpan = document.createElement("span");
       boxSpan.title = "Toggle visibility";
       boxSpan.style.color = item.fillStyle;
+      boxSpan.style.cursor = "pointer";
       boxSpan.innerHTML = `<i class="colorBoxWrapper fa ${item.hidden ? "fa-square" : "fa-check-square"}"></i>`;
 
       boxSpan.addEventListener("click", () => {
@@ -92,6 +93,7 @@ globalThis.htmlLegendPlugin = {
         // Text (link to query log page)
         link.title = `List ${item.text} queries`;
         link.className = "legend-label-text clickable";
+
         if (isQueryTypeChart) {
           link.href = `queries?type=${item.text}`;
         } else if (isForwardDestinationChart) {
@@ -99,6 +101,7 @@ globalThis.htmlLegendPlugin = {
           link.href = `queries?upstream=${encodeURIComponent(upstreams[item.text])}`;
         }
       } else {
+        // no clickable links in other charts
         link.className = "legend-label-text";
       }
 

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -270,6 +270,7 @@ td.lookatme {
 }
 
 .chart-legend li {
+  cursor: default;
   position: relative;
   line-height: 1;
   margin: 0 0 8px;
@@ -302,6 +303,10 @@ td.lookatme {
 
 .chart-legend li a.legend-label-text.clickable:hover {
   text-decoration: underline;
+}
+
+.chart-legend li a.legend-label-text.clickable {
+  cursor: pointer; /* Pointer cursor only for clickable items */
 }
 
 /* These are needed because AdmintLTE 2.x doesn't support Font Awesome 5.x */

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -300,7 +300,7 @@ td.lookatme {
   word-break: break-word;
 }
 
-.chart-legend li a.legend-label-text:hover {
+.chart-legend li a.legend-label-text.clickable:hover {
   text-decoration: underline;
 }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Don't underline pie chart items which are not links (used in the the query type chart in settings > system) and don't show the pointer cursor for them.

**How does this PR accomplish the above?:**
Adds a new CSS class 'clickable' for `legend-label-text` and handle underlining and cursor style conditionally.

Should fix https://github.com/pi-hole/web/issues/3531

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
