### PR TITLE
Amend teleporter help text that the long-term data is not included

### DIFF
--- a/settings-teleporter.lp
+++ b/settings-teleporter.lp
@@ -20,7 +20,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                 <h3 class="box-title">Export your Pi-hole's configuration</h3>
             </div>
             <div class="box-body">
-                <p><strong>Warning:</strong><br>This archive contains sensitive information about your Pi-hole installation, e.g. your 2FA-TOTP secret (if enabled). Please be careful with this file and do not share it with anyone even if they claim to help you.</p>
+                <p><strong>Warning:</strong><br>This archive contains sensitive information about your Pi-hole installation, e.g. your 2FA-TOTP secret (if enabled). Please be careful with this file and do not share it with anyone even if they claim to help you.<br> Your long-term history database <code>pihole-FTL.db</code> must be backed-up separately.</p>
                 <p class='text-danger' id="encryption-warning" style="display: none;"><strong>Warning:</strong><br>You are currently not using an end-to-end encryption. This means that secrets like your 2FA-TOTP secret will be transmitted in plain text. We recommend to use HTTPS when exporting your configuration.</p>
                 <div class="pull-right">
                     <a class="btn btn-app btn-success" id="GETTeleporter" target="_blank">


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Be more explicite that the long-term history needs to be backed-up separately. 

Before
<img width="50%" height="50%" alt="2026-02-18_18-09" src="https://github.com/user-attachments/assets/5baf47a2-a5d8-4d75-bbe3-190137d50d67" />


After
<img width="50%" height="50%" alt="2026-02-18_18-22" src="https://github.com/user-attachments/assets/afff8db2-053f-40af-aaa7-c7ef073828c3" />


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
