### PR TITLE
Add client name column to network overview

### DIFF
--- a/network.lp
+++ b/network.lp
@@ -24,6 +24,7 @@ mg.include('scripts/lua/header_authenticated.lp','r')
                             <th>ID</th>
                             <th>IP address (hostname)</th>
                             <th>Hardware address</th>
+                            <th>Client Name</th>
                             <th>Interface</th>
                             <th>First seen</th>
                             <th>Last Query</th>
@@ -37,6 +38,7 @@ mg.include('scripts/lua/header_authenticated.lp','r')
                             <th>ID</th>
                             <th>IP address (hostname)</th>
                             <th>Hardware address</th>
+                            <th>Client Name</th>
                             <th>Interface</th>
                             <th>First seen</th>
                             <th>Last Query</th>

--- a/scripts/js/network.js
+++ b/scripts/js/network.js
@@ -14,6 +14,7 @@ let tableApi;
 // How many IPs do we show at most per device?
 const MAXIPDISPLAY = 3;
 const DAY_IN_SECONDS = 24 * 60 * 60;
+const clientNameMap = {};
 
 function handleAjaxError(xhr, textStatus) {
   if (textStatus === "timeout") {
@@ -92,7 +93,7 @@ function deleteNetworkEntry() {
   });
 }
 
-$(() => {
+function initTable() {
   tableApi = $("#network-entries").DataTable({
     rowCallback(row, data) {
       let color;
@@ -125,16 +126,16 @@ $(() => {
 
       // Set determined background color
       $(row).css("background-color", color);
-      $("td:eq(6)", row).html('<i class="' + iconClasses + '"></i>');
+      $("td:eq(7)", row).html('<i class="' + iconClasses + '"></i>');
 
       // Insert "Never" into Last Query field when we have
       // never seen a query from this device
       if (data.lastQuery === 0) {
-        $("td:eq(4)", row).text("Never");
+        $("td:eq(5)", row).text("Never");
       }
 
       // Set number of queries to localized string (add thousand separators)
-      $("td:eq(5)", row).text(data.numQueries.toLocaleString());
+      $("td:eq(6)", row).text(data.numQueries.toLocaleString());
 
       const ips = [];
       const iptitles = [];
@@ -200,7 +201,7 @@ $(() => {
         '">' +
         '<span class="far fa-trash-alt"></span>' +
         "</button>";
-      $("td:eq(7)", row).html(button);
+      $("td:eq(8)", row).html(button);
     },
     dom:
       "<'row'<'col-sm-12'f>>" +
@@ -220,11 +221,23 @@ $(() => {
     },
     autoWidth: false,
     processing: true,
-    order: [[6, "desc"]],
+    order: [[7, "desc"]],
     columns: [
       { data: "id", visible: false },
       { data: "ips[].ip", type: "ip-address", width: "25%" },
       { data: "hwaddr", width: "10%" },
+      {
+        data: "hwaddr",
+        width: "10%",
+        render(data, type) {
+          const name = clientNameMap[data.toLowerCase()] || "";
+          if (type === "display") {
+            return utils.escapeHtml(name);
+          }
+
+          return name;
+        },
+      },
       { data: "interface", width: "4%" },
       {
         data: "firstSeen",
@@ -289,4 +302,22 @@ $(() => {
   input.setAttribute("autocorrect", "off");
   input.setAttribute("autocapitalize", "off");
   input.setAttribute("spellcheck", false);
+}
+
+$(() => {
+  $.ajax({
+    url: document.body.dataset.apiurl + "/clients",
+    type: "GET",
+    dataType: "json",
+    success(data) {
+      if (data && Array.isArray(data.clients)) {
+        for (const client of data.clients) {
+          if (client.comment && client.comment.length > 0) {
+            clientNameMap[client.client.toLowerCase()] = client.comment;
+          }
+        }
+      }
+    },
+    complete: initTable,
+  });
 });


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Add a new **Client Name** field to the Network Overview table, showing user-assigned client labels (mapped by client MAC address).  
This makes it easier to identify devices in the network list without relying only on IP/MAC/hostname.

**How does this PR accomplish the above?:**
- Adds a new `Client Name` column to `network.lp` table header and footer.
- Updates `scripts/js/network.js` to fetch `/clients` and build a client-name lookup from configured client comments.
- Resolves and renders client names in the new DataTable column.
- Ensures the `Client Name` column supports proper filtering/sorting behavior.
- Updates column index handling and default sort index after adding the new column.

Screenshot:
<img width="978" height="485" alt="Screenshot 2026-03-04 184539" src="https://github.com/user-attachments/assets/4aad6c08-2d76-43ce-84dd-2d2807e106a0" />

**Link documentation PRs if any are needed to support this PR:**
No documentation changes are required for this UI enhancement.
---
**By submitting this pull request, I confirm the following:**
1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.
---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
