### PR TITLE
Set "All Time " range for query log datepicker based on Database ranges (moment)

### DIFF
--- a/queries.lp
+++ b/queries.lp
@@ -64,6 +64,7 @@ mg.include('scripts/lua/header_authenticated.lp','r')
                         </div>
                         <input type="button" class="form-control pull-right" id="querytime" value="Click to select date and time range">
                         </div>
+                        <small id="querytime-note" class="form-text text-muted" style="margin-top: 5px;"></small>
                     </div>
                     <div class="form-group col-md-6">
                         <div><input type="checkbox" id="disk"><label for="disk">Query on-disk data. This is <em>a lot</em> slower but necessary if you want to obtain queries older than 24 hours. This option disables live update.</label></div>

--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -77,7 +77,7 @@ function getDatabaseInfo() {
 
 function initDateRangePicker() {
   // If there's no valid data in the database, disable the datepicker
-  if (beginningOfTime === null || endOfTime === null) {
+  if (beginningOfTime === null) {
     $("#querytime").prop("disabled", true);
     $("#querytime").addClass("disabled");
     $("#querytime-note").text("ℹ️ No data in the database");
@@ -105,8 +105,8 @@ function initDateRangePicker() {
           moment().subtract(1, "days").startOf("day"),
           moment().subtract(1, "days").endOf("day"),
         ],
-        "Last 7 Days": [moment().subtract(6, "days"), maxDateMoment],
-        "Last 30 Days": [moment().subtract(29, "days"), maxDateMoment],
+        "Last 7 Days": [moment().subtract(6, "days").startOf("day"), maxDateMoment],
+        "Last 30 Days": [moment().subtract(29, "days").startOf("day"), maxDateMoment],
         "This Month": [moment().startOf("month"), maxDateMoment],
         "Last Month": [
           moment().subtract(1, "month").startOf("month"),


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

uses the newly published earliest_timestamp_disk to set the earliest possible date in the daterangepicker. Also sets the latest possible date to end of today.

This PR is provided as an alternative to #3656, should we decide not to go in that direction just yet.

Some of the same code suggestions apply here, I expect - please feel free to point out my terrible porting skills!

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. _Check this box to confirm_