### PR TITLE
Add data-bs-theme to unauthenticathed pages

### DIFF
--- a/error403.lp
+++ b/error403.lp
@@ -10,7 +10,7 @@
 mg.include('scripts/lua/header.lp','r')
 ?>
 </head>
-<body class="hold-transition layout-boxed login-page page-<?=pihole.format_path(scriptname)?>">
+<body class="hold-transition layout-boxed login-page page-<?=pihole.format_path(scriptname)?>" data-bs-theme="<?= bs_theme ?>">
     <div class="card login-box">
         <section class="p-3">
                 <h2 class="error-headline text-danger">403</h2>

--- a/error404.lp
+++ b/error404.lp
@@ -10,7 +10,7 @@
 mg.include('scripts/lua/header.lp','r')
 ?>
 </head>
-<body class="hold-transition layout-boxed login-page page-<?=pihole.format_path(scriptname)?>">
+<body class="hold-transition layout-boxed login-page page-<?=pihole.format_path(scriptname)?>" data-bs-theme="<?= bs_theme ?>">
     <div class="card login-box">
         <section class="p-3">
                 <h2 class="error-headline text-orange">404</h2>

--- a/login.lp
+++ b/login.lp
@@ -10,7 +10,7 @@
 mg.include('scripts/lua/header.lp','r')
 ?>
 </head>
-<body class="hold-transition layout-boxed login-page page-<?=pihole.format_path(scriptname)?>" data-apiurl="<?=pihole.api_url()?>" data-webhome="<?=webhome?>">
+<body class="hold-transition layout-boxed login-page page-<?=pihole.format_path(scriptname)?>" data-apiurl="<?=pihole.api_url()?>" data-webhome="<?=webhome?>" data-bs-theme="<?= bs_theme ?>">
 <div class="card login-box" id="login-box">
     <section class="p-3">
         <div class="login-logo">


### PR DESCRIPTION
### What does this PR aim to accomplish?

Unauthenticated pages are using light styles for some elements (like the login page password field and link colors) even when a dark theme is selected.

**Before:**
<img width="512" height="489" alt="before" src="https://github.com/user-attachments/assets/9f8277f9-6dd8-4799-8532-e90587f636f4" />

### How does this PR accomplish the above?

These pages doesn't use the code in `header_authenticated.lp`.

This PR applies the same fix used in 3770112, adding `data-bs-theme` to the body tag.

**After:**
<img width="512" height="489" alt="after" src="https://github.com/user-attachments/assets/b1e8c3da-64f5-4a08-8a05-423823140c06" />

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
