### PR TITLE
Do not use 3 columns when boxed layout is used

### DIFF
--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1236,8 +1236,8 @@ table.dataTable tbody > tr > .selected {
 }
 
 @media screen and (min-width: 2250px) {
-  /* show 3 columns in larger screens */
-  .settings-container {
+  /* show 3 columns in larger screens, expect when using boxed layout */
+  body:not(.layout-boxed) .settings-container {
     --columns: 3;
   }
 }


### PR DESCRIPTION
## What does this PR aim to accomplish?

The **All Settings** page shows the options in 3 columns on screens larger than 2250px.

The 3 columns layout looks good if the user selects full page layout:

<img width="850" height="365" alt="image" src="https://github.com/user-attachments/assets/9f280f3d-4b13-4560-a5fd-bd27173e2e41" />


But the current CSS rules don't consider the use of boxed layout.

In this case, using boxed layout in larger screens will result in very narrow columns:

<img width="850" height="361" alt="image" src="https://github.com/user-attachments/assets/820a1fe9-0ece-4fce-a30b-b4c7eef7e510" />

This is specially bad on options with long text descriptions.



## How does this PR accomplish the above?

Fix the CSS to avoid using 3 columns on the All Settings page when boxed layout is used.

The page will show 2 columns (normal layout), even in big screens:

<img width="850" height="372" alt="image" src="https://github.com/user-attachments/assets/d22fcd60-7cbf-4609-ac0a-321df938facf" />


## Link documentation PRs if any are needed to support this PR:

None

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
