### PR TITLE
Add `dns.hostsLocal` to the Local DNS settings page

### DIFF
--- a/scripts/js/settings-dns-records.js
+++ b/scripts/js/settings-dns-records.js
@@ -155,6 +155,18 @@ function populateDataTable(endpoint) {
   });
 }
 
+function loadHostsLocal() {
+  $.ajax({
+    url: document.body.dataset.apiurl + "/config/dns/hostsLocal?detailed=true",
+  })
+    .done(data => {
+      setConfigValues("dns", "dns", data.config.dns);
+    })
+    .fail(data => {
+      apiFailure(data);
+    });
+}
+
 function deleteRecord() {
   if ($(this).attr("data-type") === "hosts") {
     delHosts($(this).attr("data-tag"));
@@ -227,6 +239,7 @@ function delCNAME(elem) {
 $(() => {
   populateDataTable("hosts");
   populateDataTable("cnameRecords");
+  loadHostsLocal();
 
   $("#btnAdd-host").on("click", () => {
     utils.disableAll();

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -19,7 +19,7 @@ PageTitle = "Local DNS Settings"
             <div class="col-md-12 col-lg-6">
                 <div class="card">
                     <div class="card-header">
-                        <h3 class="card-title" id="title-hosts" data-configkeys="dns.hosts">Local DNS records</h3>
+                        <h3 class="card-title" id="title-hosts" data-configkeys="dns.hosts dns.hostsLocal">Local DNS records</h3>
                     </div>
                     <div class="card-body">
                         <div class="row">
@@ -48,6 +48,19 @@ PageTitle = "Local DNS Settings"
                                         </tr>
                                     </tfoot>
                                 </table>
+                            </div>
+                        </div>
+                        <div class="row">
+                            <div class="col-md-12">
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="dns.hostsLocal" data-key="dns.hostsLocal">
+                                    <label class="form-check-label" for="dns.hostsLocal"><strong>Never forward queries for local DNS records</strong></label>
+                                    <p class="help-block">If set, the names configured above are considered local and no query
+                                        for them ever leaves your Pi-hole - not even for record types you did not define, such as
+                                        the <code>AAAA</code> query a browser sends alongside the <code>A</code> query. Without this,
+                                        such a query is forwarded and a public answer for the same name can shadow your local record.
+                                        The scope includes subdomains of the configured names.</p>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -105,6 +118,9 @@ PageTitle = "Local DNS Settings"
                         <p>Adding/removing local CNAME records will restart the DNS server.</p>
                     </div>
                 </div>
+            </div>
+            <div class="col-lg-12 save-button-container">
+                <button type="button" class="btn btn-primary save-button"><i class="fa-solid fa-fw fa-floppy-disk"></i>&nbsp;Save & Apply</button>
             </div>
         </div>
     </div><!-- /.container-fluid -->

--- a/settings-dnsrecords.lp
+++ b/settings-dnsrecords.lp
@@ -66,7 +66,7 @@ PageTitle = "Local DNS Settings"
                     </div>
                     <div class="card-footer">
                         <strong>Note:</strong>
-                        <p>Adding/removing local DNS records will flush the cache but does not require a restart of the DNS server.</p>
+                        <p>Adding/removing local DNS records will flush the cache. With the option above enabled, the DNS server is restarted as well, as the rules keeping these names local are part of its configuration.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

https://github.com/pi-hole/FTL/pull/3037 adds `dns.hostsLocal`, which decides whether the names in `dns.hosts` are kept local. It has no representation in the web interface yet, and the page that manages those records is where it belongs.

**How does this PR accomplish the above?:**

A checkbox below the local DNS record table, stored with the usual "Save & Apply" button - the page had none so far, because both tables apply their changes immediately.

Needs [FTL #3037](https://github.com/pi-hole/FTL/pull/3037) to be merged first, otherwise the page asks for a config key that does not exist.

**Link documentation PRs if any are needed to support this PR:**

N/A

---
**By submitting this pull request, I confirm the following:**

1. I have read and understood the [contributors guide](https://docs.pi-hole.net/guides/github/contributing/), as well as this entire template. I understand which branch to base my commits and Pull Requests against.
2. I have commented my proposed changes within the code and I have tested my changes.
3. I am willing to help maintain this change if there are issues with it later.
4. It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.2)
5. I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
6. I have checked that another pull request for this purpose does not exist.
7. I have considered, and confirmed that this submission will be valuable to others.
8. I accept that this submission may not be used, and the pull request closed at the will of the maintainer.
9. I give this submission freely, and claim no ownership to its content.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
