### PR TITLE
Fix `hexEncode()` for code points above `U+FFFF`

### DIFF
--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -669,12 +669,16 @@ function parseQueryString() {
   return Object.fromEntries(params);
 }
 
+// Six hex digits per code point, not four: code points go up to U+10FFFF, so
+// four digits only cover the basic multilingual plane. Anything above it (e.g.
+// emoji) would be encoded as a wider group that hexDecode() cannot split off
+// again, garbling the rest of the string. Both functions must agree on six.
 function hexEncode(text) {
   if (typeof text !== "string" || text.length === 0) {
     return "";
   }
 
-  return [...text].map(char => char.codePointAt(0).toString(16).padStart(4, "0")).join("");
+  return [...text].map(char => char.codePointAt(0).toString(16).padStart(6, "0")).join("");
 }
 
 function hexDecode(text) {
@@ -682,7 +686,7 @@ function hexDecode(text) {
     return "";
   }
 
-  const hexes = text.match(/.{1,4}/gu);
+  const hexes = text.match(/.{1,6}/gu);
   if (!hexes || hexes.length === 0) {
     return "";
   }


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

Fixes https://github.com/pi-hole/web/issues/3845

`hexEncode()` padded each code point to four hex digits and `hexDecode()` cut the string back into four-character groups. Code points go up to `U+10FFFF`, so an emoji such as `U+1F4D2` takes five and everything after it decodes to garbage.

Rows carry their address in this encoding, so a list with an emoji in its address could neither be deleted nor edited - we asked FTL to remove something that is not in the database and got a `404` back.

**How does this PR accomplish the above?:**

Six hex digits per code point in both functions, which covers the whole Unicode range. The encoding never leaves the page, so there is nothing to migrate.

To test: subscribe to a list with an emoji as its address, then delete it. The row disappears instead of raising `Error while deleting allow list`. The same applies to editing that list, and to domains, clients and groups.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
