### PR TITLE
Better user interface to edit reverse DNS servers (dns.revServers)

### DIFF
--- a/scripts/js/footer.js
+++ b/scripts/js/footer.js
@@ -175,13 +175,16 @@ function testCookies() {
 }
 
 function applyCheckboxRadioStyle() {
-  // Get all radio/checkboxes for theming, with the exception of the two radio buttons on the custom disable timer,
-  // as well as every element with an id that starts with "status_"
+  // Get all radio/checkboxes for theming, with the exception of:
+  // - the two radio buttons on the custom disable timer,
+  // - radio/checkboxes elements with class "no-icheck",
+  // - every element with an id that starts with "status_"
   const sel = $("input[type='radio'],input[type='checkbox']")
     .not("#selSec")
     .not("#selMin")
     .not("#expert-settings")
     .not("#only-changed")
+    .not(".no-icheck")
     .not("[id^=status_]");
   sel.parent().removeClass();
   sel.parent().addClass("icheck-primary");

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -140,16 +140,16 @@ function getRevServerLines() {
   // Return the lines from the textarea (array of lines)
   return $(".revServers")
     .val()
-    .split(/\r?\n/)
+    .split(/\r?\n/v)
     .filter(line => line.trim() !== "");
 }
 
 // Return an array of objects containing the current values from the textarea
 function getRevServerArray() {
-  let items = [];
+  const items = [];
 
   const lines = getRevServerLines();
-  lines.forEach((line, index) => {
+  for (const line of lines) {
     const cols = line.split(",").map(s => s.trim());
     items.push({
       enabled: cols[0] ?? "",
@@ -157,7 +157,7 @@ function getRevServerArray() {
       ip: cols[2] ?? "",
       domain: cols[3] ?? "",
     });
-  });
+  }
 
   return items;
 }
@@ -190,7 +190,7 @@ function createRevServerTable() {
       {
         targets: 0,
         class: "input-checkbox text-center",
-        render: function (data, type, row, meta) {
+        render(data, type, row, meta) {
           const name = "enabled_" + meta.row;
           const ckbox =
             `<input type="checkbox" name="${name}" id="${name}" class="no-icheck" ` +
@@ -202,7 +202,7 @@ function createRevServerTable() {
       {
         targets: "_all",
         class: "input-text",
-        render: function (data, type, row, meta) {
+        render(data, type, row, meta) {
           let name;
           switch (meta.col) {
             case 1:
@@ -221,13 +221,13 @@ function createRevServerTable() {
         },
       },
     ],
-    drawCallback: function () {
+    drawCallback() {
       $('button[id^="deleteRevServers"]').on("click", deleteRecord);
       $('button[id^="editRevServers"]').on("click", editRecord);
       $('button[id^="saveRevServers"]').on("click", saveRecord).hide();
       $('button[id^="cancelRevServers"]').on("click", restoreRecord).hide();
     },
-    rowCallback: function (row, data, displayNum, displayIndex, dataIndex) {
+    rowCallback(row, data, displayNum, displayIndex, dataIndex) {
       $(row).attr("data-index", dataIndex);
       const bt = '<button type="button" class="btn btn-xs"</button>';
       const btEdit = $(bt)
@@ -269,11 +269,11 @@ function createRevServerTable() {
     stateSave: true,
     stateDuration: 0,
     processing: true,
-    stateSaveCallback: function (settings, data) {
+    stateSaveCallback(settings, data) {
       utils.stateSaveCallback("revServers-records-table", data);
     },
-    stateLoadCallback: function () {
-      var data = utils.stateLoadCallback("revServers-records-table");
+    stateLoadCallback() {
+      const data = utils.stateLoadCallback("revServers-records-table");
       // Return if not available
       if (data === null) return null;
 
@@ -284,21 +284,21 @@ function createRevServerTable() {
 }
 
 function addRevServer() {
-  var values = [];
+  const values = [];
   values[0] = $("#enabled-revServers").is(":checked") ? "true" : "false";
   values[1] = $("#network-revServers").val();
   values[2] = $("#server-revServers").val();
   values[3] = $("#domain-revServers").val();
 
   // Reject empty network range and server IP
-  if (values[1] == "" || values[2] == "") {
+  if (values[1] === "" || values[2] === "") {
     // Show error message
     utils.showAlert("error", "fa fa-ban", "Network Range and Server IP are required", "");
     return;
   }
 
   // Domain is optional: if empty, remove it from the array
-  if (values[3] == "") values.pop();
+  if (values[3] === "") values.pop();
 
   // Add the new values to the textarea
   $(".revServers").val($(".revServers").val() + "\n" + values.join(","));
@@ -337,17 +337,17 @@ function saveRecord() {
   values[3] = $("#domain_" + index).val();
 
   // Reject empty network range and server IP
-  if (values[1] == "" || values[2] == "") {
+  if (values[1] === "" || values[2] === "") {
     // Show error message
     utils.showAlert("error", "fa fa-ban", "Network Range and Server IP are required", "");
     return;
   }
 
   // Domain is optional: if empty, remove it from the array
-  if (values[3] == "") values.pop();
+  if (values[3] === "") values.pop();
 
   // Get the values from the textarea
-  let lines = getRevServerLines();
+  const lines = getRevServerLines();
 
   // Replace the edited line on the textarea
   lines[index] = values.join(",");
@@ -394,7 +394,7 @@ function deleteRecord() {
   const index = $(this).closest("tr").attr("data-index");
 
   // Get the current lines from the textarea
-  let lines = getRevServerLines();
+  const lines = getRevServerLines();
 
   // Remove the deleted line and update the textearea
   lines.splice(index, 1);
@@ -455,7 +455,7 @@ function saveRevServerData(msg) {
 
       // Reset the table to show the updated data
       // Remove all rows from the table, then create rows with the updated data and finally redraw the table
-      var table = $("#revServers-table").DataTable();
+      const table = $("#revServers-table").DataTable();
       table.clear().rows.add(getRevServerArray()).draw();
     })
     .fail((data, exception) => {

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -141,16 +141,16 @@ function getRevServerLines() {
   return $(".revServers")
     .val()
     .split(/\r?\n/)
-    .filter((line) => line.trim() !== "");
+    .filter(line => line.trim() !== "");
 }
 
-// Return the values ​​from the textarea, structured as an array of objects
+// Return an array of objects containing the current values from the textarea
 function getRevServerArray() {
   let items = [];
 
   const lines = getRevServerLines();
   lines.forEach((line, index) => {
-    const cols = line.split(",").map((s) => s.trim());
+    const cols = line.split(",").map(s => s.trim());
     items.push({
       enabled: cols[0] ?? "",
       network: cols[1] ?? "",
@@ -162,7 +162,7 @@ function getRevServerArray() {
   return items;
 }
 
-function renderRevServerTable() {
+function createRevServerTable() {
   // The Conditional Forwarding option will be disabled when this option was set via ENV VAR.
   // Check if the textarea is disabled.
   if ($(".revServers").prop("disabled")) {
@@ -172,22 +172,9 @@ function renderRevServerTable() {
     return;
   }
 
-  // Get an array containing the current values from the textarea
-  const data = getRevServerArray();
+  // Get the data
+  const tableRows = getRevServerArray();
 
-  // Check if the DataTable already exists
-  if ($.fn.DataTable.isDataTable("#revServers-table")) {
-    // If it already exists, we need to reset it to load the updated data.
-    // Remove all rows from the table, then add new rows with the updated data and finally redraw the table
-    var table = $("#revServers-table").DataTable();
-    table.clear().rows.add(data).draw();
-  } else {
-    // If the table doesn't exist, create it.
-    createRevServerTable(data);
-  }
-}
-
-function createRevServerTable(tableRows) {
   $("#revServers-table").DataTable({
     data: tableRows,
     autoWidth: false,
@@ -314,18 +301,14 @@ function addRevServer() {
   if (values[3] == "") values.pop();
 
   // Add the new values to the textarea
-  const newValues = values.join(",");
-  $(".revServers").val($(".revServers").val() + "\n" + newValues);
-
-  // Show confirmation message
-  utils.showAlert("success", "fa fa-check", "New values added", values.join(", "));
+  $(".revServers").val($(".revServers").val() + "\n" + values.join(","));
 
   // Clear the table footer fields
   $("#revServers-table tfoot input[type=text]").val("");
   $("#revServers-table tfoot input[type=checkbox]").prop("checked", true);
 
-  // Recreate the table with updated values
-  renderRevServerTable();
+  // Save changes with message
+  saveRevServerData("New values added: " + values.join(", "));
 }
 
 // Button to add a new reverse server
@@ -373,17 +356,14 @@ function saveRecord() {
   // Finish the edition disabling the fields
   $(this).closest("tr").find("td input").prop("disabled", true);
 
-  // Show confirmation message
-  utils.showAlert("success", "fa fa-check", "Values succesfully edited", values.join(", "));
-
   // Show EDIT and DELETE buttons. Hide SAVE and UNDO buttons
   $(this).siblings('[id^="edit"]').show();
   $(this).siblings('[id^="delete"]').show();
   $(this).hide();
   $(this).siblings('[id^="cancel"]').hide();
 
-  // Recreate the table with updated values
-  renderRevServerTable();
+  // Save changes with message
+  saveRevServerData("Values successfully edited" + values.join(", "));
 }
 
 function restoreRecord() {
@@ -420,18 +400,15 @@ function deleteRecord() {
   lines.splice(index, 1);
   $(".revServers").val(lines.join("\n"));
 
-  // Show confirmation message
-  utils.showAlert("success", "fa fa-check", "Line successfully deleted", "");
-
-  // Recreate the table with updated values
-  renderRevServerTable();
+  // Save changes with message
+  saveRevServerData("Line successfully deleted");
 }
 
 function processDNSConfig() {
   $.ajax({
     url: document.body.dataset.apiurl + "/config/dns?detailed=true", // We need the detailed output to get the DNS server list
   })
-    .done((data) => {
+    .done(data => {
       // Initialize the DNS upstreams
       fillDNSupstreams(data.config.dns.upstreams, data.dns_servers);
       setInterfaceName(data.config.dns.interface.value);
@@ -439,9 +416,9 @@ function processDNSConfig() {
     })
     .done(() => {
       // This will be executed only after the done block above is executed
-      renderRevServerTable();
+      createRevServerTable();
     })
-    .fail((data) => {
+    .fail(data => {
       apiFailure(data);
     });
 }
@@ -449,3 +426,42 @@ function processDNSConfig() {
 $(() => {
   processDNSConfig();
 });
+
+// Save the Reverse Servers data via API and recreate the table with updated values
+function saveRevServerData(msg) {
+  // Get the data from the textarea
+  const data = getRevServerLines();
+
+  // Call the API to save only the dns.revServers option
+  $.ajax({
+    url: document.body.dataset.apiurl + "/config",
+    method: "PATCH",
+    dataType: "json",
+    processData: false,
+    data: JSON.stringify({ config: { dns: { revServers: data } } }),
+    contentType: "application/json; charset=utf-8",
+  })
+    .done(() => {
+      utils.enableAll();
+      // Success
+      utils.showAlert(
+        "success",
+        "fa-solid fa-fw fa-floppy-disk",
+        "Conditional Forwarding settings successfully saved",
+        msg
+      );
+      // Show loading overlay
+      utils.loadingOverlay(false);
+
+      // Reset the table to show the updated data
+      // Remove all rows from the table, then create rows with the updated data and finally redraw the table
+      var table = $("#revServers-table").DataTable();
+      table.clear().rows.add(getRevServerArray()).draw();
+    })
+    .fail((data, exception) => {
+      utils.enableAll();
+      utils.showAlert("error", "", "Error while applying settings", data.responseText);
+      console.log(exception); // eslint-disable-line no-console
+      apiFailure(data);
+    });
+}

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -136,17 +136,312 @@ function updateDNSserversTextfield(upstreams, customServers) {
   );
 }
 
+function getRevServerLines() {
+  // Return the lines from the textarea (array of lines)
+  return $(".revServers")
+    .val()
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== "");
+}
+
+// Return the values ​​from the textarea, structured as an array of objects
+function getRevServerArray() {
+  let items = [];
+
+  const lines = getRevServerLines();
+  lines.forEach((line, index) => {
+    const cols = line.split(",").map((s) => s.trim());
+    items.push({
+      enabled: cols[0] ?? "",
+      network: cols[1] ?? "",
+      ip: cols[2] ?? "",
+      domain: cols[3] ?? "",
+    });
+  });
+
+  return items;
+}
+
+function renderRevServerTable() {
+  // The Conditional Forwarding option will be disabled when this option was set via ENV VAR.
+  // Check if the textarea is disabled.
+  if ($(".revServers").prop("disabled")) {
+    // In this case, we don't show the table because the values can't be changed.
+    // Show the disabled textarea and return
+    $(".revServers").show();
+    return;
+  }
+
+  // Get an array containing the current values from the textarea
+  const data = getRevServerArray();
+
+  // Check if the DataTable already exists
+  if ($.fn.DataTable.isDataTable("#revServers-table")) {
+    // If it already exists, we need to reset it to load the updated data.
+    // Remove all rows from the table, then add new rows with the updated data and finally redraw the table
+    var table = $("#revServers-table").DataTable();
+    table.clear().rows.add(data).draw();
+  } else {
+    // If the table doesn't exist, create it.
+    createRevServerTable(data);
+  }
+}
+
+function createRevServerTable(tableRows) {
+  $("#revServers-table").DataTable({
+    data: tableRows,
+    autoWidth: false,
+    columns: [
+      { data: null, width: "54px" },
+      { data: "network" },
+      { data: "ip" },
+      { data: "domain" },
+      { data: null, width: "52px" },
+    ],
+    ordering: false,
+    columnDefs: [
+      {
+        targets: 0,
+        class: "input-checkbox text-center",
+        render: function (data, type, row, meta) {
+          const name = "enabled_" + meta.row;
+          const ckbox =
+            `<input type="checkbox" name="${name}" id="${name}" class="no-icheck" ` +
+            (data.enabled === "true" ? "checked " : "") +
+            ` data-initial-value="${data.enabled}" disabled>`;
+          return ckbox;
+        },
+      },
+      {
+        targets: "_all",
+        class: "input-text",
+        render: function (data, type, row, meta) {
+          let name;
+          switch (meta.col) {
+            case 1:
+              name = "network_" + meta.row;
+              break;
+            case 2:
+              name = "ip_" + meta.row;
+              break;
+            case 3:
+              name = "domain_" + meta.row;
+              break;
+            // No default
+          }
+
+          return `<input type="text" name="${name}" id="${name}" value="${data}" class="form-control" data-initial-value="${data}" disabled>`;
+        },
+      },
+    ],
+    drawCallback: function () {
+      $('button[id^="deleteRevServers"]').on("click", deleteRecord);
+      $('button[id^="editRevServers"]').on("click", editRecord);
+      $('button[id^="saveRevServers"]').on("click", saveRecord).hide();
+      $('button[id^="cancelRevServers"]').on("click", restoreRecord).hide();
+    },
+    rowCallback: function (row, data, displayNum, displayIndex, dataIndex) {
+      $(row).attr("data-index", dataIndex);
+      const bt = '<button type="button" class="btn btn-xs"</button>';
+      const btEdit = $(bt)
+        .addClass("btn-primary")
+        .attr("id", `editRevServers_${dataIndex}`)
+        .attr("title", "Edit")
+        .append('<span class="far fa-edit"></span>');
+      const btDel = $(bt)
+        .addClass("btn-danger")
+        .attr("id", `deleteRevServers_${dataIndex}`)
+        .attr("data-tag", Object.values(data))
+        .attr("data-type", "revServers")
+        .attr("title", "Delete")
+        .append('<span class="fa fa-trash"></span>');
+      const btSave = $(bt)
+        .addClass("btn-success")
+        .attr("id", `saveRevServers_${dataIndex}`)
+        .attr("title", "Confirm changes")
+        .append('<span class="fa fa-check"></span>');
+      const btCancel = $(bt)
+        .addClass("btn-warning")
+        .attr("id", `cancelRevServers_${dataIndex}`)
+        .attr("data-tag", Object.values(data))
+        .attr("title", "Undo changes")
+        .append('<span class="fa fa-undo"></span>');
+
+      $("td:eq(4)", row).html(btEdit).append(" ", btDel, " ", btSave, " ", btCancel);
+    },
+    dom:
+      "<'row'<'col-sm-12 text-right'l>>" +
+      "<'row'<'col-sm-12'<'table-responsive'tr>>><'row'<'col-sm-12'i>>",
+    lengthMenu: [
+      [10, 25, 50, 100, -1],
+      [10, 25, 50, 100, "All"],
+    ],
+    language: {
+      emptyTable: "No revese DNS servers defined.",
+    },
+    stateSave: true,
+    stateDuration: 0,
+    processing: true,
+    stateSaveCallback: function (settings, data) {
+      utils.stateSaveCallback("revServers-records-table", data);
+    },
+    stateLoadCallback: function () {
+      var data = utils.stateLoadCallback("revServers-records-table");
+      // Return if not available
+      if (data === null) return null;
+
+      // Apply loaded state to table
+      return data;
+    },
+  });
+}
+
+function addRevServer() {
+  var values = [];
+  values[0] = $("#enabled-revServers").is(":checked") ? "true" : "false";
+  values[1] = $("#network-revServers").val();
+  values[2] = $("#server-revServers").val();
+  values[3] = $("#domain-revServers").val();
+
+  // Reject empty network range and server IP
+  if (values[1] == "" || values[2] == "") {
+    // Show error message
+    utils.showAlert("error", "fa fa-ban", "Network Range and Server IP are required", "");
+    return;
+  }
+
+  // Domain is optional: if empty, remove it from the array
+  if (values[3] == "") values.pop();
+
+  // Add the new values to the textarea
+  const newValues = values.join(",");
+  $(".revServers").val($(".revServers").val() + "\n" + newValues);
+
+  // Show confirmation message
+  utils.showAlert("success", "fa fa-check", "New values added", values.join(", "));
+
+  // Clear the table footer fields
+  $("#revServers-table tfoot input[type=text]").val("");
+  $("#revServers-table tfoot input[type=checkbox]").prop("checked", true);
+
+  // Recreate the table with updated values
+  renderRevServerTable();
+}
+
+// Button to add a new reverse server
+$("#btnAdd-revServers").on("click", addRevServer);
+
+function editRecord() {
+  // Enable fields on the selected row
+  $(this).closest("tr").find("td input").prop("disabled", false);
+
+  // Hide EDIT and DELETE buttons. Show SAVE and UNDO buttons
+  $(this).hide();
+  $(this).siblings('[id^="delete"]').hide();
+  $(this).siblings('[id^="save"]').show();
+  $(this).siblings('[id^="cancel"]').show();
+}
+
+function saveRecord() {
+  // Find the row index
+  const index = $(this).closest("tr").attr("data-index");
+
+  // Get the edited values from each field
+  const values = [];
+  values[0] = $("#enabled_" + index).prop("checked") ? "true" : "false";
+  values[1] = $("#network_" + index).val();
+  values[2] = $("#ip_" + index).val();
+  values[3] = $("#domain_" + index).val();
+
+  // Reject empty network range and server IP
+  if (values[1] == "" || values[2] == "") {
+    // Show error message
+    utils.showAlert("error", "fa fa-ban", "Network Range and Server IP are required", "");
+    return;
+  }
+
+  // Domain is optional: if empty, remove it from the array
+  if (values[3] == "") values.pop();
+
+  // Get the values from the textarea
+  let lines = getRevServerLines();
+
+  // Replace the edited line on the textarea
+  lines[index] = values.join(",");
+  $(".revServers").val(lines.join("\n"));
+
+  // Finish the edition disabling the fields
+  $(this).closest("tr").find("td input").prop("disabled", true);
+
+  // Show confirmation message
+  utils.showAlert("success", "fa fa-check", "Values succesfully edited", values.join(", "));
+
+  // Show EDIT and DELETE buttons. Hide SAVE and UNDO buttons
+  $(this).siblings('[id^="edit"]').show();
+  $(this).siblings('[id^="delete"]').show();
+  $(this).hide();
+  $(this).siblings('[id^="cancel"]').hide();
+
+  // Recreate the table with updated values
+  renderRevServerTable();
+}
+
+function restoreRecord() {
+  // Find the row index
+  const index = $(this).closest("tr").attr("data-index");
+
+  // Reset values
+  $("#enabled_" + index).prop("checked", $("#enabled_" + index).attr("data-initial-value"));
+  $("#network_" + index).val($("#network_" + index).attr("data-initial-value"));
+  $("#ip_" + index).val($("#ip_" + index).attr("data-initial-value"));
+  $("#domain_" + index).val($("#domain_" + index).attr("data-initial-value"));
+
+  // Show cancellation message
+  utils.showAlert("info", "fas fa-undo", "Canceled", "Original values restored");
+
+  // Finish the edition disabling the fields
+  $(this).closest("tr").find("td input").prop("disabled", true);
+
+  // Show EDIT and DELETE buttons. Hide SAVE and UNDO buttons
+  $(this).siblings('[id^="edit"]').show();
+  $(this).siblings('[id^="delete"]').show();
+  $(this).siblings('[id^="save"]').hide();
+  $(this).hide();
+}
+
+function deleteRecord() {
+  // Find the row index (this is also the index of the deleted row)
+  const index = $(this).closest("tr").attr("data-index");
+
+  // Get the current lines from the textarea
+  let lines = getRevServerLines();
+
+  // Remove the deleted line and update the textearea
+  lines.splice(index, 1);
+  $(".revServers").val(lines.join("\n"));
+
+  // Show confirmation message
+  utils.showAlert("success", "fa fa-check", "Line successfully deleted", "");
+
+  // Recreate the table with updated values
+  renderRevServerTable();
+}
+
 function processDNSConfig() {
   $.ajax({
     url: document.body.dataset.apiurl + "/config/dns?detailed=true", // We need the detailed output to get the DNS server list
   })
-    .done(data => {
+    .done((data) => {
       // Initialize the DNS upstreams
       fillDNSupstreams(data.config.dns.upstreams, data.dns_servers);
       setInterfaceName(data.config.dns.interface.value);
       setConfigValues("dns", "dns", data.config.dns);
     })
-    .fail(data => {
+    .done(() => {
+      // This will be executed only after the done block above is executed
+      renderRevServerTable();
+    })
+    .fail((data) => {
       apiFailure(data);
     });
 }

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -179,82 +179,59 @@ function createRevServerTable() {
     data: tableRows,
     autoWidth: false,
     columns: [
-      { data: null, width: "54px" },
-      { data: "network" },
-      { data: "ip" },
-      { data: "domain" },
-      { data: null, width: "52px" },
+      { data: "enabled", width: "54px", className: "revserver-chkbox text-center" },
+      { data: "network", className: "revserver-network" },
+      { data: "ip", className: "revserver-ip" },
+      { data: "domain", className: "revserver-domain" },
+      { data: null, width: "82px", className: "actions" },
     ],
     ordering: false,
     columnDefs: [
       {
         targets: 0,
-        class: "input-checkbox text-center",
+        // eslint-disable-next-line no-unused-vars
+        createdCell(td, cellData, rowData, row, col) {
+          $(td).attr("data-initial-value", cellData);
+        },
         render(data, type, row, meta) {
           const name = "enabled_" + meta.row;
           const ckbox =
             `<input type="checkbox" name="${name}" id="${name}" class="no-icheck" ` +
-            (data.enabled === "true" ? "checked " : "") +
-            ` data-initial-value="${data.enabled}" disabled>`;
+            (data === "true" ? "checked " : "") +
+            ">";
           return ckbox;
         },
       },
       {
-        targets: "_all",
-        class: "input-text",
-        render(data, type, row, meta) {
-          let name;
-          switch (meta.col) {
-            case 1:
-              name = "network_" + meta.row;
-              break;
-            case 2:
-              name = "ip_" + meta.row;
-              break;
-            case 3:
-              name = "domain_" + meta.row;
-              break;
-            // No default
-          }
-
-          return `<input type="text" name="${name}" id="${name}" value="${data}" class="form-control" data-initial-value="${data}" disabled>`;
+        targets: [1, 2, 3],
+        // eslint-disable-next-line no-unused-vars
+        createdCell(td, cellData, rowData, row, col) {
+          $(td).attr("contenteditable", "true").attr("data-initial-value", cellData);
         },
       },
     ],
     drawCallback() {
-      $('button[id^="deleteRevServers"]').on("click", deleteRecord);
-      $('button[id^="editRevServers"]').on("click", editRecord);
-      $('button[id^="saveRevServers"]').on("click", saveRecord).hide();
-      $('button[id^="cancelRevServers"]').on("click", restoreRecord).hide();
+      $(".deleteRevServers").on("click", deleteRecord);
+      $(".saveRevServers").on("click", saveRecord);
+      $(".cancelRevServers").on("click", restoreRecord);
     },
     rowCallback(row, data, displayNum, displayIndex, dataIndex) {
       $(row).attr("data-index", dataIndex);
-      const bt = '<button type="button" class="btn btn-xs"</button>';
-      const btEdit = $(bt)
-        .addClass("btn-primary")
-        .attr("id", `editRevServers_${dataIndex}`)
-        .attr("title", "Edit")
-        .append('<span class="far fa-edit"></span>');
+      const bt = '<button type="button" class="btn btn-xs"></button>';
       const btDel = $(bt)
-        .addClass("btn-danger")
-        .attr("id", `deleteRevServers_${dataIndex}`)
-        .attr("data-tag", Object.values(data))
-        .attr("data-type", "revServers")
+        .addClass("btn-danger deleteRevServers")
         .attr("title", "Delete")
         .append('<span class="fa fa-trash"></span>');
       const btSave = $(bt)
-        .addClass("btn-success")
-        .attr("id", `saveRevServers_${dataIndex}`)
+        .addClass("btn-success saveRevServers")
         .attr("title", "Confirm changes")
         .append('<span class="fa fa-check"></span>');
       const btCancel = $(bt)
-        .addClass("btn-warning")
-        .attr("id", `cancelRevServers_${dataIndex}`)
-        .attr("data-tag", Object.values(data))
+        .addClass("btn-warning cancelRevServers")
         .attr("title", "Undo changes")
         .append('<span class="fa fa-undo"></span>');
 
-      $("td:eq(4)", row).html(btEdit).append(" ", btDel, " ", btSave, " ", btCancel);
+      $("td:eq(4)", row).html(btSave).append(" ", btCancel, " ", btDel);
     },
     dom:
       "<'row'<'col-sm-12 text-right'l>>" +
@@ -285,10 +262,10 @@ function createRevServerTable() {
 
 function addRevServer() {
   const values = [];
-  values[0] = $("#enabled-revServers").is(":checked") ? "true" : "false";
-  values[1] = $("#network-revServers").val();
-  values[2] = $("#server-revServers").val();
-  values[3] = $("#domain-revServers").val();
+  values[0] = $("#enabled-revServers input").prop("checked") ? "true" : "false";
+  values[1] = $("#network-revServers").text();
+  values[2] = $("#ip-revServers").text();
+  values[3] = $("#domain-revServers").text();
 
   // Reject empty network range and server IP
   if (values[1] === "" || values[2] === "") {
@@ -304,37 +281,30 @@ function addRevServer() {
   $(".revServers").val($(".revServers").val() + "\n" + values.join(","));
 
   // Clear the table footer fields
-  $("#revServers-table tfoot input[type=text]").val("");
-  $("#revServers-table tfoot input[type=checkbox]").prop("checked", true);
+  $("#revServers-table tfoot [contenteditable]").text("");
+  $("#revServers-table tfoot input[type=checkbox]").prop("checked", false);
 
   // Save changes with message
-  saveRevServerData("New values added: " + values.join(", "));
+  saveRevServerData("Added values: " + values.join(", "));
 }
 
 // Button to add a new reverse server
-$("#btnAdd-revServers").on("click", addRevServer);
-
-function editRecord() {
-  // Enable fields on the selected row
-  $(this).closest("tr").find("td input").prop("disabled", false);
-
-  // Hide EDIT and DELETE buttons. Show SAVE and UNDO buttons
-  $(this).hide();
-  $(this).siblings('[id^="delete"]').hide();
-  $(this).siblings('[id^="save"]').show();
-  $(this).siblings('[id^="cancel"]').show();
-}
+$("#btnAddRevServers").on("click", addRevServer);
 
 function saveRecord() {
-  // Find the row index
-  const index = $(this).closest("tr").attr("data-index");
+  // Find the row and its index number
+  const row = $(this).closest("tr");
+  const index = row.attr("data-index");
 
   // Get the edited values from each field
   const values = [];
-  values[0] = $("#enabled_" + index).prop("checked") ? "true" : "false";
-  values[1] = $("#network_" + index).val();
-  values[2] = $("#ip_" + index).val();
-  values[3] = $("#domain_" + index).val();
+  values[0] = $(".revserver-chkbox input", row).prop("checked") ? "true" : "false";
+  values[1] = $(".revserver-network", row).text();
+  values[2] = $(".revserver-ip", row).text();
+  values[3] = $(".revserver-domain", row).text();
+
+  // Remove "editing" class from the row. Buttons will be shown/hidden via CSS
+  row.removeClass("editing");
 
   // Reject empty network range and server IP
   if (values[1] === "" || values[2] === "") {
@@ -349,44 +319,34 @@ function saveRecord() {
   // Get the values from the textarea
   const lines = getRevServerLines();
 
-  // Replace the edited line on the textarea
+  // Update the edited line on the textarea
   lines[index] = values.join(",");
   $(".revServers").val(lines.join("\n"));
 
-  // Finish the edition disabling the fields
-  $(this).closest("tr").find("td input").prop("disabled", true);
-
-  // Show EDIT and DELETE buttons. Hide SAVE and UNDO buttons
-  $(this).siblings('[id^="edit"]').show();
-  $(this).siblings('[id^="delete"]').show();
-  $(this).hide();
-  $(this).siblings('[id^="cancel"]').hide();
-
   // Save changes with message
-  saveRevServerData("Values successfully edited" + values.join(", "));
+  saveRevServerData("Updated values: " + values.join(", "));
 }
 
 function restoreRecord() {
-  // Find the row index
-  const index = $(this).closest("tr").attr("data-index");
+  // Find the row and its index number
+  const row = $(this).closest("tr");
 
-  // Reset values
-  $("#enabled_" + index).prop("checked", $("#enabled_" + index).attr("data-initial-value"));
-  $("#network_" + index).val($("#network_" + index).attr("data-initial-value"));
-  $("#ip_" + index).val($("#ip_" + index).attr("data-initial-value"));
-  $("#domain_" + index).val($("#domain_" + index).attr("data-initial-value"));
+  // Reset values using "data-initial-value"
+  $(".revserver-chkbox input", row).prop(
+    "checked",
+    $(".revserver-chkbox input", row).attr("data-initial-value")
+  );
+  $('[contenteditable="true"]', row).text(function () {
+    return $(this).attr("data-initial-value");
+  });
 
   // Show cancellation message
   utils.showAlert("info", "fas fa-undo", "Canceled", "Original values restored");
 
-  // Finish the edition disabling the fields
-  $(this).closest("tr").find("td input").prop("disabled", true);
-
-  // Show EDIT and DELETE buttons. Hide SAVE and UNDO buttons
-  $(this).siblings('[id^="edit"]').show();
-  $(this).siblings('[id^="delete"]').show();
-  $(this).siblings('[id^="save"]').hide();
-  $(this).hide();
+  // Make sure all highlighted cells are restored
+  // Remove "editing" class from the row. The buttons will be shown/hidden via CSS
+  row.find(".table-danger").removeClass("table-danger");
+  row.removeClass("editing");
 }
 
 function deleteRecord() {
@@ -443,14 +403,13 @@ function saveRevServerData(msg) {
   })
     .done(() => {
       utils.enableAll();
-      // Success
       utils.showAlert(
         "success",
         "fa-solid fa-fw fa-floppy-disk",
         "Conditional Forwarding settings successfully saved",
         msg
       );
-      // Show loading overlay
+      // Show loading overlay (without reloading the page)
       utils.loadingOverlay(false);
 
       // Reset the table to show the updated data
@@ -465,3 +424,51 @@ function saveRevServerData(msg) {
       apiFailure(data);
     });
 }
+
+// Mark the row with "editing" class when an editable cell or checkbox is focused/edited
+// This will use CSS rules to show/hide buttons
+$(document).on("focus input", "#revServers-table [contenteditable]", function () {
+  $(this).closest("tr").addClass("editing");
+});
+$(document).on("change", "#revServers-table .revserver-chkbox input", function () {
+  $(this).closest("tr").addClass("editing");
+});
+
+// Validate data entered on the table
+// If a cell contains an invalid value, it will be highlighted and the save button will be disabled
+$(document).on("input blur paste", ".revserver-network", function () {
+  const val = $(this).text().trim();
+  if (val && !(utils.validateIPv4(val) || utils.validateIPv6(val))) {
+    $(this).addClass("table-danger");
+    $(this).attr("title", "Invalid network range");
+    $(this).siblings(".actions").find(".saveRevServers").prop("disabled", true);
+  } else {
+    $(this).removeClass("table-danger");
+    $(this).attr("title", "");
+    $(this).siblings(".actions").find(".saveRevServers").prop("disabled", false);
+  }
+});
+$(document).on("input blur paste", ".revserver-ip", function () {
+  const val = $(this).text().trim();
+  if (val && !(utils.validateIPv4(val) || utils.validateIPv6(val))) {
+    $(this).addClass("table-danger");
+    $(this).attr("title", "Invalid server IP");
+    $(this).siblings(".actions").find(".saveRevServers").prop("disabled", true);
+  } else {
+    $(this).removeClass("table-danger");
+    $(this).attr("title", "");
+    $(this).siblings(".actions").find(".saveRevServers").prop("disabled", false);
+  }
+});
+$(document).on("input blur paste", ".revserver-domain", function () {
+  const val = $(this).text().trim();
+  if (val && !utils.validateHostnameStrict(val)) {
+    $(this).addClass("table-danger");
+    $(this).attr("title", "Invalid domain");
+    $(this).siblings(".actions").find(".saveRevServers").prop("disabled", true);
+  } else {
+    $(this).removeClass("table-danger");
+    $(this).attr("title", "");
+    $(this).siblings(".actions").find(".saveRevServers").prop("disabled", false);
+  }
+});

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -212,7 +212,7 @@ function createRevServerTable() {
     ],
     drawCallback() {
       $(".deleteRevServers").on("click", deleteRecord);
-      $(".saveRevServers").on("click", saveRecord);
+      $("tbody .saveRevServers").on("click", saveRecord);
       $(".cancelRevServers").on("click", restoreRecord);
     },
     rowCallback(row, data, displayNum, displayIndex, dataIndex) {

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -163,15 +163,6 @@ function getRevServerArray() {
 }
 
 function createRevServerTable() {
-  // The Conditional Forwarding option will be disabled when this option was set via ENV VAR.
-  // Check if the textarea is disabled.
-  if ($(".revServers").prop("disabled")) {
-    // In this case, we don't show the table because the values can't be changed.
-    // Show the disabled textarea and return
-    $(".revServers").show();
-    return;
-  }
-
   // Get the data
   const tableRows = getRevServerArray();
 
@@ -376,7 +367,16 @@ function processDNSConfig() {
     })
     .done(() => {
       // This will be executed only after the done block above is executed
-      createRevServerTable();
+
+      // If Conditional Forwarding option is set via ENV VAR, the textarea will be disabled and no values can be edited
+      if ($(".revServers").prop("disabled")) {
+        // In this case, we hide the table and show the textarea
+        $("#revServers-table").hide();
+        $(".revServers").show().attr("title", "Disabled: Set by environment variable");
+      } else {
+        // We only populate the table when the textarea is enabled
+        createRevServerTable();
+      }
     })
     .fail(data => {
       apiFailure(data);

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -429,6 +429,11 @@ function saveRevServerData(msg) {
 // This will use CSS rules to show/hide buttons
 $(document).on("focus input", "#revServers-table [contenteditable]", function () {
   $(this).closest("tr").addClass("editing");
+
+  // Make sure the placeholder text is shown when a contenteditable cell is empty (or only contains spaces)
+  if ($(this).text().trim() === "") {
+    $(this).empty();
+  }
 });
 $(document).on("change", "#revServers-table .revserver-chkbox input", function () {
   $(this).closest("tr").addClass("editing");

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -450,7 +450,7 @@ $(document).on("input blur paste", ".revserver-network", function () {
 });
 $(document).on("input blur paste", ".revserver-ip", function () {
   const val = $(this).text().trim();
-  if (val && !(utils.validateIPv4(val) || utils.validateIPv6(val))) {
+  if (val && !(utils.validateIPv4WithPort(val) || utils.validateIPv6WithPort(val))) {
     $(this).addClass("table-danger");
     $(this).attr("title", "Invalid server IP");
     $(this).siblings(".actions").find(".saveRevServers").prop("disabled", true);

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -140,29 +140,29 @@ function getRevServerLines() {
   // Return the lines from the textarea (array of lines)
   return $(".revServers")
     .val()
-    .split(/\r?\n/)
-    .filter((line) => line.trim() !== "");
+    .split(/\r?\n/u)
+    .filter(line => line.trim() !== "");
 }
 
-// Return the values ​​from the textarea, structured as an array of objects
+// Return an array of objects containing the current values from the textarea
 function getRevServerArray() {
-  let items = [];
+  const items = [];
 
   const lines = getRevServerLines();
-  lines.forEach((line, index) => {
-    const cols = line.split(",").map((s) => s.trim());
+  for (const line of lines) {
+    const cols = line.split(",").map(s => s.trim());
     items.push({
       enabled: cols[0] ?? "",
       network: cols[1] ?? "",
       ip: cols[2] ?? "",
       domain: cols[3] ?? "",
     });
-  });
+  }
 
   return items;
 }
 
-function renderRevServerTable() {
+function createRevServerTable() {
   // The Conditional Forwarding option will be disabled when this option was set via ENV VAR.
   // Check if the textarea is disabled.
   if ($(".revServers").prop("disabled")) {
@@ -172,22 +172,9 @@ function renderRevServerTable() {
     return;
   }
 
-  // Get an array containing the current values from the textarea
-  const data = getRevServerArray();
+  // Get the data
+  const tableRows = getRevServerArray();
 
-  // Check if the DataTable already exists
-  if ($.fn.DataTable.isDataTable("#revServers-table")) {
-    // If it already exists, we need to reset it to load the updated data.
-    // Remove all rows from the table, then add new rows with the updated data and finally redraw the table
-    var table = $("#revServers-table").DataTable();
-    table.clear().rows.add(data).draw();
-  } else {
-    // If the table doesn't exist, create it.
-    createRevServerTable(data);
-  }
-}
-
-function createRevServerTable(tableRows) {
   $("#revServers-table").DataTable({
     data: tableRows,
     autoWidth: false,
@@ -203,7 +190,7 @@ function createRevServerTable(tableRows) {
       {
         targets: 0,
         class: "input-checkbox text-center",
-        render: function (data, type, row, meta) {
+        render(data, type, row, meta) {
           const name = "enabled_" + meta.row;
           const ckbox =
             `<input type="checkbox" name="${name}" id="${name}" class="no-icheck" ` +
@@ -215,7 +202,7 @@ function createRevServerTable(tableRows) {
       {
         targets: "_all",
         class: "input-text",
-        render: function (data, type, row, meta) {
+        render(data, type, row, meta) {
           let name;
           switch (meta.col) {
             case 1:
@@ -234,13 +221,13 @@ function createRevServerTable(tableRows) {
         },
       },
     ],
-    drawCallback: function () {
+    drawCallback() {
       $('button[id^="deleteRevServers"]').on("click", deleteRecord);
       $('button[id^="editRevServers"]').on("click", editRecord);
       $('button[id^="saveRevServers"]').on("click", saveRecord).hide();
       $('button[id^="cancelRevServers"]').on("click", restoreRecord).hide();
     },
-    rowCallback: function (row, data, displayNum, displayIndex, dataIndex) {
+    rowCallback(row, data, displayNum, displayIndex, dataIndex) {
       $(row).attr("data-index", dataIndex);
       const bt = '<button type="button" class="btn btn-xs"</button>';
       const btEdit = $(bt)
@@ -282,11 +269,11 @@ function createRevServerTable(tableRows) {
     stateSave: true,
     stateDuration: 0,
     processing: true,
-    stateSaveCallback: function (settings, data) {
+    stateSaveCallback(settings, data) {
       utils.stateSaveCallback("revServers-records-table", data);
     },
-    stateLoadCallback: function () {
-      var data = utils.stateLoadCallback("revServers-records-table");
+    stateLoadCallback() {
+      const data = utils.stateLoadCallback("revServers-records-table");
       // Return if not available
       if (data === null) return null;
 
@@ -297,35 +284,31 @@ function createRevServerTable(tableRows) {
 }
 
 function addRevServer() {
-  var values = [];
+  const values = [];
   values[0] = $("#enabled-revServers").is(":checked") ? "true" : "false";
   values[1] = $("#network-revServers").val();
   values[2] = $("#server-revServers").val();
   values[3] = $("#domain-revServers").val();
 
   // Reject empty network range and server IP
-  if (values[1] == "" || values[2] == "") {
+  if (values[1] === "" || values[2] === "") {
     // Show error message
     utils.showAlert("error", "fa fa-ban", "Network Range and Server IP are required", "");
     return;
   }
 
   // Domain is optional: if empty, remove it from the array
-  if (values[3] == "") values.pop();
+  if (values[3] === "") values.pop();
 
   // Add the new values to the textarea
-  const newValues = values.join(",");
-  $(".revServers").val($(".revServers").val() + "\n" + newValues);
-
-  // Show confirmation message
-  utils.showAlert("success", "fa fa-check", "New values added", values.join(", "));
+  $(".revServers").val($(".revServers").val() + "\n" + values.join(","));
 
   // Clear the table footer fields
   $("#revServers-table tfoot input[type=text]").val("");
   $("#revServers-table tfoot input[type=checkbox]").prop("checked", true);
 
-  // Recreate the table with updated values
-  renderRevServerTable();
+  // Save changes with message
+  saveRevServerData("New values added: " + values.join(", "));
 }
 
 // Button to add a new reverse server
@@ -354,17 +337,17 @@ function saveRecord() {
   values[3] = $("#domain_" + index).val();
 
   // Reject empty network range and server IP
-  if (values[1] == "" || values[2] == "") {
+  if (values[1] === "" || values[2] === "") {
     // Show error message
     utils.showAlert("error", "fa fa-ban", "Network Range and Server IP are required", "");
     return;
   }
 
   // Domain is optional: if empty, remove it from the array
-  if (values[3] == "") values.pop();
+  if (values[3] === "") values.pop();
 
   // Get the values from the textarea
-  let lines = getRevServerLines();
+  const lines = getRevServerLines();
 
   // Replace the edited line on the textarea
   lines[index] = values.join(",");
@@ -373,17 +356,14 @@ function saveRecord() {
   // Finish the edition disabling the fields
   $(this).closest("tr").find("td input").prop("disabled", true);
 
-  // Show confirmation message
-  utils.showAlert("success", "fa fa-check", "Values succesfully edited", values.join(", "));
-
   // Show EDIT and DELETE buttons. Hide SAVE and UNDO buttons
   $(this).siblings('[id^="edit"]').show();
   $(this).siblings('[id^="delete"]').show();
   $(this).hide();
   $(this).siblings('[id^="cancel"]').hide();
 
-  // Recreate the table with updated values
-  renderRevServerTable();
+  // Save changes with message
+  saveRevServerData("Values successfully edited" + values.join(", "));
 }
 
 function restoreRecord() {
@@ -414,24 +394,21 @@ function deleteRecord() {
   const index = $(this).closest("tr").attr("data-index");
 
   // Get the current lines from the textarea
-  let lines = getRevServerLines();
+  const lines = getRevServerLines();
 
   // Remove the deleted line and update the textearea
   lines.splice(index, 1);
   $(".revServers").val(lines.join("\n"));
 
-  // Show confirmation message
-  utils.showAlert("success", "fa fa-check", "Line successfully deleted", "");
-
-  // Recreate the table with updated values
-  renderRevServerTable();
+  // Save changes with message
+  saveRevServerData("Line successfully deleted");
 }
 
 function processDNSConfig() {
   $.ajax({
     url: document.body.dataset.apiurl + "/config/dns?detailed=true", // We need the detailed output to get the DNS server list
   })
-    .done((data) => {
+    .done(data => {
       // Initialize the DNS upstreams
       fillDNSupstreams(data.config.dns.upstreams, data.dns_servers);
       setInterfaceName(data.config.dns.interface.value);
@@ -439,9 +416,9 @@ function processDNSConfig() {
     })
     .done(() => {
       // This will be executed only after the done block above is executed
-      renderRevServerTable();
+      createRevServerTable();
     })
-    .fail((data) => {
+    .fail(data => {
       apiFailure(data);
     });
 }
@@ -449,3 +426,42 @@ function processDNSConfig() {
 $(() => {
   processDNSConfig();
 });
+
+// Save the Reverse Servers data via API and recreate the table with updated values
+function saveRevServerData(msg) {
+  // Get the data from the textarea
+  const data = getRevServerLines();
+
+  // Call the API to save only the dns.revServers option
+  $.ajax({
+    url: document.body.dataset.apiurl + "/config",
+    method: "PATCH",
+    dataType: "json",
+    processData: false,
+    data: JSON.stringify({ config: { dns: { revServers: data } } }),
+    contentType: "application/json; charset=utf-8",
+  })
+    .done(() => {
+      utils.enableAll();
+      // Success
+      utils.showAlert(
+        "success",
+        "fa-solid fa-fw fa-floppy-disk",
+        "Conditional Forwarding settings successfully saved",
+        msg
+      );
+      // Show loading overlay
+      utils.loadingOverlay(false);
+
+      // Reset the table to show the updated data
+      // Remove all rows from the table, then create rows with the updated data and finally redraw the table
+      const table = $("#revServers-table").DataTable();
+      table.clear().rows.add(getRevServerArray()).draw();
+    })
+    .fail((data, exception) => {
+      utils.enableAll();
+      utils.showAlert("error", "", "Error while applying settings", data.responseText);
+      console.log(exception); // eslint-disable-line no-console
+      apiFailure(data);
+    });
+}

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -613,7 +613,7 @@ function loadingOverlayTimeoutCallback(reloadAfterTimeout) {
       if (reloadAfterTimeout) {
         location.reload();
       } else {
-        waitMe.hideAll();
+        waitMe.hide();
       }
     })
     .fail(() => {

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -274,6 +274,43 @@ function validateIPv6Brackets(ip) {
   return validateIPv6(ipWithoutBrackets);
 }
 
+function validatePort(port) {
+  // Ports containing spaces are not valid
+  if (port.trim() !== port) return false;
+
+  // Check if the port is an integer and within the valid network port range
+  const portNum = Number(port);
+  return Number.isInteger(portNum) && portNum >= 1 && portNum <= 65_535;
+}
+
+function validateIPv4WithPort(ip) {
+  // The port is optional
+  // If no "#" is present, validate just the IP
+  if (!ip.includes("#")) return validateIPv4(ip);
+
+  const parts = ip.split("#");
+  if (parts.length !== 2) return false;
+
+  const [ipv4, port] = parts;
+
+  // Validate IP part and port
+  return validateIPv4(ipv4) && validatePort(port);
+}
+
+function validateIPv6WithPort(ip) {
+  // The port is optional
+  // If no "#" is present, validate just the IP
+  if (!ip.includes("#")) return validateIPv6(ip);
+
+  const parts = ip.split("#");
+  if (parts.length !== 2) return false;
+
+  const [ipv6, port] = parts;
+
+  // Validate IP part and port
+  return validateIPv6(ipv6) && validatePort(port);
+}
+
 function validateMAC(mac) {
   // Format: xx:xx:xx:xx:xx:xx where each xx is 0-9 or a-f (case insensitive)
   // Also allows dashes as separator, e.g. xx-xx-xx-xx-xx-xx
@@ -747,6 +784,9 @@ globalThis.utils = (function () {
     validateIPv6CIDR,
     validateIPv6,
     validateIPv6Brackets,
+    validatePort,
+    validateIPv4WithPort,
+    validateIPv6WithPort,
     setBsSelectDefaults,
     stateSaveCallback,
     stateLoadCallback,

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -647,7 +647,7 @@ function loadingOverlayTimeoutCallback(reloadAfterTimeout) {
       if (reloadAfterTimeout) {
         location.reload();
       } else {
-        waitMe.hideAll();
+        waitMe.hide();
       }
     })
     .fail(() => {

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -210,23 +210,72 @@ mg.include('scripts/lua/settings_header.lp','r')
                             home network.  To configure this we will need to know the IP
                             address of your DHCP server and which addresses belong to your local network.
                             Exemplary input is given below as placeholder in the text boxes (if empty).</p>
-                        <p>If your local network spans 192.168.0.1 - 192.168.0.255, then you will have to input
-                            <code>192.168.0.0/24</code>. If your local network is 192.168.47.1 - 192.168.47.255, it will
-                            be <code>192.168.47.0/24</code> and similar. If your network is larger, the CIDR has to be
-                            different, for instance a range of 10.8.0.1 - 10.8.255.255 results in <code>10.8.0.0/16</code>,
-                            whereas an even wider network of 10.0.0.1 - 10.255.255.255 results in <code>10.0.0.0/8</code>.
-                            Setting up IPv6 ranges is exactly similar to setting up IPv4 here and fully supported.
-                            Feel free to reach out to us on our
-                            <a href="https://discourse.pi-hole.net" rel="noopener noreferrer" target="_blank">Discourse forum</a>
-                            in case you need any assistance setting up local host name resolution for your particular system.</p>
-                        <p>You can also specify a local domain name (like <code>fritz.box</code>) to ensure queries to
-                            devices ending in your local domain name will not leave your network, however, this is optional.
-                            The local domain name must match the domain name specified
-                            in your DHCP server for this to work. You can likely find it within the DHCP settings.</p>
                         <p>Enabling Conditional Forwarding will also forward all hostnames (i.e., non-FQDNs) to the router
                             when "Never forward non-FQDNs" is <em>not</em> enabled.</p>
-                        <p>The following list contains all reverse servers you want to add. The expected format is one server per line in form of <code>&lt;enabled&gt;,&lt;ip-address&gt;[/&lt;prefix-len&gt;],&lt;server&gt;[#&lt;port&gt;][,&lt;domain&gt;]</code>. A valid config line could look like <code>true,192.168.0.0/24,192.168.0.1,fritz.box</code></p>
-                        <textarea class="form-control field-sizing-content" id="dns.revServers" data-key="dns.revServers" placeholder="Enter reverse DNS servers, one per line" style="resize: vertical;"></textarea>
+                        <p>The following list contains all reverse servers you want to add.</p>
+                        <textarea class="form-control field-sizing-content revServers" id="dns.revServers" data-key="dns.revServers" placeholder="Enter reverse DNS servers, one per line"></textarea>
+
+                        <table id="revServers-table" class="table table-striped table-bordered" width="100%">
+                            <thead>
+                                <tr>
+                                    <th>Enabled</th>
+                                    <th>Network Range <sup>1</sup></th>
+                                    <th>Server IP <sup>2</sup></th>
+                                    <th>Domain <sup>3</sup></th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <!-- Dynamically updated -->
+                            </tbody>
+                            <tfoot class="add-new-item">
+                                <tr>
+                                    <th>
+                                        <input id="enabled-revServers" type="checkbox" class="no-icheck" data-configkeys="revServers" checked>
+                                    </th>
+                                    <th>
+                                        <input id="network-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="192.168.0.0/24" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <input id="server-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="192.168.0.1" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <input id="domain-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="local" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                    </th>
+                                    <th>
+                                        <button type="button" id="btnAdd-revServers" class="btn btn-primary btn-xs" data-configkeys="revServers"><i class="fa fa-plus"></i></button>
+                                    </th>
+                                </tr>
+                                <tr>
+                                    <th colspan="5">
+                                        <ol>
+                                            <li>
+                                                <label>Local network range using <a href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing" target="_blank">CIDR notation</a></label>
+                                                <span class="help-block">If your local network spans 192.168.0.1 - 192.168.0.255, then you will have to input
+                                                <code>192.168.0.0/24</code>. If your local network is 192.168.47.1 - 192.168.47.255, it will be
+                                                <code>192.168.47.0/24</code> and similar. If your network is larger, the CIDR has to be  different,
+                                                for instance a range of 10.8.0.1 - 10.8.255.255 results in <code>10.8.0.0/16</code>, whereas an even
+                                                wider network of 10.0.0.1 - 10.255.255.255 results in <code>10.0.0.0/8</code>. Setting up IPv6 ranges
+                                                is exactly similar to setting up IPv4 here and fully supported. Feel free to reach out to us on our
+                                                <a href="https://discourse.pi-hole.net" rel="noopener noreferrer" target="_blank">Discourse forum</a>
+                                                in case you need any assistance setting up local host name resolution for your particular system.</span>
+                                            </li>
+                                            <li>
+                                                <label>IP address of your DHCP server (or router)</label>
+                                                <span class="help-block"></span>
+                                            </li>
+                                            <li>
+                                                <label>Local domain name (optional)</label>
+                                                <span class="help-block">You can also specify a local domain name (like <code>fritz.box</code>) to ensure queries to
+                                                devices ending in your local domain name will not leave your network, however, this is optional.
+                                                The local domain name must match the domain name specified in your DHCP server for this to work.
+                                                You can likely find it within the DHCP settings.</span>
+                                            </li>
+                                        </ol>
+                                    </th>
+                                </tr>
+                            </tfoot>
+                        </table>
                     </div>
                 </div>
             </div>

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -230,20 +230,14 @@ mg.include('scripts/lua/settings_header.lp','r')
                             </tbody>
                             <tfoot class="add-new-item">
                                 <tr>
-                                    <th>
-                                        <input id="enabled-revServers" type="checkbox" class="no-icheck" checked>
+                                    <th id="enabled-revServers" class="revserver-chkbox" type="checkbox">
+                                        <input type="checkbox" class="no-icheck">
                                     </th>
+                                    <th id="network-revServers" class="revserver-network" contenteditable="true"></th>
+                                    <th id="ip-revServers" class="revserver-ip" contenteditable="true"></th>
+                                    <th id="domain-revServers" class="revserver-domain" contenteditable="true"></th>
                                     <th>
-                                        <input id="network-revServers" type="text" class="form-control" placeholder="192.168.0.0/24" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
-                                    </th>
-                                    <th>
-                                        <input id="server-revServers" type="text" class="form-control" placeholder="192.168.0.1" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
-                                    </th>
-                                    <th>
-                                        <input id="domain-revServers" type="text" class="form-control" placeholder="local" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
-                                    </th>
-                                    <th>
-                                        <button type="button" id="btnAdd-revServers" class="btn btn-primary btn-xs"><i class="fa fa-plus"></i></button>
+                                        <button type="button" id="btnAddRevServers" class="btn btn-primary btn-xs saveRevServers" data-configkeys="revServers"><i class="fa fa-plus"></i></button>
                                     </th>
                                 </tr>
                                 <tr>

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -231,19 +231,19 @@ mg.include('scripts/lua/settings_header.lp','r')
                             <tfoot class="add-new-item">
                                 <tr>
                                     <th>
-                                        <input id="enabled-revServers" type="checkbox" class="no-icheck" data-configkeys="revServers" checked>
+                                        <input id="enabled-revServers" type="checkbox" class="no-icheck" checked>
                                     </th>
                                     <th>
-                                        <input id="network-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="192.168.0.0/24" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="network-revServers" type="text" class="form-control" placeholder="192.168.0.0/24" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </th>
                                     <th>
-                                        <input id="server-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="192.168.0.1" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="server-revServers" type="text" class="form-control" placeholder="192.168.0.1" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </th>
                                     <th>
-                                        <input id="domain-revServers" type="text" class="form-control" data-configkeys="revServers" placeholder="local" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
+                                        <input id="domain-revServers" type="text" class="form-control" placeholder="local" autocomplete="off" spellcheck="false" autocapitalize="none" autocorrect="off">
                                     </th>
                                     <th>
-                                        <button type="button" id="btnAdd-revServers" class="btn btn-primary btn-xs" data-configkeys="revServers"><i class="fa fa-plus"></i></button>
+                                        <button type="button" id="btnAdd-revServers" class="btn btn-primary btn-xs"><i class="fa fa-plus"></i></button>
                                     </th>
                                 </tr>
                                 <tr>

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -237,7 +237,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                                     <th id="ip-revServers" class="revserver-ip" contenteditable="true"></th>
                                     <th id="domain-revServers" class="revserver-domain" contenteditable="true"></th>
                                     <th>
-                                        <button type="button" id="btnAddRevServers" class="btn btn-primary btn-xs saveRevServers" data-configkeys="revServers"><i class="fa fa-plus"></i></button>
+                                        <button type="button" id="btnAddRevServers" class="btn btn-primary btn-xs saveRevServers" title="Save the new entry"><i class="fa fa-plus"></i></button>
                                     </th>
                                 </tr>
                                 <tr>

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1580,6 +1580,32 @@ textarea.field-sizing-content {
   field-sizing: content;
 }
 
+/* Used in Settings DNS page */
+.revServers {
+  display: none;
+  resize: vertical;
+}
+
+#revServers-table .btn-xs {
+  width: 24px;
+  height: 24px;
+}
+.btn-xs .fa-fw {
+  width: 1em;
+}
+
+#revServers-table tbody td {
+  vertical-align: middle;
+}
+
+#revServers-table th {
+  white-space: normal;
+}
+
+#revServers-table tfoot ol {
+  padding: 0.5em 0 0 1em;
+}
+
 /* Used in interfaces page */
 .list-group-item {
   background: transparent;

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1582,9 +1582,20 @@ table.dataTable tbody > tr > .selected {
   resize: vertical;
 }
 
-#revServers-table .btn-xs {
-  width: 24px;
-  height: 24px;
+.actions {
+  text-align: right;
+}
+
+/* Initially hide Save and Cancel buttons */
+:not(#btnAddRevServers).saveRevServers,
+.cancelRevServers {
+  display: none;
+}
+
+/* Show Save and Cancel buttons, when the row is being edited */
+.editing :not(#btnAddRevServers).saveRevServers,
+.editing .cancelRevServers {
+  display: unset;
 }
 
 #revServers-table tbody td {
@@ -1639,10 +1650,11 @@ table.dataTable tbody > tr > .selected {
   text-align: right;
 }
 
-#StaticDHCPTable .table-danger {
+.table-danger {
   background-color: #d337;
 }
 
+#revServers-table .btn-xs,
 #StaticDHCPTable .btn-xs {
   width: 24px;
   height: 24px;

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1598,6 +1598,10 @@ table.dataTable tbody > tr > .selected {
   display: unset;
 }
 
+#revServers-table {
+  table-layout: fixed; /* Ensures that column widths remain the same when the content is edited */
+}
+
 #revServers-table tbody td {
   vertical-align: middle;
 }
@@ -1608,6 +1612,22 @@ table.dataTable tbody > tr > .selected {
 
 #revServers-table tfoot ol {
   padding: 0.5em 0 0 1em;
+}
+
+/* Add placeholder text to the footer cells, when empty */
+#revServers-table :is(td, tfoot th):empty::before {
+  color: rgba(127, 127, 127, 0.5);
+  pointer-events: none; /* Allow clicks on the parent element (cell) */
+  display: block;
+}
+#network-revServers:empty::before {
+  content: "Enter a network range (CIDR notation)";
+}
+#ip-revServers:empty::before {
+  content: "Enter the server IP";
+}
+#domain-revServers:empty::before {
+  content: "Domain name (optional)";
 }
 
 /* Used in interfaces page */

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1576,6 +1576,29 @@ table.dataTable tbody > tr > .selected {
   margin: 0 4px;
 }
 
+/* Used in Settings DNS page */
+.revServers {
+  display: none;
+  resize: vertical;
+}
+
+#revServers-table .btn-xs {
+  width: 24px;
+  height: 24px;
+}
+
+#revServers-table tbody td {
+  vertical-align: middle;
+}
+
+#revServers-table th {
+  white-space: normal;
+}
+
+#revServers-table tfoot ol {
+  padding: 0.5em 0 0 1em;
+}
+
 /* Used in interfaces page */
 .list-group-item {
   background: transparent;


### PR DESCRIPTION
### What does this PR aim to accomplish?

Replace the current single <textarea> with a table.
Each reverse server will be in a separate row and each field will be in a separate table cell.

A small legend will improve usability (maybe we will need to change the help text).

This is an update of https://github.com/pi-hole/web/pull/2943

### How does this PR accomplish the above?

Using _datatables_ plugin and the FTL API to save _dns.revServers_ entries immediately.

![image](https://github.com/pi-hole/web/assets/1385443/9c8613ae-bb71-4dbe-89b0-9576942de1a2)

---

This is still a work in progress.

TODO:
- [x] add validation function to the text fields
- [x] fix waitMe calls
- [x] test properly
- [x] check the visual on all themes

