### PR TITLE
Enable one-time code autofill for TOTP input

### DIFF
--- a/login.lp
+++ b/login.lp
@@ -53,7 +53,7 @@ mg.include('scripts/lua/header.lp','r')
                     </div>
                     <div class="form-group hidden" id="totp_input">
                         <div class="input-group">
-                            <input type="text" id="totp" size="6" maxlen="6" class="form-control totp_token" placeholder="123456" value="" spellcheck="false" autofocus autocomplete="off">
+                            <input type="text" id="totp" size="6" maxlen="6" class="form-control totp_token" placeholder="123456" value="" spellcheck="false" autofocus autocomplete="one-time-code">
                             <div class="input-group-addon" data-toggle="tooltip" data-placement="auto" title="TOTP verification code">
                                 <i class="fa fa-clock-rotate-left"></i>
                             </div>


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

This PR improves the user experience for two-factor authentication (2FA) by enabling automatic one-time passcode suggestions in supported browsers and mobile devices.

**How does this PR accomplish the above?:**

Replaces `autocomplete="off"` with `autocomplete="one-time-code"` on the TOTP input field to allow browsers and password managers to recognize and suggest one-time codes automatically.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
