### PR TITLE
Fix and rename the host name validators

### DIFF
--- a/scripts/js/groups-clients.js
+++ b/scripts/js/groups-clients.js
@@ -360,17 +360,17 @@ function addClient() {
   // - IPv4 address (with and without CIDR)
   // - IPv6 address (with and without CIDR)
   // - MAC address (in the form AA:BB:CC:DD:EE:FF)
-  // - host name (arbitrary form, we're only checking against some reserved characters)
+  // - host name, or an interface prefaced with a colon (like :eth0)
   for (const [index, ip] of ips.entries()) {
     if (utils.validateIPv4CIDR(ip) || utils.validateIPv6CIDR(ip) || utils.validateMAC(ip)) {
       // Convert input to upper case (important for MAC addresses)
       ips[index] = ip.toUpperCase();
-    } else if (!utils.validateHostname(ip)) {
+    } else if (!utils.validateClientPattern(ip)) {
       utils.showAlert(
         "warning",
         "",
         "Warning",
-        "Input is neither a valid IP or MAC address nor a valid host name!"
+        "Input is neither a valid IP or MAC address nor a valid host name or interface!"
       );
       return;
     }

--- a/scripts/js/settings-dhcp.js
+++ b/scripts/js/settings-dhcp.js
@@ -338,7 +338,7 @@ $(document).on("click", ".save-static-row", function () {
   // Validate MAC and IP before saving
   const macValid = !hwaddr || utils.validateMAC(hwaddr);
   const ipValid = !ipaddr || utils.validateIPv4(ipaddr) || utils.validateIPv6Brackets(ipaddr);
-  const nameValid = !hostname || utils.validateHostnameStrict(hostname);
+  const nameValid = !hostname || utils.validateHostname(hostname);
   if (!macValid || !ipValid || !nameValid) {
     utils.showAlert(
       "error",
@@ -536,7 +536,7 @@ function renderStaticDHCPTable() {
       }
 
       const tdHostname = $(cell).addClass("static-hostname").text(parsed.hostname);
-      if (parsed.hostname && !utils.validateHostnameStrict(parsed.hostname)) {
+      if (parsed.hostname && !utils.validateHostname(parsed.hostname)) {
         tdHostname.addClass("table-danger");
       }
 
@@ -658,7 +658,7 @@ $(document).on("input blur paste", "#StaticDHCPTable td.static-ipaddr", function
 
 $(document).on("input blur paste", "#StaticDHCPTable td.static-hostname", function () {
   const val = $(this).text().trim();
-  if (val && !utils.validateHostnameStrict(val)) {
+  if (val && !utils.validateHostname(val)) {
     $(this).addClass("table-danger");
     $(this).attr("title", "Invalid hostname: only letters, digits, hyphens, and dots allowed");
   } else {

--- a/scripts/js/settings-dns.js
+++ b/scripts/js/settings-dns.js
@@ -564,7 +564,7 @@ $(document).on("input blur paste", ".revserver-ip", function () {
 });
 $(document).on("input blur paste", ".revserver-domain", function () {
   const val = $(this).text().trim();
-  if (val && !utils.validateHostnameStrict(val)) {
+  if (val && !utils.validateHostname(val)) {
     $(this).addClass("table-danger");
     $(this).attr("title", "Invalid domain");
     $(this).siblings(".actions").find(".saveRevServers").prop("disabled", true);

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -366,8 +366,10 @@ function validateClientPattern(name) {
   return clientValidator.test(name.trim());
 }
 
-function validateHostnameStrict(name) {
-  // Hostnames must not contain spaces, commas, or characters invalid in DNS names
+function validateHostname(name) {
+  // These end up in comma-separated dnsmasq config lines, so a space or a comma
+  // is never acceptable. The rest follows a host name: dot-separated labels of
+  // letters, digits and inner hyphens.
   const hostnameValidator =
     /^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?)*$/u;
   return hostnameValidator.test(name.trim());
@@ -878,7 +880,7 @@ globalThis.utils = (function () {
     stateLoadCallback,
     validateMAC,
     validateClientPattern,
-    validateHostnameStrict,
+    validateHostname,
     addFromQueryLog,
     addTD,
     toPercent,

--- a/scripts/js/utils.js
+++ b/scripts/js/utils.js
@@ -357,9 +357,13 @@ function validateMAC(mac) {
   return macvalidator.test(mac.trim());
 }
 
-function validateHostname(name) {
-  const namevalidator = /[^<>;"]/u;
-  return namevalidator.test(name.trim());
+function validateClientPattern(name) {
+  // A client that is neither an IP/subnet nor a MAC address can only be a host
+  // name or an interface (prefaced with a colon). FTL matches both verbatim and
+  // only ever records names built from these characters, so anything else can
+  // never describe a client.
+  const clientValidator = /^:?[\w.-]+$/u;
+  return clientValidator.test(name.trim());
 }
 
 function validateHostnameStrict(name) {
@@ -873,7 +877,7 @@ globalThis.utils = (function () {
     stateSaveCallback,
     stateLoadCallback,
     validateMAC,
-    validateHostname,
+    validateClientPattern,
     validateHostnameStrict,
     addFromQueryLog,
     addTD,


### PR DESCRIPTION
## Thank you for your contribution to the Pi-hole Community!

Please read the comments below to help us consider your Pull Request.

We are all volunteers and completing the process outlined will help us review your commits quicker.

**Please make sure you**

 1. Base your code and PRs against the repositories developmental branch.
 2. [Sign Off](https://docs.pi-hole.net/guides/github/how-to-signoff/) all commits as we enforce the [DCO](https://docs.pi-hole.net/guides/github/dco/) for all contributions
 3. [Sign](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) all your commits as they must have verified signatures
 4. File a pull request for any change that requires changes to [our documentation](https://docs.pi-hole.net/) at our [documentation repo](https://github.com/pi-hole/docs)

---

**What does this PR aim to accomplish?:**

`validateHostname()` validates nothing. `/[^<>;"]/` is unanchored, so it matches on the first character that is not one of those four - `evil<script>` passes. Only the empty string is ever rejected.

Noticed while reviewing #3853.

**How does this PR accomplish the above?:**

Its only caller is the client field in group management, which after the IP/CIDR and MAC branches takes a host name or an interface like `:eth0`. FTL matches both verbatim and only ever records names of `[A-Za-z0-9._-]` ([`valid_hostname()`](https://github.com/pi-hole/FTL/blob/6f0dbe32ab0f83d02bd41cab0b49e90a635d0a91/src/resolve.c#L206-L222)), so the check is now `/^:?[\w.-]+$/u` and the function is named after what it does.

The reserved characters are not lost: the table escapes on render.

`validateHostnameStrict()` then drops a suffix that no longer tells it apart from anything.

Please merge this after #3853. The two touch neighboring lines, and I would rather resolve that here than push it onto the contributor.

**Link documentation PRs if any are needed to support this PR:**

None needed.

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
