### PR TITLE
Trim whitespaces before adding custom DNS record

### DIFF
--- a/scripts/js/settings-dns-records.js
+++ b/scripts/js/settings-dns-records.js
@@ -215,7 +215,7 @@ $(() => {
 
   $("#btnAdd-host").on("click", () => {
     utils.disableAll();
-    const elem = $("#Hip").val() + " " + $("#Hdomain").val();
+    const elem = $("#Hip").val().trim() + " " + $("#Hdomain").val().trim();
     const url = document.body.dataset.apiurl + "/config/dns/hosts/" + encodeURIComponent(elem);
     utils.showAlert("info", "", "Adding DNS record...", elem);
     $.ajax({

--- a/scripts/js/settings-dns-records.js
+++ b/scripts/js/settings-dns-records.js
@@ -239,7 +239,7 @@ $(() => {
 
   $("#btnAdd-cname").on("click", () => {
     utils.disableAll();
-    let elem = $("#Cdomain").val() + "," + $("#Ctarget").val();
+    let elem = $("#Cdomain").val().trim() + "," + $("#Ctarget").val().trim();
     const ttlVal = Number.parseInt($("#Cttl").val(), 10);
     // TODO Fix eslint
     // eslint-disable-next-line unicorn/prefer-number-properties


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/web/issues/3568

Trim white spaces form hostname and IP input fields of custom DNS records.


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
