### PR TITLE
Bind address to new element instead of raw HTML construction

### DIFF
--- a/scripts/js/groups-lists.js
+++ b/scripts/js/groups-lists.js
@@ -234,23 +234,20 @@ function initTable() {
       if (data.address.startsWith("file://")) {
         // Local files cannot be downloaded from a distant client so don't show
         // a link to such a list here
-        $("td:eq(3)", row).html(
-          '<code id="address_' +
-            dataId +
-            '" class="breakall">' +
-            utils.escapeHtml(data.address) +
-            "</code>"
-        );
+        const codeElem = document.createElement("code");
+        codeElem.id = "address_" + dataId;
+        codeElem.className = "breakall";
+        codeElem.textContent = data.address;
+        $("td:eq(3)", row).empty().append(codeElem);
       } else {
-        $("td:eq(3)", row).html(
-          '<a id="address_' +
-            dataId +
-            '" class="breakall" href="' +
-            encodeURI(data.address) +
-            '" target="_blank" rel="noopener noreferrer">' +
-            utils.escapeHtml(data.address) +
-            "</a>"
-        );
+        const aElem = document.createElement("a");
+        aElem.id = "address_" + dataId;
+        aElem.className = "breakall";
+        aElem.href = data.address;
+        aElem.target = "_blank";
+        aElem.rel = "noopener noreferrer";
+        aElem.textContent = data.address;
+        $("td:eq(3)", row).empty().append(aElem);
       }
 
       $("td:eq(4)", row).html(


### PR DESCRIPTION
# What does this implement/fix?

Fix incorrectly doubly-escaped links. This is a follow-up on the abandoned https://github.com/pi-hole/web/pull/3552

Can be tested by adding the list
```
https://raw.githubusercontent.com/DandelionSprout/adfilt/master/Alternate%20versions%20Anti-Malware%20List/AntiMalwareHosts.txt
```
and seeing that the click-link does not work on current `development`.

---

**Related issue or feature (if applicable):** N/A

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.