### PR TITLE
Edit domains and groups via an `?item=` query parameter

### DIFF
--- a/scripts/js/groups-domains.js
+++ b/scripts/js/groups-domains.js
@@ -606,11 +606,16 @@ function editDomain() {
   const domainDecoded = utils.hexDecode(domain.split("_")[0]);
   utils.showAlert("info", "", "Editing domain...", domainDecoded);
   $.ajax({
+    // Identify the item with an "item" query parameter rather than a path
+    // segment. A segment equal to "." or ".." is a WHATWG URL dot segment that
+    // the browser strips while resolving the URL, so it could never be sent in
+    // the path. Using the query form for every edit keeps a single code path
+    // (requires the FTL "?item=" fallback, pi-hole/FTL#2953).
     url:
       document.body.dataset.apiurl +
       "/domains/" +
       newTypestr +
-      "/" +
+      "?item=" +
       encodeURIComponent(domainDecoded),
     method: "put",
     dataType: "json",

--- a/scripts/js/groups.js
+++ b/scripts/js/groups.js
@@ -328,7 +328,10 @@ function editGroup() {
   utils.disableAll();
   utils.showAlert("info", "", "Editing group...", oldName);
   $.ajax({
-    url: document.body.dataset.apiurl + "/groups/" + oldName,
+    // Identify the group with an "item" query parameter rather than a path
+    // segment, so a name of "." or ".." (a WHATWG URL dot segment the browser
+    // strips) survives (requires the FTL "?item=" fallback, pi-hole/FTL#2953).
+    url: document.body.dataset.apiurl + "/groups?item=" + encodeURIComponent(oldName),
     method: "put",
     dataType: "json",
     processData: false,


### PR DESCRIPTION
# What does this implement/fix?

A regex domain or group whose value is literally `.` or `..` cannot be edited from the web UI (Fixes #3308). Per the WHATWG URL standard, a path segment equal to `.`/`%2e` (single-dot) or `..`/`%2e%2e` (double-dot) is a dot segment that the browser removes while resolving the URL, so such an item is stripped from the `PUT` request before it is sent and never reaches the API. Percent-encoding the dot does not help, as `%2e` is normalized identically to `.` (this is why #3746 had no effect and was closed).

This identifies the item to edit with an `?item=...` query parameter, which is not subject to path normalization, instead of a trailing path segment. Doing so for every edit (not only `.`/`..`) keeps a single code path. As a side effect, `editGroup()` now URL-encodes the group name, which it previously interpolated into the path unescaped.

Deleting a `.`/`..` entry already works today, as deletion goes through `POST /<type>s:batchDelete` with the item in the JSON body, so no change is needed there.

This requires the matching FTL change that reads `?item=` as a fallback when the URI path carries no item: pi-hole/FTL#2953. The two PRs should be merged together.

---

**Related issue or feature (if applicable):** Fixes https://github.com/pi-hole/web/issues/3308

**Pull request in [docs](https://github.com/pi-hole/docs) with documentation (if applicable):** N/A

**Depends on:** pi-hole/FTL#2953

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))

## Checklist:

- [x] The code change is tested and works locally.
- [x] I based my code and PRs against the repositories `development` branch.
- [x] I [signed off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits. Pi-hole enforces the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
- [x] I [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all my commits. Pi-hole requires signatures to verify authorship
- [x] I have read the above and my PR is ready for review.
