### PR TITLE
Remove some unused code (leftover from v5)

### DIFF
--- a/scripts/js/messages.js
+++ b/scripts/js/messages.js
@@ -13,13 +13,7 @@ let table;
 const toasts = {};
 
 $(() => {
-  const ignoreNonfatal = localStorage
-    ? localStorage.getItem("hideNonfatalDnsmasqWarnings_chkbox") === "true"
-    : false;
-  const url =
-    document.body.dataset.apiurl +
-    "/info/messages" +
-    (ignoreNonfatal ? "?filter_dnsmasq_warnings=true" : "");
+  const url = document.body.dataset.apiurl + "/info/messages";
   table = $("#messagesTable").DataTable({
     ajax: {
       url,

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -386,14 +386,8 @@ function colorBar(percentage, total, cssClass) {
 }
 
 function checkMessages() {
-  const ignoreNonfatal = localStorage
-    ? localStorage.getItem("hideNonfatalDnsmasqWarnings_chkbox") === "true"
-    : false;
   $.ajax({
-    url:
-      document.body.dataset.apiurl +
-      "/info/messages/count" +
-      (ignoreNonfatal ? "?filter_dnsmasq_warnings=true" : ""),
+    url: document.body.dataset.apiurl + "/info/messages/count",
     method: "GET",
     dataType: "json",
   })


### PR DESCRIPTION
### What does this PR aim to accomplish?

Remove the old `filter_dnsmasq_warnings=true` from the `/info/message` API call.

Also remove the old code used to read hideNonfatalDnsmasqWarnings_chkbox from localstorage. This value was a leftover from v5 web interface.

This is a https://github.com/pi-hole/FTL/pull/2657 follow up.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
