### PR TITLE
Improve line graph tooltip

### DIFF
--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -233,6 +233,10 @@ function positionTooltip(tooltipEl, tooltip, context) {
   const arrowMinIndent = 2 * tooltip.options.cornerRadius;
   const arrowSize = 5;
 
+  // Check if this is a queryOverTimeChart or clientsChart - these should stick to x-axis
+  const canvasId = context.chart.canvas.id;
+  const isTimelineChart = canvasId === "queryOverTimeChart" || canvasId === "clientsChart";
+
   let tooltipX = offsetX + caretX;
   let arrowX;
 
@@ -289,27 +293,37 @@ function positionTooltip(tooltipEl, tooltip, context) {
     arrowX = offsetX + caretX - tooltipX;
   }
 
-  let tooltipY = offsetY + caretY;
+  let tooltipY;
 
-  // Compute Y position
-  switch (tooltip.yAlign) {
-    case "top": {
-      tooltipY += arrowSize + caretPadding;
-      break;
-    }
+  if (isTimelineChart) {
+    // For timeline charts, always position tooltip below the chart with caret pointing to x-axis
+    const chartArea = context.chart.chartArea;
+    const canvasBottom = chartArea.bottom;
+    tooltipY = offsetY + canvasBottom + arrowSize + caretPadding;
 
-    case "center": {
-      tooltipY -= tooltipHeight / 2;
-      if (tooltip.xAlign === "left") tooltipX += arrowSize;
-      if (tooltip.xAlign === "right") tooltipX -= arrowSize;
-      break;
-    }
+    // Ensure the arrow points to the correct X position
+    arrowX = tooltip.caretX - (tooltipX - offsetX);
+  } else {
+    tooltipY = offsetY + caretY;
+    switch (tooltip.yAlign) {
+      case "top": {
+        tooltipY += arrowSize + caretPadding;
+        break;
+      }
 
-    case "bottom": {
-      tooltipY -= tooltipHeight + arrowSize + caretPadding;
-      break;
+      case "center": {
+        tooltipY -= tooltipHeight / 2;
+        if (tooltip.xAlign === "left") tooltipX += arrowSize;
+        if (tooltip.xAlign === "right") tooltipX -= arrowSize;
+        break;
+      }
+
+      case "bottom": {
+        tooltipY -= tooltipHeight + arrowSize + caretPadding;
+        break;
+      }
+      // No default
     }
-    // No default
   }
 
   // Position tooltip and display

--- a/scripts/js/index.js
+++ b/scripts/js/index.js
@@ -521,8 +521,8 @@ function labelWithPercentage(tooltipLabel, skipZero = false) {
   // Sum all queries for the current time by iterating over all keys in the
   // current dataset
   let sum = 0;
-  for (const value of Object.values(tooltipLabel.parsed._stacks.y)) {
-    if (value === undefined) continue;
+  for (const [key, value] of Object.entries(tooltipLabel.parsed._stacks.y)) {
+    if (key.startsWith("_") || value === undefined) continue;
     const num = Number.parseInt(value, 10);
     if (num) sum += num;
   }

--- a/scripts/js/index.js
+++ b/scripts/js/index.js
@@ -639,9 +639,11 @@ $(() => {
           display: false,
         },
         tooltip: {
-          enabled: true,
+          // Disable the on-canvas tooltip
+          enabled: false,
           intersect: false,
-          yAlign: "bottom",
+          external: customTooltips,
+          yAlign: "top",
           itemSort(a, b) {
             return b.datasetIndex - a.datasetIndex;
           },

--- a/scripts/js/index.js
+++ b/scripts/js/index.js
@@ -658,7 +658,7 @@ $(() => {
               return "Queries from " + from + " to " + to;
             },
             label(tooltipLabel) {
-              return labelWithPercentage(tooltipLabel);
+              return labelWithPercentage(tooltipLabel, true);
             },
           },
         },


### PR DESCRIPTION

**What does this PR aim to accomplish?:**
It does 3 things:

1) While thinking about https://github.com/pi-hole/web/issues/3600 I noticed that the tooltip in the total query graph was floating above the cursor position and mostly hiding the bars. In the client activity this was a bit better, because the tooltip was below the cursor position but it would still follow the cursor in y direction which could also hiding bars. This PR fixes the tooltip to the x-axis independently of the y-postion of the cursor.

![Peek 2025-09-10 10-10](https://github.com/user-attachments/assets/a316fbad-b5a7-4026-8db6-961f0ea0cf3f)


2) The client graph tooltip did hide all elements which had no queries in the selected time slot, the query graph did not. This is fixed now

<img width="749" height="579" alt="Screenshot from 2025-09-10 10-10-58" src="https://github.com/user-attachments/assets/7f72f436-28d1-43cb-902f-662d9833b2bc" />


3) Fixed the calculation of the tooltip percentage (this was most obvious in low-query time slots, see the screenshot above). The issue was that the total sum of the time slot was calculated by the values of `tooltipLabel.parsed._stacks.y`, but it did not only contained key/values for the actual data but some meta-data. This is fixed by only sum the values for keys not starting with `_`

Fixes https://github.com/pi-hole/web/issues/3600

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
