### PR TITLE
Update daterangepicker ranges everytime the picker is shown

### DIFF
--- a/scripts/js/queries.js
+++ b/scripts/js/queries.js
@@ -80,10 +80,27 @@ function initDateRangePicker(data) {
 
   const minDateMoment = moment.unix(beginningOfTime);
   const maxDateMoment = moment.unix(endOfTime);
-  const earliestDateStr = minDateMoment.format(dateformat);
-  $("#querytime-note").text(`Earliest date: ${earliestDateStr}`);
+  const buildRanges = () => ({
+    "Last 10 Minutes": [moment().subtract(10, "minutes"), moment()],
+    "Last Hour": [moment().subtract(1, "hours"), moment()],
+    Today: [moment().startOf("day"), maxDateMoment],
+    Yesterday: [
+      moment().subtract(1, "days").startOf("day"),
+      moment().subtract(1, "days").endOf("day"),
+    ],
+    "Last 7 Days": [moment().subtract(6, "days").startOf("day"), maxDateMoment],
+    "Last 30 Days": [moment().subtract(29, "days").startOf("day"), maxDateMoment],
+    "This Month": [moment().startOf("month"), maxDateMoment],
+    "Last Month": [
+      moment().subtract(1, "month").startOf("month"),
+      moment().subtract(1, "month").endOf("month"),
+    ],
+    "This Year": [moment().startOf("year"), maxDateMoment],
+    "All Time": [minDateMoment, maxDateMoment],
+  });
 
-  $("#querytime").daterangepicker(
+  const querytime = $("#querytime");
+  querytime.daterangepicker(
     {
       timePicker: true,
       timePickerIncrement: 5,
@@ -91,24 +108,7 @@ function initDateRangePicker(data) {
       locale: { format: dateformat },
       startDate: moment(from * 1000), // convert to milliseconds since epoch
       endDate: moment(until * 1000), // convert to milliseconds since epoch
-      ranges: {
-        "Last 10 Minutes": [moment().subtract(10, "minutes"), moment()],
-        "Last Hour": [moment().subtract(1, "hours"), moment()],
-        Today: [moment().startOf("day"), maxDateMoment],
-        Yesterday: [
-          moment().subtract(1, "days").startOf("day"),
-          moment().subtract(1, "days").endOf("day"),
-        ],
-        "Last 7 Days": [moment().subtract(6, "days").startOf("day"), maxDateMoment],
-        "Last 30 Days": [moment().subtract(29, "days").startOf("day"), maxDateMoment],
-        "This Month": [moment().startOf("month"), maxDateMoment],
-        "Last Month": [
-          moment().subtract(1, "month").startOf("month"),
-          moment().subtract(1, "month").endOf("month"),
-        ],
-        "This Year": [moment().startOf("year"), maxDateMoment],
-        "All Time": [minDateMoment, maxDateMoment],
-      },
+      ranges: buildRanges(),
       // Don't allow selecting dates outside the database range
       minDate: minDateMoment,
       maxDate: maxDateMoment,
@@ -123,6 +123,13 @@ function initDateRangePicker(data) {
       until = moment(endt).utc().valueOf() / 1000;
     }
   );
+
+  querytime.on("show.daterangepicker", (_, picker) => {
+    // Refresh relative ranges so options like "Last 10 Minutes" are based on now.
+    picker.ranges = buildRanges();
+    picker.updateView();
+    picker.updateCalendars();
+  });
 }
 
 function handleAjaxError(xhr, textStatus) {


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/web/issues/3792

**How does this PR accomplish the above?:**

Updates the date/time ranges of the datarangepicker each time the drop-down daterangepicker is shown. Uses `show.daterangepicker` event

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
