### PR TITLE
Fix `#revServers-table` after migrating to datatables v2

### DIFF
--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -275,6 +275,23 @@ function createRevServerTable() {
         },
       },
     ],
+    initComplete() {
+      $(this.api().table().footer())
+        // Remove elements automatically created by datatables in the table footer
+        .find(".dt-column-footer")
+        .each(function () {
+          const $innerTitle = $(this).find(".dt-column-title");
+
+          // If the inner span has no text or HTML, empty the cell entirely
+          if ($.trim($innerTitle.html()) === "") {
+            $(this).closest("th, td").empty();
+          } else {
+            // Otherwise, safely strip both wrappers to restore original HTML
+            $innerTitle.contents().unwrap();
+            $(this).contents().unwrap();
+          }
+        });
+    },
     drawCallback() {
       $(".deleteRevServers").on("click", deleteRecord);
       $("tbody .saveRevServers").on("click", saveRecord);

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1549,7 +1549,8 @@ table.table.dataTable.table-striped > tbody > tr.selected:nth-of-type(2n + 1) > 
   resize: vertical;
 }
 
-.actions {
+.actions,
+.dataTable :is(td, th).actions {
   text-align: right;
 }
 
@@ -1583,6 +1584,7 @@ table.table.dataTable.table-striped > tbody > tr.selected:nth-of-type(2n + 1) > 
 
 /* Add placeholder text to the footer cells, when empty */
 #revServers-table :is(td, tfoot th):empty::before {
+  font-size: 0.9rem;
   color: rgba(127, 127, 127, 0.5);
   pointer-events: none; /* Allow clicks on the parent element (cell) */
   display: block;


### PR DESCRIPTION
### What does this PR aim to accomplish?

This PR fixes the `#revServers-table` footer, after migrating to the new datatables version.

The new plugin automatically adds some elements to the header and footer cells, used to render sorting controls.

We use the footer table as user interface to enter new reverse servers. Also, we show placeholder texts when the cells are empty, but the cells are not considered as empty when these elements are there.

Before the fix:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/80121dbc-ca8f-4756-833a-c9d9f79aa5f6" />

After:
<img width="800" alt="image" src="https://github.com/user-attachments/assets/4cf629ef-7fc9-49e5-99d2-cd36040047cf" />


### How does this PR accomplish the above?

Since there is no way to ask datatables to avoid the automatically created `.dt-column-title` and `.dt-column-footer` elements, we need to remove them after the table is initialized.

This PR also adjusts CSS `.actions` class to force right aligned text on the footer (new datatables styles are interfering with the original cell alignment).

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
