### PR TITLE
Clarify uptime in container matching the host uptime with a tooltip

### DIFF
--- a/settings-system.lp
+++ b/settings-system.lp
@@ -44,7 +44,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                                     <th scope="row">Kernel:</th>
                                     <td><span id="sysinfo-kernel"></span></td>
                                 </tr>
-                                <tr>
+                                <tr title="The machine uptime. For containers, this will match the host uptime">
                                     <th scope="row">Uptime:</th>
                                     <td><span id="sysinfo-uptime"></span></td>
                                 </tr>


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Adding a tooltip

<img width="1029" height="311" alt="Screenshot at 2025-10-11 09-52-12" src="https://github.com/user-attachments/assets/8497805a-65db-4d4c-9b06-3f4b8463d0f3" />


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
