### PR TITLE
Update FTL %cpu and %mem everytime total CPU stats are updated

### DIFF
--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -344,15 +344,17 @@ function updateSystemInfo() {
       );
       $("#cpu").prop(
         "title",
-        "Load averages for the past 1, 5, and 15 minutes\non a system with " +
+        "CPU usage: " +
+          system.cpu["%cpu"].toFixed(1) +
+          "%\nLoad averages for the past 1, 5, and 15 minutes\non a system with " +
           system.cpu.nprocs +
           " core" +
           (system.cpu.nprocs > 1 ? "s" : "") +
           " running " +
           system.procs +
-          " processes " +
+          " processes" +
           (system.cpu.load.raw[0] > system.cpu.nprocs
-            ? " (load is higher than the number of cores)"
+            ? "\n(load is higher than the number of cores)"
             : "")
       );
       $("#sysinfo-cpu").text(

--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -261,8 +261,6 @@ function updateFtlInfo() {
             " regex filters are enabled"
         );
       updateQueryFrequency(intl, ftl.query_frequency);
-      $("#sysinfo-cpu-ftl").text("(" + ftl["%cpu"].toFixed(1) + "% used by FTL)");
-      $("#sysinfo-ram-ftl").text("(" + ftl["%mem"].toFixed(1) + "% used by FTL)");
       $("#sysinfo-pid-ftl").text(ftl.pid);
       const startdate = moment()
         .subtract(ftl.uptime, "milliseconds")
@@ -367,6 +365,9 @@ function updateSystemInfo() {
           system.procs +
           " processes"
       );
+
+      $("#sysinfo-cpu-ftl").text("(" + system.ftl["%cpu"].toFixed(1) + "% used by FTL)");
+      $("#sysinfo-ram-ftl").text("(" + system.ftl["%mem"].toFixed(1) + "% used by FTL)");
 
       const startdate = moment()
         .subtract(system.uptime, "seconds")


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Currently, the cpu and mem stats for FTL are less frequently updated than the total cpu and mem stats on the settings/system page. Reason is, that FTL stats are refreshed only every 2 minutes (`REFRESH_INTERVAL.ftl`), but total cpu and mem every 20 seconds ( `REFRESH_INTERVAL.system`).

This PR builds upon https://github.com/pi-hole/FTL/pull/2645 which provides FTL's CPU and mem share within the `/info/system` endpoint as well. 

**How does this PR accomplish the above?:**

Move the update function from `updateFtlInfo()` to `updateSystemInfo()`


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
