### PR TITLE
Fix typo in the validation regex (static DHCP lease table)

### DIFF
--- a/scripts/js/settings-dhcp.js
+++ b/scripts/js/settings-dhcp.js
@@ -249,7 +249,7 @@ function parseStaticDHCPLine(line) {
   }
 
   // Advanced if line contains id:, set:, tag, or "*":
-  if (/id:|set:|tag:\*/u.test(line)) {
+  if (/id:|set:|tag:|\*/u.test(line)) {
     return "advanced";
   }
 


### PR DESCRIPTION
### What does this PR aim to accomplish and how?

Fixes https://github.com/pi-hole/web/issues/3826

It fixes the regex used to filter entries containing the string `tag:`. The validation was broken because there was a typo (missing `|`).

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
