### PR TITLE
Fix eslint warning about eslint-env comment by removing it

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 "use strict";
 
 module.exports = (/* ctx */) => ({


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Currently, all our test warn about

> 
> pi-hole-web-interface@1.0.0 xo
> xo
>
>(node:2553) ESLintEnvWarning: /* eslint-env */ comments are no longer recognized when linting with flat config and will be reported as errors as of v10.0.0. Replace them with /* global */ comments or define globals in your config file. See https://eslint.org/docs/latest/use/configure/migration-guide#eslint-env-configuration-comments for details. Found in /home/runner/work/web/web/postcss.config.js at line 1.
(Use `node --trace-warnings ...` to show where the warning was created)

See: https://github.com/pi-hole/web/actions/runs/22803762043/job/66149454362

Since `postcss.config.js` is CommonJS and it uses module export, this comment should not be necessary so I removed it.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
