### PR TITLE
Make sure the table is redrawn after the dnssec API call returns

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -34,6 +34,9 @@ let doDNSSEC = false;
 function getDnssecConfig() {
   $.getJSON(document.body.dataset.apiurl + "/config/dns/dnssec", data => {
     doDNSSEC = data.config.dns.dnssec;
+
+    // redraw the table to show the icons when the API call returns
+    $("#all-queries").DataTable().draw();
   });
 }
 


### PR DESCRIPTION
### What does this PR aim to accomplish?

Fixes https://github.com/pi-hole/web/issues/3644

### How does this PR accomplish the above?

Forcing a table redraw after the AJAX call is completed.

Without this, the icons won't show up on the initial table draw because the asynchronous AJAX call usually only completes after that.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
