### PR TITLE
Encode dots in URL path segments to prevent browser resolution 

### DIFF
--- a/scripts/js/groups-domains.js
+++ b/scripts/js/groups-domains.js
@@ -611,7 +611,7 @@ function editDomain() {
       "/domains/" +
       newTypestr +
       "/" +
-      encodeURIComponent(domainDecoded),
+      utils.encodePathSegment(domainDecoded),
     method: "put",
     dataType: "json",
     processData: false,

--- a/scripts/js/groups.js
+++ b/scripts/js/groups.js
@@ -328,7 +328,7 @@ function editGroup() {
   utils.disableAll();
   utils.showAlert("info", "", "Editing group...", oldName);
   $.ajax({
-    url: document.body.dataset.apiurl + "/groups/" + oldName,
+    url: document.body.dataset.apiurl + "/groups/" + utils.encodePathSegment(oldName),
     method: "put",
     dataType: "json",
     processData: false,

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -518,6 +518,13 @@ function parseQueryString() {
   return Object.fromEntries(params.entries());
 }
 
+// Encode a string for use as a URL path segment. encodeURIComponent does not
+// encode dots, but browsers resolve "." and ".." as relative path components
+// before sending the request, breaking domains like "." or "..".
+function encodePathSegment(text) {
+  return encodeURIComponent(text).replaceAll(".", "%2E");
+}
+
 function hexEncode(text) {
   if (typeof text !== "string" || text.length === 0) return "";
 
@@ -726,6 +733,7 @@ globalThis.utils = (function () {
     changeTableButtonStates,
     getCSSval,
     parseQueryString,
+    encodePathSegment,
     hexEncode,
     hexDecode,
     listsAlert,


### PR DESCRIPTION
# What does this implement/fix?

When editing a regex domain that is just "." (single dot), the browser
interprets it as a relative path component ("current directory") and
resolves it away before sending the request. The server receives an
empty string, causing "Invalid request: Specify item in URI".

This happens because encodeURIComponent(".") returns "." unchanged —
dots are unreserved characters per RFC 3986. The browser only normalizes
literal "." and ".." path segments, not percent-encoded "%2E".

Add utils.encodePathSegment() which wraps encodeURIComponent and also
encodes dots to %2E, then apply it in groups-domains.js (the reported
bug) and groups.js (which was also missing encoding entirely).

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/web/issues/3308

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.