### PR TITLE
Add DoT/DoH columns to the Upstream DNS Servers picker

### DIFF
--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -20,6 +20,18 @@ function removeFromArray(arr, what) {
   }
 }
 
+// Show how many upstreams are selected on each Plain/DoT/DoH tab, so it's not
+// hidden behind whichever tab happens to be active
+function updateUpstreamTabBadges() {
+  for (const protocol of ["plain", "dot", "doh"]) {
+    const count = $("#DNSupstreamsTable-" + protocol + " input:checked").length;
+    $("#upstreams-count-" + protocol)
+      .text(count)
+      .toggle(count > 0)
+      .attr("title", "Selected servers: " + count);
+  }
+}
+
 function fillDNSupstreams(value, servers) {
   let disabledStr = "";
   if (value.flags.env_var === true) {
@@ -29,48 +41,64 @@ function fillDNSupstreams(value, servers) {
 
   let i = 0;
   let customServers = value.value.length;
-  for (const element of servers) {
-    let row = "<tr>";
-    // Build checkboxes for IPv4 and IPv6
-    const addresses = [element.v4, element.v6];
-    // Loop over address types (IPv4, IPv6)
-    for (let v = 0; v < 2; v++) {
-      const address = addresses[v];
-      // Loop over available addresses (up to 2)
-      for (let index = 0; index < 2; index++) {
-        if (address.length > index) {
-          let checkedStr = "";
-          if (
-            value.value.includes(address[index]) ||
-            value.value.includes(address[index] + "#53")
-          ) {
-            checkedStr = "checked";
-            customServers--;
-          }
 
-          row += `<td title="${address[index]}">
-                    <div>
-                      <input type="checkbox" id="DNSupstreams-${i}" ${disabledStr} ${checkedStr}>
-                      <label for="DNSupstreams-${i++}"></label>
-                    </div>
-                  </td>`;
-        } else {
-          row += "<td></td>";
-        }
-      }
+  // Build a single checkbox <td> for the given address, tracking selection
+  // state and consuming a custom-server slot when it matches. Plain v4/v6
+  // addresses also match the default-port-suffixed form; the pinned DoT/DoH
+  // URIs are matched verbatim only. Returns an empty cell when there is no
+  // address for this slot (only used within the Plain table, since a vendor
+  // may only publish one of the two plain addresses in a family).
+  function checkboxCell(address, portSuffix) {
+    if (!address) {
+      return "<td></td>";
     }
 
-    // Add server name
-    row += "<td>" + element.name + "</td>";
+    let checkedStr = "";
+    if (value.value.includes(address) || (portSuffix && value.value.includes(address + "#53"))) {
+      checkedStr = "checked";
+      customServers--;
+    }
 
-    // Close table row
-    row += "</tr>";
-
-    // Add row to table
-    $("#DNSupstreamsTable").append(row);
+    return `<td title="${address}">
+              <div>
+                <input type="checkbox" id="DNSupstreams-${i}" ${disabledStr} ${checkedStr}>
+                <label for="DNSupstreams-${i++}"></label>
+              </div>
+            </td>`;
   }
 
-  // Add event listener to checkboxes
+  for (const element of servers) {
+    // Plain IPv4/IPv6 addresses always get a row, even if a vendor only
+    // publishes one address per family
+    let plainRow = "<tr>";
+    plainRow += checkboxCell(element.v4[0], true);
+    plainRow += checkboxCell(element.v4[1], true);
+    plainRow += checkboxCell(element.v6[0], true);
+    plainRow += checkboxCell(element.v6[1], true);
+    plainRow += "<td>" + element.name + "</td></tr>";
+    $("#DNSupstreamsTable-plain").append(plainRow);
+
+    // DoT/DoH only get a row when the vendor actually publishes a pinned URI
+    // for at least one address family, so those tabs never fill up with rows
+    // that are entirely empty
+    if (element.dot && (element.dot.v4 || element.dot.v6)) {
+      let dotRow = "<tr>";
+      dotRow += checkboxCell(element.dot.v4, false);
+      dotRow += checkboxCell(element.dot.v6, false);
+      dotRow += "<td>" + element.name + "</td></tr>";
+      $("#DNSupstreamsTable-dot").append(dotRow);
+    }
+
+    if (element.doh && (element.doh.v4 || element.doh.v6)) {
+      let dohRow = "<tr>";
+      dohRow += checkboxCell(element.doh.v4, false);
+      dohRow += checkboxCell(element.doh.v6, false);
+      dohRow += "<td>" + element.name + "</td></tr>";
+      $("#DNSupstreamsTable-doh").append(dohRow);
+    }
+  }
+
+  // Add event listener to checkboxes (shared across the Plain/DoT/DoH tabs)
   $("input[id^='DNSupstreams-']").on("change", () => {
     const upstreams = $("#DNSupstreamsTextfield").val().split("\n");
     let customServerCount = 0;
@@ -92,10 +120,12 @@ function fillDNSupstreams(value, servers) {
     // get the correct number of custom servers
     customServerCount += upstreams.length;
     updateDNSserversTextfield(upstreams, customServerCount);
+    updateUpstreamTabBadges();
   });
 
   // Initialize textfield
   updateDNSserversTextfield(value.value, customServers);
+  updateUpstreamTabBadges();
 
   // Expand the box if there are custom servers
   if (customServers > 0) {

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -22,17 +22,60 @@ mg.include('scripts/lua/settings_header.lp','r')
             <div class="box-body">
                 <div class="row">
                     <div class="col-sm-12">
-                        <table class="table table-striped table-bordered">
-                            <thead>
-                                <tr>
-                                    <th colspan="2">IPv4</th>
-                                    <th colspan="2">IPv6</th>
-                                    <th>Name</th>
-                                </tr>
-                            </thead>
-                            <tbody id="DNSupstreamsTable">
-                            </tbody>
-                        </table>
+                        <div class="nav-tabs-custom">
+                            <ul class="nav nav-tabs" role="tablist">
+                                <li class="active" role="presentation">
+                                    <a href="#tab-upstreams-plain" aria-controls="tab-upstreams-plain" aria-expanded="true" role="tab" data-toggle="tab">Plain <span class="label label-primary" id="upstreams-count-plain" style="display: none;"></span></a>
+                                </li>
+                                <li role="presentation">
+                                    <a href="#tab-upstreams-dot" aria-controls="tab-upstreams-dot" aria-expanded="false" role="tab" data-toggle="tab">DoT <span class="label label-primary" id="upstreams-count-dot" style="display: none;"></span></a>
+                                </li>
+                                <li role="presentation">
+                                    <a href="#tab-upstreams-doh" aria-controls="tab-upstreams-doh" aria-expanded="false" role="tab" data-toggle="tab">DoH <span class="label label-primary" id="upstreams-count-doh" style="display: none;"></span></a>
+                                </li>
+                            </ul>
+                            <div class="tab-content">
+                                <div id="tab-upstreams-plain" class="tab-pane active fade in">
+                                    <table class="table table-striped table-bordered upstream-servers-table">
+                                        <thead>
+                                            <tr>
+                                                <th colspan="2">IPv4</th>
+                                                <th colspan="2">IPv6</th>
+                                                <th class="server-names">Name</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="DNSupstreamsTable-plain">
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div id="tab-upstreams-dot" class="tab-pane fade">
+                                    <table class="table table-striped table-bordered upstream-servers-table">
+                                        <thead>
+                                            <tr>
+                                                <th>IPv4</th>
+                                                <th>IPv6</th>
+                                                <th class="server-names">Name</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="DNSupstreamsTable-dot">
+                                        </tbody>
+                                    </table>
+                                </div>
+                                <div id="tab-upstreams-doh" class="tab-pane fade">
+                                    <table class="table table-striped table-bordered upstream-servers-table">
+                                        <thead>
+                                            <tr>
+                                                <th>IPv4</th>
+                                                <th>IPv6</th>
+                                                <th class="server-names">Name</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="DNSupstreamsTable-doh">
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
                         <p>ECS (Extended Client Subnet) defines a mechanism for recursive resolvers to send partial client IP address information to authoritative DNS name servers. Content Delivery Networks (CDNs) and latency-sensitive services use this to give geo-located responses when responding to name lookups coming through public DNS resolvers. <em>Note that ECS may result in reduced privacy.</em></p>
                     </div>
                     <div class="col-sm-12">

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1049,6 +1049,28 @@ table.dataTable tr.selected th.select-checkbox::after {
   font-size: 17px;
 }
 
+/* DNS settings page - Upstream servers table */
+.upstream-servers-table {
+  table-layout: fixed;
+}
+.upstream-servers-table .server-names {
+  width: 210px;
+}
+.upstream-servers-table > tbody > tr > td {
+  vertical-align: middle;
+}
+
+/* DNS settings page - selection-count label on the Plain/DoT/DoH tabs */
+.nav-tabs .label {
+  position: absolute;
+  top: 4px;
+  right: 5px;
+  font-size: 11px;
+}
+.nav-tabs > li > a:has(.label) {
+  padding-right: 30px;
+}
+
 /* Datatables Select - selected row bgcolor */
 table.dataTable tbody > tr.selected,
 table.dataTable tbody > tr > .selected {


### PR DESCRIPTION
### **What does this PR aim to accomplish?:**

FTL's DoT/DoH client work (pi-hole/FTL#2940) adds pinned `tls://`/`https://` URIs to the well-known resolver suggestions returned by `/api/config/dns`, but the Upstream DNS Servers picker only ever rendered checkboxes for the plain addresses - so there was no way to pick an encrypted upstream from the UI, even though FTL was already offering one.

Adds a **Plain / DoT / DoH tabbed picker** (one checkbox per address family per tab, since FTL only offers a single pinned URI per family, not a primary/secondary pair like the plain v4/v6 columns). The DoT and DoH tabs only list vendors that actually publish a pinned URI for that protocol, so resolvers without encrypted support (e.g. Level3, Comodo) are simply absent instead of showing empty rows. This keeps the table narrow regardless of how many protocols FTL ends up supporting in future (DoQ, DoH3, ...), rather than adding two more columns per protocol to a single flat table.

Depends on pi-hole/FTL#2940.

**Before:**
<img width="900" height="420" alt="before" src="https://github.com/user-attachments/assets/c4056649-71f2-4266-b5c9-a6e2a4458ace" />


**After:**
<img width="794" height="1118" alt="dotdohtab" src="https://github.com/user-attachments/assets/fb22792b-b52f-4597-b0e5-8cf7c1f4c426" />


---
**By submitting this pull request, I confirm the following:** 

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against. 
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
