### PR TITLE
Set the end date for live query update to end of epoch

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -14,6 +14,8 @@
 let beginningOfTime = null; // seconds since epoch (set from API: info/database.earliest_timestamp)
 // endOfTime should be the end of today (local), in seconds since epoch
 const endOfTime = moment().endOf("day").unix();
+// endOfEpoch to allow live updates to continue beyond end of day
+const endOfEpoch = 2_147_483_647; // Jan 19, 2038, 03:14 in seconds
 let from = null;
 let until = null;
 
@@ -532,6 +534,7 @@ let liveMode = false;
 $("#live").prop("checked", liveMode);
 $("#live").on("click", function () {
   liveMode = $(this).prop("checked");
+  until = endOfEpoch; // allow live updates to continue indefinitely
   liveUpdate();
 });
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Allow live query view to continue indefinitely.

Fixes issue raised in https://github.com/pi-hole/web/issues/3676 where live query stops at end of day.

<!--- Replace this with detailed description, screenshots (if necessary), as well as links to any relevant GitHub issues -->

**How does this PR accomplish the above?:**

Sets the until date for live query view to end of epoch, rather than end of day.

(End of day remains unchanged as default for date picker).

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
