### PR TITLE
Add warning to the multiple DNS advertisement

### DIFF
--- a/settings-dhcp.lp
+++ b/settings-dhcp.lp
@@ -116,7 +116,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                     <div class="col-sm-12">
                         <div>
                             <input type="checkbox" id="dhcp.multiDNS" data-key="dhcp.multiDNS" class="DHCPgroup">&nbsp;<label for="dhcp.multiDNS"><strong>Advertise DNS server multiple times</strong></label>
-                            <p class="help-block">Advertise DNS server multiple times to clients. Some devices will add their own proprietary DNS servers to the list of DNS servers, which can cause issues with Pi-hole. This option will advertise the Pi-hole DNS server multiple times to clients, which should prevent this from happening.</p>
+                            <p class="help-block">Advertise DNS server multiple times to clients. Some devices will add their own proprietary DNS servers to the list of DNS servers, which can cause issues with Pi-hole. This option will advertise the Pi-hole DNS server multiple times to clients, which should prevent this from happening. This is not compatible with adding dhcp-option=6,... in dnsmasq_lines in /etc/pihole/config.toml or /etc/dnsmasq.d/</p>
                         </div>
                     </div>
                     <div class="col-sm-12">


### PR DESCRIPTION
Quick workaround for https://github.com/pi-hole/pi-hole/issues/6360 for details.

Signed-off-by: wsw70 <wsw70wsw70@gmail.com>

**What does this PR aim to accomplish?:**

Update the UI `Advertise DNS server multiple times` description to account for https://github.com/pi-hole/pi-hole/issues/6360

**How does this PR accomplish the above?:**

By adding to the description 

```
(...) This is not compatible with adding dhcp-option=6,... in dnsmasq_lines in /etc/pihole/config.toml or /etc/dnsmasq.d/
```
---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
