### PR TITLE
bug: multiline comments on doughnut chart

### DIFF
--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -377,7 +377,7 @@ globalThis.doughnutTooltip = tooltipLabel => {
   // tooltipLabel.chart._metasets[0].total returns the total percentage of the shown slices
   // to compensate rounding errors we round to one decimal
   let percentageTotalShown = tooltipLabel.chart._metasets[0].total.toFixed(1);
-  const label = ` ${tooltipLabel.label}`;
+  const label = ` ${utils.escapeHtml(tooltipLabel.label)}`;
   let itemPercentage;
 
   // if we only show < 1% percent of all, show each item with two decimals

--- a/scripts/js/charts.js
+++ b/scripts/js/charts.js
@@ -231,7 +231,7 @@ function setTooltipContent(tooltipEl, tooltip) {
     // Do not display entries with value of 0 in bar chart,
     // but pass through entries with "0.0%" (in pie charts)
     if (num[1] !== "0") {
-      tooltipHtml += `<tr><td>${span}${utils.escapeHtml(body.toString())}</td></tr>`;
+      tooltipHtml += `<tr><td>${span}${body}</td></tr>`;
       printed++;
     }
   }

--- a/scripts/js/index.js
+++ b/scripts/js/index.js
@@ -167,7 +167,7 @@ function updateClientsOverTime() {
     const clients = {};
     for (const [ip, clientData] of Object.entries(data.clients)) {
       clients[ip] = numClients++;
-      labels.push(clientData.name !== null ? clientData.name : ip);
+      labels.push(clientData.name !== null ? utils.escapeHtml(clientData.name) : ip);
     }
 
     // Remove possibly already existing data


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

when chosen only  `cache` and `one.one.one.one#53` on the doughnut chart, i am below text:

```text
 cache:<br>&bull; 83.0% of all data<br>&bull; 83.6% of shown items
```

<img width="485" height="298" alt="image" src="https://github.com/user-attachments/assets/27ce7135-40c1-49a6-a71a-ec9016197f85" />






from the below code i was supposed to see bullet points [ref-code](https://github.com/pi-hole/web/blob/master/scripts/js/charts.js#L405-L409): 

<img width="713" height="110" alt="image" src="https://github.com/user-attachments/assets/8c3f0278-4ef1-4ea6-ae7a-55f943b8d261" />



This HTML is being escaped purposefully, which is not good, as there is no HTML passed here which can corrupt/crash the application, hence by not escaping the HTML while rendering this content we are safe and we will be able to see multi line output in the UI.

**How does this PR accomplish the above?:**

```diff
- tooltipHtml += `<tr><td>${span}${utils.escapeHtml(body.toString())}</td></tr>`;
+ tooltipHtml += `<tr><td>${span}${body}</td></tr>`;
```

By making the above changes we should see something like below:

<img width="418" height="274" alt="image" src="https://github.com/user-attachments/assets/c8ca1a89-fbdf-40f3-b6af-a4029c7ebf28" />

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*


