### PR TITLE
Fix addList function to include type in API request URL

### DIFF
--- a/scripts/js/groups-lists.js
+++ b/scripts/js/groups-lists.js
@@ -515,12 +515,12 @@ function addList(event) {
   }
 
   $.ajax({
-    url: document.body.dataset.apiurl + "/lists",
+    url: document.body.dataset.apiurl + "/lists?type=" + encodeURIComponent(type),
     method: "post",
     dataType: "json",
     processData: false,
     contentType: "application/json; charset=utf-8",
-    data: JSON.stringify({ address: addresses, comment, type, groups: group }),
+    data: JSON.stringify({ address: addresses, comment, groups: group }),
     success(data) {
       utils.enableAll();
       utils.listsAlert(type + "list", addresses, data);


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

The web interface was sending POST requests to /api/lists with the list type specified only in the JSON payload:

```json
{
  "address": ["example.com"],
  "type": "block",
  "groups": [0]
}
```

However, the FTL API expects the type to be specified as a URL query parameter for the generic /api/lists endpoint, not in the payload. This caused requests to fail with the error: "Specify type parameter (should be either 'allow' or 'block')".

Fixes an issue reported on Discourse: https://discourse.pi-hole.net/t/blocklist-error-on-qnap-container/82625

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_