### PR TITLE
settings-system : Avoid division by zero in DNS metrics

### DIFF
--- a/scripts/js/settings-system.js
+++ b/scripts/js/settings-system.js
@@ -134,7 +134,7 @@ function setMetrics(data, prefix) {
       cacheData[val.name] = val.count;
     } else if (typeof val === "object") {
       setMetrics(val, prefix + key + "-");
-    } else if (prefix === "sysinfo-dns-replies-") {
+    } else if (prefix === "sysinfo-dns-replies-" && data.sum !== 0) {
       // Compute and display percentage of DNS replies in addition to the absolute value
       const lval = val.toLocaleString();
       const percent = (100 * val) / data.sum;


### PR DESCRIPTION
Don't attempt to calculate a percentage if there are no replies yet

**What does this PR aim to accomplish?:**

Avoid a division by zero and resulting NaN% display in DNS metrics, such as the viewing on the system settings page immediately after restarting pihole-FTL:

![image](https://github.com/user-attachments/assets/0545a1b4-5fe2-4c88-9b93-188cef568119)

**How does this PR accomplish the above?:**

Ensure that the sum of queries is not zero before calcuating and displaying percentage:
![image](https://github.com/user-attachments/assets/fa280df3-8e5e-46db-8231-4053848b76a4)

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [X] I have read the above and my PR is ready for review. *Check this box to confirm*
