### PR TITLE
Do not try to compare component version when remote version info is not available

### DIFF
--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -454,6 +454,7 @@ function updateVersionInfo() {
     let updateAvailable = false;
     let dockerUpdate = false;
     let isDocker = false;
+    let versionWarning = false;
     $("#versions").empty();
     $("#update-hint").empty();
 
@@ -518,7 +519,7 @@ function updateVersionInfo() {
               "</a>";
             if (v.remote === null) {
               // No remote version available, we cannot determine if an update is available
-              localVersion = v.local + " (Latest: N/A)";
+              versionWarning = true;
             } else if (versionCompare(v.local, v.remote) === -1) {
               // Update available
               updateComponentAvailable = true;
@@ -538,7 +539,7 @@ function updateVersionInfo() {
         if (v.name === "Docker Tag") {
           if (v.remote === null) {
             // No remote version available, we cannot determine if an update is available
-            localVersion = v.local + " (Latest: N/A)";
+            versionWarning = true;
           } else if (versionCompare(v.local, v.remote) === -1) {
             // Display update information for the docker tag
             updateComponentAvailable = true;
@@ -573,6 +574,13 @@ function updateVersionInfo() {
           $("#versions").append("<li><strong>" + v.name + "</strong> " + localVersion + "</li>");
         }
       }
+    }
+
+    // Display message asking to run updatechecker, to populate versions file
+    if (versionWarning) {
+      $("#versions").append(
+        "<p><small>The <code>versions</code> file is incomplete. Please execute <code>sudo pihole updatechecker</code> on the command line.</small></p>"
+      );
     }
 
     if (dockerUpdate)

--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -518,7 +518,6 @@ function updateVersionInfo() {
               "</a>";
             if (v.remote === null) {
               // No remote version available, we cannot determine if an update is available
-              updateComponentAvailable = false;
               localVersion = v.local + " (Latest: N/A)";
             } else if (versionCompare(v.local, v.remote) === -1) {
               // Update available
@@ -539,8 +538,6 @@ function updateVersionInfo() {
         if (v.name === "Docker Tag") {
           if (v.remote === null) {
             // No remote version available, we cannot determine if an update is available
-            updateComponentAvailable = false;
-            dockerUpdate = false;
             localVersion = v.local + " (Latest: N/A)";
           } else if (versionCompare(v.local, v.remote) === -1) {
             // Display update information for the docker tag

--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -516,9 +516,12 @@ function updateVersionInfo() {
               '" rel="noopener noreferrer" target="_blank">' +
               localVersion +
               "</a>";
-            if (versionCompare(v.local, v.remote) === -1) {
-              // Update available
-              updateComponentAvailable = true;
+            if (v.remote == null) {
+              // No remote version available, we cannot determine if an update is available
+              updateComponentAvailable = false;
+            } else if (versionCompare(v.local, v.remote) === -1) {
+                // Update available
+                updateComponentAvailable = true;
             }
           } else {
             // non-master branch
@@ -533,7 +536,11 @@ function updateVersionInfo() {
         }
 
         if (v.name === "Docker Tag") {
-          if (versionCompare(v.local, v.remote) === -1) {
+          if (v.remote === null) {
+            // No remote version available, we cannot determine if an update is available
+            updateComponentAvailable = false;
+            dockerUpdate = false;
+          } else if (versionCompare(v.local, v.remote) === -1) {
             // Display update information for the docker tag
             updateComponentAvailable = true;
             dockerUpdate = true;

--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -516,12 +516,13 @@ function updateVersionInfo() {
               '" rel="noopener noreferrer" target="_blank">' +
               localVersion +
               "</a>";
-            if (v.remote == null) {
+            if (v.remote === null) {
               // No remote version available, we cannot determine if an update is available
               updateComponentAvailable = false;
+              localVersion = v.local + " (Latest: N/A)";
             } else if (versionCompare(v.local, v.remote) === -1) {
-                // Update available
-                updateComponentAvailable = true;
+              // Update available
+              updateComponentAvailable = true;
             }
           } else {
             // non-master branch
@@ -540,6 +541,7 @@ function updateVersionInfo() {
             // No remote version available, we cannot determine if an update is available
             updateComponentAvailable = false;
             dockerUpdate = false;
+            localVersion = v.local + " (Latest: N/A)";
           } else if (versionCompare(v.local, v.remote) === -1) {
             // Display update information for the docker tag
             updateComponentAvailable = true;


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

If (for any reason) we can't get the remote components version (and the API returns 'null' for that component), the [versionCompare](https://github.com/pi-hole/web/blob/master/scripts/js/footer.js#L408) function fails and the whole component information is not printed. 
This PR guards the `versionCompare` function by checking if the remote version != null. In this case, we skip the test and print a hint that the check failed.

<img width="850" height="170" alt="2026-02-23_13-36" src="https://github.com/user-attachments/assets/e2d17afd-96ea-4260-958a-fc76e1fdb949" />

Fixes https://github.com/pi-hole/web/issues/3728

In conjunction with https://github.com/pi-hole/pi-hole/pull/6550

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
