### PR TITLE
Show client description in Query Log Client column (incl. MAC-defined clients)

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -35,6 +35,10 @@ const filters = [
 ];
 let doDNSSEC = false;
 
+// Map of client identifier (lower-cased IP or hostname) -> description/comment,
+// populated from the /clients endpoint (same data as the Clients settings page).
+let clientComments = {};
+
 // Check if pihole is validiting DNSSEC
 function getDnssecConfig() {
   $.getJSON(document.body.dataset.apiurl + "/config/dns/dnssec", data => {
@@ -42,6 +46,55 @@ function getDnssecConfig() {
 
     // redraw the table to show the icons when the API call returns
     $("#all-queries").DataTable().draw();
+  });
+}
+
+// Fetch the client descriptions (comments) so they can be shown in the
+// Client column instead of the bare IP address.
+function getClientComments() {
+  $.getJSON(document.body.dataset.apiurl + "/clients", data => {
+    const comments = {};
+    const macComments = {};
+    const macRe = /^([\da-f]{2}:){5}[\da-f]{2}$/iu;
+    for (const client of data.clients) {
+      if (client.comment !== null && client.comment !== "") {
+        // Clients may be identified by IP, MAC, hostname or subnet; key the
+        // lookup on that identifier so we can match it against a query's client.
+        const id = client.client.toLowerCase();
+        comments[id] = client.comment;
+        // MAC-defined clients never match a query's IP/hostname directly;
+        // remember them so we can resolve their live IPs/names below.
+        if (macRe.test(id)) {
+          macComments[id] = client.comment;
+        }
+      }
+    }
+
+    const applyComments = () => {
+      clientComments = comments;
+      // redraw the table to apply the comments once the API call returns
+      $("#all-queries").DataTable().draw();
+    };
+
+    // Clients defined by MAC address won't match a query's IP/hostname, so
+    // resolve each MAC to its current IP(s)/hostname(s) via the network
+    // devices endpoint and key the comment under those too.
+    if (Object.keys(macComments).length > 0) {
+      $.getJSON(document.body.dataset.apiurl + "/network/devices", netData => {
+        for (const device of netData.devices) {
+          const mac = (device.hwaddr || "").toLowerCase();
+          if (!(mac in macComments)) continue;
+          for (const entry of device.ips || []) {
+            if (entry.ip) comments[entry.ip.toLowerCase()] = macComments[mac];
+            if (entry.name) comments[entry.name.toLowerCase()] = macComments[mac];
+          }
+        }
+
+        applyComments();
+      }).fail(applyComments);
+    } else {
+      applyComments();
+    }
   });
 }
 
@@ -543,6 +596,9 @@ $(() => {
   // Do we want to show DNSSEC icons?
   getDnssecConfig();
 
+  // Fetch client descriptions to show them in the Client column
+  getClientComments();
+
   // Do we want to filter queries?
   const GETDict = utils.parseQueryString();
 
@@ -681,8 +737,14 @@ $(() => {
         $("td:eq(3)", row).html(domain);
       }
 
-      // Show hostname instead of IP if available
-      if (data.client.name !== null && data.client.name !== "") {
+      // Prefer the client's description (comment) if one is set, showing the IP
+      // alongside it. Fall back to the hostname, then the bare IP.
+      const clientComment =
+        clientComments[data.client.ip.toLowerCase()] ||
+        (data.client.name ? clientComments[data.client.name.toLowerCase()] : undefined);
+      if (clientComment) {
+        $("td:eq(4)", row).text(clientComment + " (" + data.client.ip + ")");
+      } else if (data.client.name !== null && data.client.name !== "") {
         $("td:eq(4)", row).text(data.client.name);
       } else {
         $("td:eq(4)", row).text(data.client.ip);


### PR DESCRIPTION
I used CC to write the code in this PR but this comment is 100% human (except where noted).

**What does this PR aim to accomplish?:**

TLDR: Mapping client MAC addresses using the editable WebUI Clients->Description field, to be displayed alongside corresponding entries in the Query Log. I understand that this is not the current intended method but if you bear with me I think it's worth changing things.

First let me say I'm brand new to pihole. I set it up to block ads but the Query Log is awesome for seeing whats happening on my network.  

One of the first things I thought was "Nice query log but which IP in the log is which device?"   I immediately click on the Clients tab and there are the clients nicely listed and I can add a custom Description!  "Perfect!" I think...

Add Description, view Log...  Hmm its not working.  Try again, refresh, restart, hmm still not working, so odd...

Lots of google searching, lots of other people having the same issue.  Its hard to find an answer tbh. Sounds like there are workarounds, like logging into the CLI and editing /etc/hosts manually. I now see this is the supported method, and it makes sense why.  But still, why would I login to a CLI and manually edit an important file when I'm already in a nice webui and everything needed is right there and I can put in nice descriptions with spaces and real text, not just a hostname... and its right there in front of me?

I'm not going to edit /etc/hosts.  Further, I think the client descriptions in the webui are linked to the MAC addresses.  I dont know if /etc/hosts can accomplish that.  I'm not going to update /etc/hosts every time I see a new client or a client changes IPs.  I'm not going to force MAC:IP mapping on my router. I'm literally going to use the webui for its intended purpose, keeping me out of the CLI... 


**How does this PR accomplish the above?:**

(claude section)

Shows a client's configured **Description** (the comment set on *Settings → Clients*) in the **Query Log → Client** column as `Description (IP)`, e.g. `Office PC (192.168.1.5)`. When no description is set it falls back to the hostname, then the bare IP — existing behavior is unchanged.

A new getClientComments() fetches /clients on page load, builds a lookup of description keyed by client identifier, and redraws the table once it returns.
The Client-column renderer now prefers a matching description, then hostname, then IP.
Clients defined by MAC address never match a query's IP/hostname directly. To support them, each MAC-defined client is additionally resolved to its current IP(s)/hostname(s) via /network/devices, and the description is keyed under those too. A nice side effect: the description follows DHCP IP changes automatically.
- Frontend-only — no FTL/Core changes, nothing to restart.
- Supersedes my earlier #3785, which only matched clients defined by IP/hostname.

(end claude)


This could have potentially avoided or fix the following issues (and still if someone wants to have consistent hostnames from DNS, this PR does not change that behavior):

https://github.com/pi-hole/pi-hole/issues/379
https://github.com/pi-hole/pi-hole/issues/1507
https://github.com/pi-hole/pi-hole/issues/3976
https://github.com/pi-hole/FTL/issues/1260

> Hostnames shown on the dashboard for clients instead of ip addresses (both ipv4 and ipv6)
https://github.com/pi-hole/docker-pi-hole/issues/356


It could be used to fix a Top Clients display if that still exists.
> When adding clients, they should be described also by their IP address in the client list, they should be described also by their hostname/assigned commentary name in the top lists of long term data, and they should disappear from the drop-down menu of the client list
https://github.com/pi-hole/web/issues/2010


---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.

There are a LOT of instances on various sites where people are expecting the the behavior of seeing the provided Descriptions inside the WebUI.  I would not be opposed to populating more of the webui with these descriptions in futher commits, if this PR is merged / considered of value.

9. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
10. I give this submission freely, and claim no ownership to its content.

---
- [ ] I have read the above and my PR is ready for review. *Check this box to confirm*
- [ X] 
- 

I (finally)( found the Local DNS records settings in the GUI. Perhaps using that kind of negate this PR, but still wouldnt link  MAC addresses to descriptions for hosts that change IPs, nor would it allow spaces or other more viewable text formatting.  Also, its just not clear that this would do what the end user might want to accomplish.   Further its not as intuitive or easy as entering a Description using the Clients tab.

The behavior in the PR could be toggle-able via a setting at /admin/settings/api for those who have set custom hostnames / their network has real hostnames and who also used Client Description field.  But this seems like a small thing to create a toggle setting for when it has a very small effect and there are basically no other settings there controlling things like this.

Another option would be to not override the IP field with a description if a hostname exists.  Or to show <description> <hostname> instead of <description> <ip>.


<img width="1977" height="551" alt="image" src="https://github.com/user-attachments/assets/cb19c46f-1d5e-4f4a-a0ae-ed0b7f876d0d" />

<img width="1944" height="641" alt="image" src="https://github.com/user-attachments/assets/f2a42c39-de70-4c56-84ee-4b19a05c86b4" />
