### PR TITLE
Fix: reject invalid server IPs (CIDR) in Conditional Forwarding table

### DIFF
--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -300,6 +300,12 @@ function addRevServer() {
     return;
   }
 
+  // Validate server IP (reject CIDR notation, invalid IPs)
+  if (!(utils.validateIPv4WithPort(values[2]) || utils.validateIPv6WithPort(values[2]))) {
+    utils.showAlert("error", "fa fa-ban", "Invalid Server IP: " + values[2], "Server IP must be a valid IPv4 or IPv6 address (optionally with #port). Network ranges (CIDR) are not allowed.");
+    return;
+  }
+
   // Domain is optional: if empty, remove it from the array
   if (values[3] === "") {
     values.pop();
@@ -338,6 +344,12 @@ function saveRecord() {
   if (values[1] === "" || values[2] === "") {
     // Show error message
     utils.showAlert("error", "fa fa-ban", "Network Range and Server IP are required", "");
+    return;
+  }
+
+  // Validate server IP (reject CIDR notation, invalid IPs)
+  if (!(utils.validateIPv4WithPort(values[2]) || utils.validateIPv6WithPort(values[2]))) {
+    utils.showAlert("error", "fa fa-ban", "Invalid Server IP: " + values[2], "Server IP must be a valid IPv4 or IPv6 address (optionally with #port). Network ranges (CIDR) are not allowed.");
     return;
   }
 

--- a/settings-dns.lp
+++ b/settings-dns.lp
@@ -279,7 +279,7 @@ mg.include('scripts/lua/settings_header.lp','r')
                                     <th id="network-revServers" class="revserver-network" contenteditable="true"></th>
                                     <th id="ip-revServers" class="revserver-ip" contenteditable="true"></th>
                                     <th id="domain-revServers" class="revserver-domain" contenteditable="true"></th>
-                                    <th>
+                                    <th class="actions">
                                         <button type="button" id="btnAddRevServers" class="btn btn-primary btn-xs saveRevServers" title="Save the new entry"><i class="fa fa-plus"></i></button>
                                     </th>
                                 </tr>


### PR DESCRIPTION
Fixes #3829

## What does this PR aim to accomplish?

Reject invalid server IPs (CIDR notation like `192.168.1.0/24`) in the Conditional Forwarding table. Previously, the Server IP field accepted these invalid values due to two bugs.

## How does this PR accomplish the above?

1. **Fix footer row save button not being disabled** (`settings-dns.lp`): Added `class=actions` to the footer row's `<th>` containing the save button. The validation handler uses ```javascript\n.siblings(.actions).find(.saveRevServers).prop(disabled, true);\n``` but the footer row's `<th>` lacked the `actions` class, so the button was never disabled.

2. **Add server-side IP validation** (`scripts/js/settings-dns.js`): Added IP format validation in `addRevServer()` and `saveRecord()` using existing `utils.validateIPv4WithPort()` and `utils.validateIPv6WithPort()` functions, which already reject CIDR notation.

## Link documentation PRs if any are needed to support this PR

N/A

---

By submitting this pull request, I confirm the following:
1. ✅ Based against the `development` branch
2. ✅ Commits are DCO-signed-off
3. ✅ Commits are GPG-signed
4. ✅ No documentation changes needed