### PR TITLE
Show client description in Query Log Client column

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -35,12 +35,36 @@ const filters = [
 ];
 let doDNSSEC = false;
 
+// Map of client identifier (lower-cased IP or hostname) -> description/comment,
+// populated from the /clients endpoint (same data as the Clients settings page).
+let clientComments = {};
+
 // Check if pihole is validiting DNSSEC
 function getDnssecConfig() {
   $.getJSON(document.body.dataset.apiurl + "/config/dns/dnssec", data => {
     doDNSSEC = data.config.dns.dnssec;
 
     // redraw the table to show the icons when the API call returns
+    $("#all-queries").DataTable().draw();
+  });
+}
+
+// Fetch the client descriptions (comments) so they can be shown in the
+// Client column instead of the bare IP address.
+function getClientComments() {
+  $.getJSON(document.body.dataset.apiurl + "/clients", data => {
+    const comments = {};
+    for (const client of data.clients) {
+      if (client.comment !== null && client.comment !== "") {
+        // Clients may be identified by IP, MAC, hostname or subnet; key the
+        // lookup on that identifier so we can match it against a query's client.
+        comments[client.client.toLowerCase()] = client.comment;
+      }
+    }
+
+    clientComments = comments;
+
+    // redraw the table to apply the comments once the API call returns
     $("#all-queries").DataTable().draw();
   });
 }
@@ -543,6 +567,9 @@ $(() => {
   // Do we want to show DNSSEC icons?
   getDnssecConfig();
 
+  // Fetch client descriptions to show them in the Client column
+  getClientComments();
+
   // Do we want to filter queries?
   const GETDict = utils.parseQueryString();
 
@@ -681,8 +708,14 @@ $(() => {
         $("td:eq(3)", row).html(domain);
       }
 
-      // Show hostname instead of IP if available
-      if (data.client.name !== null && data.client.name !== "") {
+      // Prefer the client's description (comment) if one is set, showing the IP
+      // alongside it. Fall back to the hostname, then the bare IP.
+      const clientComment =
+        clientComments[data.client.ip.toLowerCase()] ||
+        (data.client.name ? clientComments[data.client.name.toLowerCase()] : undefined);
+      if (clientComment) {
+        $("td:eq(4)", row).text(clientComment + " (" + data.client.ip + ")");
+      } else if (data.client.name !== null && data.client.name !== "") {
         $("td:eq(4)", row).text(data.client.name);
       } else {
         $("td:eq(4)", row).text(data.client.ip);


### PR DESCRIPTION
## What this does

Displays a client's configured **description** (the comment set on the *Settings → Clients* page) in the **Query Log → Client** column, instead of only the IP address.

When a description is set, the column shows `Description (IP)` (e.g. `Office PC (192.168.1.5)`). When no description exists, it falls back to the existing behaviour: the hostname if known, otherwise the bare IP.

## How it works

- On the Query Log page, client descriptions are fetched once from the `/clients` endpoint (the same data the Clients settings page uses) and cached in a lookup map keyed on the client identifier.
- In the table `rowCallback`, the description is matched against the query's client IP or hostname and rendered with `.text()` (HTML-escaped).
- Mirrors the existing `getDnssecConfig()` pattern (async fetch + table redraw).

## Notes / limitations

- Matching is on the exact IP or hostname. Clients defined by **MAC address** or **subnet/CIDR** are not matched and fall back to hostname/IP as before. Resolving those would require expanding MAC entries to their known addresses or subnet matching (potentially better handled in FTL); kept out of scope here to keep the change small.
- `npm test` (prettier + xo) passes; no new lint warnings introduced.
- Falls back gracefully (to hostname/IP) if the `/clients` request fails.
