### PR TITLE
Simplify code and classes used to style toast elements

### DIFF
--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -123,9 +123,13 @@ function getOrCreateToastContainer() {
 
 // Set the toast element's properties
 function createToast(alertState) {
+  let clsName = alertState.type;
+  if (alertState.type === "error") {
+    clsName = "danger";
+  }
+
   const toast = document.createElement("div");
-  toast.className = "toast align-items-center border-0 shadow rounded overflow-hidden";
-  toast.className += ` ${alertState.bgColor}`;
+  toast.className = `toast toast-${clsName} overflow-hidden`;
   toast.dataset.toastType = alertState.type;
   toast.dataset.bsAutohide = String(alertState.autohide);
   toast.dataset.bsDelay = String(alertState.delay);
@@ -136,7 +140,7 @@ function createToast(alertState) {
   const content = document.createElement("div");
   content.className = "d-flex flex-column";
   const header = document.createElement("div");
-  header.className = `toast-header ${alertState.bgColor}`;
+  header.className = "toast-header";
 
   if (alertState.icon !== "") {
     const icon = document.createElement("i");
@@ -152,7 +156,7 @@ function createToast(alertState) {
 
   const closeButton = document.createElement("button");
   closeButton.type = "button";
-  closeButton.className = `${alertState.closeButtonClass} ms-2 mb-auto`;
+  closeButton.className = "btn-close ms-2 mb-auto";
   closeButton.dataset.bsDismiss = "toast";
   closeButton.setAttribute("aria-label", "Close");
 
@@ -186,29 +190,23 @@ function showAlert(type, icon, title, message, oldToastInstance = undefined) {
     message: escapeHtml(message),
     icon,
     type,
-    bgColor: "",
     animation: true,
     delay: 5000, // default value
     autohide: true,
     role: "status",
     live: "polite",
     ariaAtomic: "true",
-    closeButtonClass: "btn-close",
   };
 
   switch (type) {
     case "info":
       alertState.icon = icon !== null && icon.length > 0 ? icon : "fas fa-clock";
-      alertState.bgColor = "text-bg-info";
       break;
     case "success":
-      alertState.bgColor = "text-bg-success";
-      alertState.closeButtonClass += " btn-close-white";
       break;
     case "warning":
       alertState.icon = "fas fa-exclamation-triangle";
       alertState.delay *= 2;
-      alertState.bgColor = "text-bg-warning";
       break;
     case "error":
       alertState.icon = "fas fa-times";
@@ -217,10 +215,8 @@ function showAlert(type, icon, title, message, oldToastInstance = undefined) {
       }
 
       alertState.delay *= 2;
-      alertState.bgColor = "text-bg-danger";
       alertState.role = "alert";
       alertState.live = "assertive";
-      alertState.closeButtonClass += " btn-close-white";
 
       // If the message is an API object, nicely format the error message
       // Try to parse message as JSON

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -162,18 +162,25 @@ function createToast(alertState) {
 
   header.append(title, closeButton);
 
-  const body = document.createElement("div");
-  body.className = "toast-body";
+  // Only create toast-body if there is a message
+  if (alertState.message !== "") {
+    const body = document.createElement("div");
+    body.className = "toast-body";
 
-  const message = document.createElement("div");
-  message.className = "toast-message flex-grow-1";
-  message.style.whiteSpace = "pre-line";
-  message.style.overflowWrap = "anywhere";
-  // Message is already escaped in showAlert() function, so we can safely set it as innerHTML
-  message.innerHTML = alertState.message;
+    const message = document.createElement("div");
+    message.className = "toast-message flex-grow-1";
+    message.style.whiteSpace = "pre-line";
+    message.style.overflowWrap = "anywhere";
 
-  body.append(message);
-  content.append(header, body);
+    // Message is already escaped in showAlert() function, so we can safely set it as innerHTML
+    message.innerHTML = alertState.message;
+    body.append(message);
+
+    content.append(header, body);
+  } else {
+    content.append(header);
+  }
+
   toast.append(content);
 
   return toast;

--- a/style/pi-hole.css
+++ b/style/pi-hole.css
@@ -1799,3 +1799,8 @@ td.dnssec i {
 [data-bs-theme="dark"] .ts-wrapper.multi .ts-control > div .remove:hover {
   background: rgba(255, 255, 255, 0.1);
 }
+
+.toast {
+  --bs-toast-bg: var(--bs-toast-header-bg);
+  color: var(--bs-toast-header-color);
+}


### PR DESCRIPTION
### What does this PR aim to accomplish?

This branch simplifies a little the CSS classes used to style toasts.

It is an extension of `replace/notify` branch.

### How does this PR accomplish the above?

The original code was adding bootstrap 5 classes to 3 different elements of the toast markup. This PR adds just one AdminLTE class to the main toast element. 

We also removed a few redundant classes (styles already present on the AdminLTE theme).

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
