### PR TITLE
Do not blame the password for a refusal that is not about it

### DIFF
--- a/scripts/js/login.js
+++ b/scripts/js/login.js
@@ -41,7 +41,6 @@ function wrongPassword(isError = false, isSuccess = false, data = null) {
     $("#error-hint").text("");
 
     if ("error" in data.responseJSON && "message" in data.responseJSON.error) {
-      // This is an error, highlight both the password and the TOTP field
       isErrorResponse = true;
       // Check if the error is caused by an invalid TOTP token
       isInvalidTOTP = data.responseJSON.error.message === "Invalid 2FA token";
@@ -52,21 +51,21 @@ function wrongPassword(isError = false, isSuccess = false, data = null) {
       }
     }
 
+    // A wrong password comes back as a session that is not valid rather than as
+    // an error object. Of the error objects, only the invalid 2FA token is about
+    // what was typed - the others are refusals of the server's own (no seats
+    // left, a read-only configuration) and blame neither field
     showErrorMessage(errorMessage);
-    // Always highlight the TOTP field on error
-    if (isErrorResponse) {
-      $("#totp_input").addClass("has-error");
-    }
-
-    // Only show the invalid 2FA box if the error is caused by an invalid TOTP
-    // token
+    // Highlight the TOTP field only when the token was rejected
     if (isInvalidTOTP) {
+      $("#totp_input").addClass("has-error");
+
+      // Only show the invalid 2FA box if the error is caused by an invalid TOTP token
       $("#invalid2fa-box").removeClass("hidden");
     }
 
-    // Only highlight the password field if the error is NOT caused by an
-    // invalid TOTP token
-    if (!isInvalidTOTP) {
+    // ...and the password field only when the password was
+    if (!isErrorResponse) {
       $("#pw-field").addClass("has-error");
     }
 


### PR DESCRIPTION
**What does this PR aim to accomplish?:**

FTL answers a wrong password with a session that is not valid, and refuses a login for reasons of its own - `api_seats_exceeded`, a read-only configuration - with an error object instead. The login form treated both alike and marked the password *and* the 2FA field as wrong for every failure, so `API seats exceeded` arrived looking like a typo in a password that was perfectly correct.

I ran into this after filling the session table on a test machine: the message and its hint were there, but everything around them said the credentials were wrong.

**How does this PR accomplish the above?:**

The two cases are told apart by what comes back rather than treated as one:

- the 2FA field is marked only when the token was what got rejected
- the password field only when the password was, which is the response carrying no error object
- the message and its hint are shown exactly as before

**Link documentation PRs if any are needed to support this PR:**

None - no documented behaviour changes.

---
- [x] I have read the above and my PR is ready for review. *Check this box to confirm*
