### PR TITLE
Fix the link on the upstream chart legend

### DIFF
--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -100,10 +100,14 @@ globalThis.htmlLegendPlugin = {
           // Encode the forward destination as it may contain an "#" character
           link.href = `queries?upstream=${encodeURIComponent(upstreamIPs[item.index])}`;
 
-          // If server name and IP are different, replace the title tooltip
-          // including the upstream IP to the text
+          // If server name and IP are different:
           if (item.text !== upstreamIPs[item.index]) {
+            // replace the title tooltip to include the upstream IP to the text ...
             link.title = `List ${item.text} (${upstreamIPs[item.index]}) queries`;
+
+            // ... and include the server name (without port) to the querystring, to match
+            // the text used on the SELECT element (sent by suggestions API endpoint)
+            link.href += ` (${item.text.split("#")[0]})`;
           }
         }
       } else {

--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -99,6 +99,12 @@ globalThis.htmlLegendPlugin = {
         } else {
           // Encode the forward destination as it may contain an "#" character
           link.href = `queries?upstream=${encodeURIComponent(upstreamIPs[item.index])}`;
+
+          // If server name and IP are different, replace the title tooltip
+          // including the upstream IP to the text
+          if (item.text !== upstreamIPs[item.index]) {
+            link.title = `List ${item.text} (${upstreamIPs[item.index]}) queries`;
+          }
         }
       } else {
         // no clickable links in other charts

--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -63,6 +63,23 @@ globalThis.htmlLegendPlugin = {
     for (const item of items) {
       const li = document.createElement("li");
 
+      // Select the corresponding "slice" of the chart when the mouse is over a legend item
+      li.addEventListener("mouseover", () => {
+        chart.setActiveElements([
+          {
+            datasetIndex: 0,
+            index: item.index,
+          },
+        ]);
+        chart.update();
+      });
+
+      // Deselect all "slices"
+      li.addEventListener("mouseout", () => {
+        chart.setActiveElements([]);
+        chart.update();
+      });
+
       // Color checkbox (toggle visibility)
       const boxSpan = document.createElement("span");
       boxSpan.title = "Toggle visibility";

--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -96,7 +96,7 @@ globalThis.htmlLegendPlugin = {
 
         if (isQueryTypeChart) {
           link.href = `queries?type=${item.text}`;
-        } else if (isForwardDestinationChart) {
+        } else {
           // Encode the forward destination as it may contain an "#" character
           link.href = `queries?upstream=${encodeURIComponent(upstreams[item.text])}`;
         }

--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -5,7 +5,7 @@
  *  This file is copyright under the latest version of the EUPL.
  *  Please see LICENSE file for your rights under this license. */
 
-/* global upstreams:false */
+/* global upstreamIPs:false */
 
 "use strict";
 
@@ -98,7 +98,7 @@ globalThis.htmlLegendPlugin = {
           link.href = `queries?type=${item.text}`;
         } else {
           // Encode the forward destination as it may contain an "#" character
-          link.href = `queries?upstream=${encodeURIComponent(upstreams[item.text])}`;
+          link.href = `queries?upstream=${encodeURIComponent(upstreamIPs[item.index])}`;
         }
       } else {
         // no clickable links in other charts

--- a/scripts/js/index.js
+++ b/scripts/js/index.js
@@ -890,6 +890,8 @@ $(() => {
         elements: {
           arc: {
             borderColor: $(".box").css("background-color"),
+            hoverBorderColor: $(".box").css("background-color"),
+            hoverOffset: 10,
           },
         },
         plugins: {
@@ -914,6 +916,9 @@ $(() => {
         animation: {
           duration: 750,
         },
+        layout: {
+          padding: 10,
+        },
       },
     });
 
@@ -936,6 +941,8 @@ $(() => {
         elements: {
           arc: {
             borderColor: $(".box").css("background-color"),
+            hoverBorderColor: $(".box").css("background-color"),
+            hoverOffset: 10,
           },
         },
         plugins: {
@@ -959,6 +966,9 @@ $(() => {
         },
         animation: {
           duration: 750,
+        },
+        layout: {
+          padding: 10,
         },
       },
     });

--- a/scripts/js/index.js
+++ b/scripts/js/index.js
@@ -226,7 +226,7 @@ function updateClientsOverTime() {
     });
 }
 
-const upstreams = {};
+const upstreamIPs = [];
 function updateForwardDestinationsPie() {
   $.getJSON(document.body.dataset.apiurl + "/stats/upstreams", data => {
     const v = [];
@@ -248,11 +248,8 @@ function updateForwardDestinationsPie() {
         label += "#" + item.port;
       }
 
-      // Store upstreams for generating links to the Query Log
-      upstreams[label] = item.ip;
-      if (item.port > 0) {
-        upstreams[label] += "#" + item.port;
-      }
+      // Store upstreams IPs for generating links to the Query Log
+      upstreamIPs.push(item.port > 0 ? item.ip + "#" + item.port : item.ip);
 
       const percent = (100 * item.count) / sum;
       values.push([label, percent, THEME_COLORS[i++ % THEME_COLORS.length]]);


### PR DESCRIPTION
### What does this PR aim to accomplish?

When 2 or more upstream servers have the same name, both links on the chart legend point to the same IP:

<img width="600" alt="Upstreams" src="https://github.com/user-attachments/assets/31352cb3-6ed3-4341-b07a-58c50b495f20" />

Each link should point to the correct IP and show different queries, but the issue happens because the current code uses an object containing the server name (label) as `key` and the `value` is the IP, but when there are 2 items with the same key, the first one is overwritten and its IP is lost.

### How does this PR accomplish the above?

Using an array of IPs with indexes will avoid the issue.

This PR also adds the IP to the legend tooltip, to make easier for users to identify different DNS servers, even when they have the same name:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/82cb508c-c6fe-438d-aced-ade1a454a4f9" />


### Link documentation PRs if any are needed to support this PR:

none

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
