### PR TITLE
Show loading overlay when adding/removing CNAME records as it requires a FTL restart

### DIFF
--- a/scripts/js/settings-dns-records.js
+++ b/scripts/js/settings-dns-records.js
@@ -207,6 +207,8 @@ function delCNAME(elem) {
         "Successfully deleted local CNAME record",
         elem
       );
+      // Show loading overlay
+      utils.loadingOverlay(true);
       $("#cnameRecords-Table").DataTable().ajax.reload(null, false);
     })
     .fail((data, exception) => {
@@ -267,6 +269,8 @@ $(() => {
       .done(() => {
         utils.enableAll();
         utils.showAlert("success", "fas fa-plus", "Successfully added CNAME record", elem);
+        // Show loading overlay
+        utils.loadingOverlay(true);
         $("#Cdomain").val("");
         $("#Ctarget").val("");
         $("#cnameRecords-Table").DataTable().ajax.reload(null, false);


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

When users use the 'Save & Apply' button on the settings page, an loading overlay is shown which stays until FTL is available again in case a restart is required.
Currently, no overlay was shown when a CNAME was added/removed, but this required a FTL restart as well. This should be signaled to the users.

**How does this PR accomplish the above?:**

Re-use the `utils.loadingOverlay` function

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
