### PR TITLE
Use innerHTML instead of append to fix gravity color output

### DIFF
--- a/scripts/js/gravity.js
+++ b/scripts/js/gravity.js
@@ -138,7 +138,7 @@ function parseLines(outputElement, text) {
     });
 
     // Append the new text to the end of the output
-    outputElement.append(line);
+    outputElement.innerHTML += line;
   }
 }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes the gravity color output in the web interface. See https://github.com/pi-hole/web/pull/3545#issuecomment-3077107483


**How does this PR accomplish the above?:**

`.append` adds text only, but this PR replaces it with `innerHTML`

<img width="442" height="982" alt="2025-07-16_09-05" src="https://github.com/user-attachments/assets/86630778-6909-47f0-ba9b-51d9bfc0801a" />



---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
